### PR TITLE
Use Provider for providing SubiquityClient

### DIFF
--- a/ubuntu_desktop_installer/lib/keyboard_layout_page.dart
+++ b/ubuntu_desktop_installer/lib/keyboard_layout_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:keyboard_info/keyboard_info.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 
 import 'keyboard_model.dart';
 import 'localized_view.dart';
@@ -13,11 +12,7 @@ import 'rounded_list_view.dart';
 class KeyboardLayoutPage extends StatefulWidget {
   const KeyboardLayoutPage({
     Key key,
-    @required this.client,
-  })  : assert(client != null, '`SubiquityClient` must not be `null`'),
-        super(key: key);
-
-  final SubiquityClient client;
+  }) : super(key: key);
 
   @override
   _KeyboardLayoutPageState createState() => _KeyboardLayoutPageState();

--- a/ubuntu_desktop_installer/lib/main.dart
+++ b/ubuntu_desktop_installer/lib/main.dart
@@ -15,20 +15,19 @@ import 'welcome_page.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();
-  final client = SubiquityClient();
-  runApp(ChangeNotifierProvider(
-      create: (context) => KeyboardModel(),
-      child: UbuntuDesktopInstallerApp(client: client)));
+  runApp(MultiProvider(
+    providers: [
+      Provider(create: (_) => SubiquityClient()),
+      ChangeNotifierProvider(create: (_) => KeyboardModel()),
+    ],
+    child: UbuntuDesktopInstallerApp(),
+  ));
 }
 
 class UbuntuDesktopInstallerApp extends StatelessWidget {
-  final SubiquityClient client;
-
   const UbuntuDesktopInstallerApp({
     Key key,
-    @required this.client,
-  })  : assert(client != null, '`SubiquityClient` must not be `null`'),
-        super(key: key);
+  }) : super(key: key);
 
   static final _locale =
       ValueNotifier(Locale(Intl.shortLocale(Intl.systemLocale)));
@@ -53,11 +52,11 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
           const LocalizationsDelegateOc(),
         ],
         supportedLocales: AppLocalizations.supportedLocales,
-        home: WelcomePage(client: client),
+        home: WelcomePage(),
         routes: <String, WidgetBuilder>{
-          '/tryorinstall': (context) => TryOrInstallPage(client: client),
+          '/tryorinstall': (context) => TryOrInstallPage(),
           '/turnoffrst': (context) => const TurnOffRSTPage(),
-          '/keyboardlayout': (context) => KeyboardLayoutPage(client: client),
+          '/keyboardlayout': (context) => KeyboardLayoutPage(),
         },
       ),
     );

--- a/ubuntu_desktop_installer/lib/try_or_install_page.dart
+++ b/ubuntu_desktop_installer/lib/try_or_install_page.dart
@@ -5,8 +5,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:subiquity_client/subiquity_client.dart';
-
 import 'localized_view.dart';
 
 enum Option { none, repairUbuntu, tryUbuntu, installUbuntu }
@@ -102,13 +100,9 @@ class TryOrInstallPageInheritedContainer extends InheritedWidget {
 }
 
 class TryOrInstallPage extends StatefulWidget {
-  final SubiquityClient client;
-
   const TryOrInstallPage({
     Key key,
-    @required this.client,
-  })  : assert(client != null, '`SubiquityClient` must not be `null`'),
-        super(key: key);
+  }) : super(key: key);
 
   static TryOrInstallPageState of(BuildContext context) {
     return context

--- a/ubuntu_desktop_installer/lib/welcome_page.dart
+++ b/ubuntu_desktop_installer/lib/welcome_page.dart
@@ -7,7 +7,6 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:tuple/tuple.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 
 import 'keyboard_model.dart';
 import 'localized_view.dart';
@@ -17,11 +16,7 @@ import 'rounded_list_view.dart';
 class WelcomePage extends StatefulWidget {
   const WelcomePage({
     Key key,
-    @required this.client,
-  })  : assert(client != null, '`SubiquityClient` must not be `null`'),
-        super(key: key);
-
-  final SubiquityClient client;
+  }) : super(key: key);
 
   @override
   _WelcomePageState createState() => _WelcomePageState();

--- a/ubuntu_desktop_installer/test/widget_test.dart
+++ b/ubuntu_desktop_installer/test/widget_test.dart
@@ -7,7 +7,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 
 import 'package:ubuntu_desktop_installer/keyboard_model.dart';
 import 'package:ubuntu_desktop_installer/l10n/app_localizations.dart';
@@ -20,10 +19,9 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     await setupAppLocalizations();
 
-    final client = SubiquityClient();
     await tester.pumpWidget(ChangeNotifierProvider(
         create: (context) => KeyboardModel(),
-        child: UbuntuDesktopInstallerApp(client: client)));
+        child: UbuntuDesktopInstallerApp()));
     await tester.pumpAndSettle();
     expect(find.byType(WelcomePage), findsOneWidget);
   });


### PR DESCRIPTION
Nice for lazy initialization and to avoid having to pass the client instance down to constructors.