### PR TITLE
fixing TODO in _KeyboardLayoutPageState

### DIFF
--- a/subiquity_client/lib/subiquity_client.dart
+++ b/subiquity_client/lib/subiquity_client.dart
@@ -197,9 +197,9 @@ class SubiquityClient {
   // TODO: un-hardcode
   final releaseNotesURL = 'https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes';
 
-  Set<String> keyboardlangs = {};
-  var keyboardlayoutlist = [];
-  Map<String, List<Tuple2<String, String>>> keyboardvariantlist = {};
+  final Set<String> keyboardlangs = {};
+  final List<Tuple2<String, String>> keyboardlayoutlist = [];
+  final Map<String, List<Tuple2<String, String>>> keyboardvariantlist = {};
 
   Future<void> fetchKeyboardLayouts(String assetName, Locale locale) async {
     final langtag = locale.toLanguageTag().replaceAll('-', '_');


### PR DESCRIPTION
fix for

```dart
  @override
  void initState() {
    super.initState();
    final locale = Intl.defaultLocale.toString().split('_').last.toLowerCase();
    // FIXME: incorrect heuristic:
    //    Ukrainian is uk, but the default keyboard layout is ua
    //    Greek is el, but the default keyboard layout is gr
    for (var i = 0; i < widget.client.keyboardlayoutlist.length; ++i) {
      if (widget.client.keyboardlayoutlist[i].item1 == locale) {
        _selectedLayoutIndex = i;
        _selectedLayoutName = locale;
        break;
      }
    }
```