### PR TITLE
Setup Melos for executing tasks across the project tree

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
     - uses: subosito/flutter-action@v1
       with:
         channel: 'dev'
@@ -21,57 +24,35 @@ jobs:
     - name: Enable Linux desktop support
       run: flutter config --enable-linux-desktop
 
-    # subiquity
+    - name: Install Melos
+      run: flutter pub global activate melos
 
-    - name: Checkout subiquity
-      run: git submodule update --init --recursive
+    - name: Install lcov
+      run: sudo apt update && sudo apt install lcov
+
+    # subiquity
     
     - name: Get subiquity dependencies
       working-directory: ./packages/subiquity_client/subiquity
       run: sudo apt update && make install_deps
 
-    # subiquity_client
+    # test all packages
 
-    - name: Get subiquity_client dependencies
-      working-directory: ./packages/subiquity_client
-      run: dart pub get
+    - name: Bootstrap workspace
+      run: melos bootstrap
     
-    - name: Run tests on subiquity_client
-      working-directory: ./packages/subiquity_client
-      run: flutter test --coverage
-
-    - name: Cleanup coverage results
-      working-directory: ./packages/subiquity_client
-      run: |
-        dart pub global activate remove_from_coverage
-        dart pub global run remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$' -r '\.freezed\.dart$'
+    - name: Run tests
+      run: melos run coverage
 
     - name: Upload coverage results
       uses: codecov/codecov-action@v1
       with:
-        files: packages/subiquity_client/coverage/lcov.info
-        token: ${{secrets.CODECOV_TOKEN}}
-
-    # ubuntu_desktop_installer
-
-    - name: Get ubuntu_desktop_installer dependencies
-      working-directory: ./packages/ubuntu_desktop_installer
-      run: flutter pub get
-    
-    - name: Run tests on ubuntu_desktop_installer
-      working-directory: ./packages/ubuntu_desktop_installer
-      run: flutter test --coverage
-
-    - name: Upload coverage results
-      uses: codecov/codecov-action@v1
-      with:
-        files: packages/ubuntu_desktop_installer/coverage/lcov.info
         token: ${{secrets.CODECOV_TOKEN}}
 
     # general
 
     - name: Check for any formatting issues
-      run: flutter format --set-exit-if-changed .
+      run: melos run format
     
     - name: Check for any analyzer issues
-      run: flutter analyze --no-fatal-infos .
+      run: melos run analyze

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 coverage/
+.idea/
+*.iml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,37 @@ The translation template has one special string (`languageName`) that is used to
 
 ## Code Generation
 
-The Subiquity client uses [freezed](https://pub.dev/packages/freezed) and
+This project uses [freezed](https://pub.dev/packages/freezed) and
 [json_serializable](https://pub.dev/packages/json_serializable) to generate
-immutable classes with JSON serialization support. Adding new types or members
-to `packages/subiquity_client/lib/src/types.dart` requires the code to be re-generated:
+immutable data classes with JSON serialization support. Adding new types or
+members to classes annotated with `@freezed` or `@JsonSerializable` requires
+the code to be re-generated (see also the Melos section below):
 
 ```
-cd packages/subiquity_client
-./tools/codegen.sh
+melos run generate
+```
+
+## Melos
+
+The project provides a [Melos](https://docs.page/invertase/melos) configuration
+to make it straightforward to execute certain tasks across the project tree.
+
+Install Melos:
+```
+dart pub global activate melos
+```
+
+Bootstrap the workspace:
+```
+melos bootstrap
+```
+
+Select a task interactively:
+```
+melos run
+```
+
+Run a specific task directly:
+```
+melos run coverage
 ```

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,40 @@
+name: ubuntu_desktop_installer
+
+packages:
+  - packages/**
+
+ignore:
+  - synthetic_package
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+scripts:
+  # analyze all packages
+  analyze: >
+    melos exec -c 1 -- \
+      flutter analyze --no-fatal-infos .
+
+  # collect coverage information for all packages
+  coverage: >
+    melos exec -c 1 --fail-fast --dir-exists=test -- \
+      flutter test --coverage && melos run coverage:cleanup
+
+  # cleanup generated files from coverage
+  coverage:cleanup: >
+    melos exec --file-exists=coverage/lcov.info -- \
+      lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
+
+  # format all packages
+  format: >
+    flutter format --set-exit-if-changed .
+
+  # run build_runner to generate code in all packages
+  generate: >
+    melos exec -c 1 --fail-fast --depends-on="build_runner" -- \
+      dart run build_runner build --delete-conflicting-outputs
+
+  # run tests in all packages
+  test: >
+    melos exec -c 1 --fail-fast --dir-exists=test -- \
+      flutter test

--- a/packages/subiquity_client/tools/codegen.sh
+++ b/packages/subiquity_client/tools/codegen.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-path=$(realpath "$(dirname $0)/..")
-
-(cd $path && dart run build_runner build --delete-conflicting-outputs)


### PR DESCRIPTION
Motivated by #77 - to avoid adding scripts around the project tree.

- Install [Melos](https://docs.page/invertase/melos):
  ```
  dart pub global activate melos
  ```

- Bootstrap the workspace:
  ```
  melos bootstrap
  ```

- Select a task interactively:
  ```
  melos run
  ```

- Run a specific task directly:
  ```
  melos run coverage
  ```

Currently, the following tasks are available:
1) analyze
2) coverage
3) format
4) generate
5) test

P.S. This is where the `packages/` subdirectory (https://github.com/canonical/ubuntu-desktop-installer/pull/68/commits/7e243de4bb422e44947e66c9b25f1d05987964b4) comes in handy. :slightly_smiling_face: 