### PR TITLE
import yaru as yaru and change theme names

### DIFF
--- a/ubuntu_desktop_installer/lib/main.dart
+++ b/ubuntu_desktop_installer/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:yaru/yaru.dart';
+import 'package:yaru/yaru.dart' as yaru;
 
 import 'keyboardlayoutpage.dart';
 import 'l10n/app_localizations.dart';
@@ -41,8 +41,8 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
       builder: (context, value, _) => MaterialApp(
         locale: value,
         onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
-        theme: yaruLightTheme,
-        darkTheme: yaruDarkTheme,
+        theme: yaru.lightTheme,
+        darkTheme: yaru.darkTheme,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: [
           ...AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
Due to a recent quiet [big change in the yaru theme organisation](https://github.com/ubuntu/yaru.dart/pull/29) it is needed for the ubuntu installer to change the theme name vars which is done with this PR.

Tested locally:

https://user-images.githubusercontent.com/15329494/112620834-4fe2d080-8e29-11eb-9217-c981ca6f9b12.mp4

But a review is much appreciated!

CC @MarcusTomlinson 