### PR TITLE
Follow light vs. dark system theme

### DIFF
--- a/ubuntu_desktop_installer/lib/main.dart
+++ b/ubuntu_desktop_installer/lib/main.dart
@@ -42,6 +42,8 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         locale: value,
         onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
         theme: yaruLightTheme,
+        darkTheme: yaruDarkTheme,
+        themeMode: ThemeMode.system,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: [
           ...AppLocalizations.localizationsDelegates,

--- a/ubuntu_desktop_installer/lib/main.dart
+++ b/ubuntu_desktop_installer/lib/main.dart
@@ -43,7 +43,6 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
         theme: yaruLightTheme,
         darkTheme: yaruDarkTheme,
-        themeMode: ThemeMode.system,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: [
           ...AppLocalizations.localizationsDelegates,

--- a/ubuntu_desktop_installer/lib/tryorinstallpage.dart
+++ b/ubuntu_desktop_installer/lib/tryorinstallpage.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:yaru/yaru.dart';
 
 import 'package:subiquity_client/subiquity_client.dart';
 
@@ -63,11 +62,11 @@ class _OptionCardState extends State<OptionCard> {
                 )),
             const SizedBox(height: 10),
             Expanded(
-                child: Text(
-              widget.bodyText,
-              style: yaruBodyText1Style.copyWith(
-                  color: yaruLightColorScheme.primaryVariant),
-            )),
+              child: Opacity(
+                opacity: 0.9,
+                child: Text(widget.bodyText),
+              ),
+            ),
           ]),
         ),
         onTap: () {

--- a/ubuntu_desktop_installer/lib/turnoffrstpage.dart
+++ b/ubuntu_desktop_installer/lib/turnoffrstpage.dart
@@ -3,7 +3,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/style.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:yaru/yaru.dart';
 
 import 'localized_view.dart';
 
@@ -44,7 +43,10 @@ class TurnOffRSTPage extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 40),
-                Image.asset('assets/rst.png'),
+                Image.asset(
+                  'assets/rst.png',
+                  color: Theme.of(context).textTheme.bodyText1.color,
+                ),
               ])),
               const SizedBox(height: 20),
               ButtonBar(
@@ -54,13 +56,14 @@ class TurnOffRSTPage extends StatelessWidget {
                     onPressed: Navigator.of(context).pop,
                   ),
                   OutlinedButton(
-                    style: yaruOutlinedButtonThemeData.style.copyWith(
-                      backgroundColor: MaterialStateColor.resolveWith(
-                        (states) => Color(0xFF0e8420),
-                      ),
-                      foregroundColor:
-                          MaterialStateColor.resolveWith((states) => yaruWhite),
-                    ),
+                    style: OutlinedButtonTheme.of(context).style.copyWith(
+                          backgroundColor: MaterialStateColor.resolveWith(
+                            (states) => Color(0xFF0e8420),
+                          ),
+                          foregroundColor: MaterialStateColor.resolveWith(
+                            (states) => Colors.white,
+                          ),
+                        ),
                     child: Text(lang.restartButtonText),
                     onPressed: () {
                       print('TODO: restart computer');


### PR DESCRIPTION
| Before | After, light | After, dark |
|---|---|---|
| ![Screenshot from 2021-03-21 19-09-00](https://user-images.githubusercontent.com/140617/111915956-071dc700-8a79-11eb-88e3-5590b5cc630b.png) | ![Screenshot from 2021-03-21 19-11-08](https://user-images.githubusercontent.com/140617/111916005-49470880-8a79-11eb-81e1-4c6213cc0c29.png) | ![Screenshot from 2021-03-21 19-12-42](https://user-images.githubusercontent.com/140617/111916045-7693b680-8a79-11eb-99ec-8757667b9fe1.png) |
| ![Screenshot from 2021-03-21 19-09-07](https://user-images.githubusercontent.com/140617/111915958-07b65d80-8a79-11eb-95b4-16f8c550af83.png) | ![Screenshot from 2021-03-21 19-11-12](https://user-images.githubusercontent.com/140617/111916006-49df9f00-8a79-11eb-8c08-f0a5aa0cb40b.png) | ![Screenshot from 2021-03-21 19-12-46](https://user-images.githubusercontent.com/140617/111916047-772c4d00-8a79-11eb-9e73-5fc1fae53279.png) |
| ![Screenshot from 2021-03-21 19-09-38](https://user-images.githubusercontent.com/140617/111915959-07b65d80-8a79-11eb-90c8-42deae5866c3.png) | ![Screenshot from 2021-03-21 19-11-17](https://user-images.githubusercontent.com/140617/111916007-49df9f00-8a79-11eb-830c-e766f6a2e8d0.png) | ![Screenshot from 2021-03-21 19-12-52](https://user-images.githubusercontent.com/140617/111916050-77c4e380-8a79-11eb-98c7-da4ad700d07b.png) |
| ![Screenshot from 2021-03-21 19-09-41](https://user-images.githubusercontent.com/140617/111915960-084ef400-8a79-11eb-8294-499e6e358ba4.png) | ![Screenshot from 2021-03-21 19-11-40](https://user-images.githubusercontent.com/140617/111916008-4a783580-8a79-11eb-8ece-e37d54b1e75f.png) | ![Screenshot from 2021-03-21 19-12-56](https://user-images.githubusercontent.com/140617/111916051-77c4e380-8a79-11eb-9a6f-518b6fa7b6e7.png) |
