### PR TITLE
Subiquity client: cut Flutter dependencies

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -34,11 +34,11 @@ jobs:
 
     - name: Get subiquity_client dependencies
       working-directory: ./subiquity_client
-      run: flutter pub get
+      run: dart pub get
     
     - name: Run tests on subiquity_client
       working-directory: ./subiquity_client
-      run: flutter test
+      run: dart test
 
     # ubuntu_desktop_installer
 

--- a/subiquity_client/pubspec.yaml
+++ b/subiquity_client/pubspec.yaml
@@ -7,8 +7,6 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   diacritic:
   tuple:
   http: ^0.12.2
@@ -17,8 +15,7 @@ dependencies:
 
 dev_dependencies:
   effective_dart: ^1.3.0
-  flutter_test:
-    sdk: flutter
   build_runner: ^1.11.5
   freezed: ^0.12.7
   json_serializable: ^3.5.1
+  test: ^1.16.0

--- a/subiquity_client/test/subiquity_client_test.dart
+++ b/subiquity_client/test/subiquity_client_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/src/types.dart';
 import 'package:subiquity_client/test/test_server.dart';

--- a/subiquity_client/test/types_test.dart
+++ b/subiquity_client/test/types_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:subiquity_client/src/types.dart';
 
 void main() {

--- a/subiquity_client/tools/codegen.sh
+++ b/subiquity_client/tools/codegen.sh
@@ -2,4 +2,4 @@
 
 path=$(realpath "$(dirname $0)/..")
 
-(cd $path && flutter pub run build_runner build --delete-conflicting-outputs)
+(cd $path && dart run build_runner build --delete-conflicting-outputs)


### PR DESCRIPTION
I don't know if there are any future plans for the client that would require `dart:ui` but this seems like the right thing to do based on the functionality it has today.