### PR TITLE
Add WizardPage to reduce boilerplate & ensure consistent page structure

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout_page.dart
@@ -7,6 +7,7 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 
 import '../keyboard_model.dart';
 import '../widgets.dart';
+import 'wizard_page.dart';
 
 class KeyboardLayoutPage extends StatefulWidget {
   const KeyboardLayoutPage({
@@ -69,124 +70,100 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
   Widget build(BuildContext context) {
     return Consumer<KeyboardModel>(builder: (context, keyboardModel, child) {
       return LocalizedView(
-        builder: (context, lang) => Scaffold(
-          appBar: AppBar(
-            title: Text(lang.keyboardLayoutPageTitle),
-            automaticallyImplyLeading: false,
-          ),
-          body: Container(
-            padding: const EdgeInsets.all(20),
-            child: Column(
-              children: <Widget>[
-                Expanded(
-                  child: Column(
-                    children: <Widget>[
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(lang.chooseYourKeyboardLayout),
-                      ),
-                      const SizedBox(height: 10),
-                      Expanded(
-                        child: Row(
-                          children: <Widget>[
-                            Expanded(
-                              child: RoundedListView.builder(
-                                controller: _layoutListScrollController,
-                                itemCount: keyboardModel.layouts.length,
-                                itemBuilder: (context, index) {
-                                  return AutoScrollTag(
-                                      index: index,
-                                      key: ValueKey(index),
-                                      controller: _layoutListScrollController,
-                                      child: ListTile(
-                                        title: Text(
-                                            keyboardModel.layouts[index].name!),
-                                        selected: index == _selectedLayoutIndex,
-                                        onTap: () {
-                                          setState(() {
-                                            _selectedLayoutIndex = index;
-                                            _selectedLayoutName = keyboardModel
-                                                .layouts[index].code!;
-                                            _selectedVariantIndex = 0;
-                                          });
-                                        },
-                                      ));
-                                },
-                              ),
+        builder: (context, lang) => WizardPage(
+          title: Text(lang.keyboardLayoutPageTitle),
+          header: Text(lang.chooseYourKeyboardLayout),
+          content: Column(
+            children: <Widget>[
+              Expanded(
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: RoundedListView.builder(
+                        controller: _layoutListScrollController,
+                        itemCount: keyboardModel.layouts.length,
+                        itemBuilder: (context, index) {
+                          return AutoScrollTag(
+                            index: index,
+                            key: ValueKey(index),
+                            controller: _layoutListScrollController,
+                            child: ListTile(
+                              title: Text(keyboardModel.layouts[index].name!),
+                              selected: index == _selectedLayoutIndex,
+                              onTap: () {
+                                setState(() {
+                                  _selectedLayoutIndex = index;
+                                  _selectedLayoutName =
+                                      keyboardModel.layouts[index].code!;
+                                  _selectedVariantIndex = 0;
+                                });
+                              },
                             ),
-                            const SizedBox(width: 20),
-                            Expanded(
-                              child: RoundedListView.builder(
-                                controller:
-                                    _keyboardVariantListScrollController,
-                                itemCount: _selectedLayoutName.isNotEmpty
-                                    ? keyboardModel
-                                        .layouts[_selectedLayoutIndex]
-                                        .variants!
-                                        .length
-                                    : 0,
-                                itemBuilder: (context, index) {
-                                  return AutoScrollTag(
-                                      index: index,
-                                      key: ValueKey(index),
-                                      controller:
-                                          _keyboardVariantListScrollController,
-                                      child: ListTile(
-                                        title: Text(keyboardModel
-                                            .layouts[_selectedLayoutIndex]
-                                            .variants![index]
-                                            .name!),
-                                        selected:
-                                            index == _selectedVariantIndex,
-                                        onTap: () {
-                                          setState(() {
-                                            _selectedVariantIndex = index;
-                                          });
-                                        },
-                                      ));
-                                },
-                              ),
-                            ),
-                          ],
-                        ),
+                          );
+                        },
                       ),
-                      const SizedBox(height: 15),
-                      TextField(
-                        decoration: InputDecoration(
-                          border: const OutlineInputBorder(),
-                          hintText: lang.typeToTest,
-                        ),
-                      ),
-                      const SizedBox(height: 15),
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: OutlinedButton(
-                          child: Text(lang.detectLayout),
-                          onPressed: () {
-                            print(
-                                'TODO: show dialog to detect keyboard layout');
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 20),
-                ButtonBar(
-                  children: <OutlinedButton>[
-                    OutlinedButton(
-                      child: Text(lang.backButtonText),
-                      onPressed: Navigator.of(context).pop,
                     ),
-                    OutlinedButton(
-                      child: Text(lang.continueButtonText),
-                      onPressed: () {},
+                    const SizedBox(width: 20),
+                    Expanded(
+                      child: RoundedListView.builder(
+                        controller: _keyboardVariantListScrollController,
+                        itemCount: _selectedLayoutName.isNotEmpty
+                            ? keyboardModel
+                                .layouts[_selectedLayoutIndex].variants!.length
+                            : 0,
+                        itemBuilder: (context, index) {
+                          return AutoScrollTag(
+                            index: index,
+                            key: ValueKey(index),
+                            controller: _keyboardVariantListScrollController,
+                            child: ListTile(
+                              title: Text(keyboardModel
+                                  .layouts[_selectedLayoutIndex]
+                                  .variants![index]
+                                  .name!),
+                              selected: index == _selectedVariantIndex,
+                              onTap: () {
+                                setState(() {
+                                  _selectedVariantIndex = index;
+                                });
+                              },
+                            ),
+                          );
+                        },
+                      ),
                     ),
                   ],
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 20),
+              TextField(
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: lang.typeToTest,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton(
+                  child: Text(lang.detectLayout),
+                  onPressed: () {
+                    print('TODO: show dialog to detect keyboard layout');
+                  },
+                ),
+              ),
+            ],
           ),
+          actions: <WizardAction>[
+            WizardAction(
+              label: lang.backButtonText,
+              onActivated: Navigator.of(context).pop,
+            ),
+            WizardAction(
+              label: lang.continueButtonText,
+              onActivated: () {},
+            ),
+          ],
         ),
       );
     });

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install_page.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../app.dart';
 import '../routes.dart';
 import '../widgets.dart';
+import 'wizard_page.dart';
 
 enum Option { none, repairUbuntu, tryUbuntu, installUbuntu }
 
@@ -76,81 +77,57 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
   @override
   Widget build(BuildContext context) {
     return LocalizedView(
-      builder: (context, lang) => Scaffold(
-        appBar: AppBar(
-          title: Text(lang.tryOrInstallPageTitle),
-          automaticallyImplyLeading: false,
+      builder: (context, lang) => WizardPage(
+        title: Text(lang.tryOrInstallPageTitle),
+        contentPadding: EdgeInsets.fromLTRB(20, 50, 20, 150),
+        content: Row(
+          children: [
+            Expanded(
+              child: OptionCard(
+                selected: _option == Option.repairUbuntu,
+                imageAsset: 'assets/repair-wrench.png',
+                titleText: lang.repairInstallation,
+                bodyText: lang.repairInstallationDescription,
+                onSelected: () => selectOption(Option.repairUbuntu),
+              ),
+            ),
+            const SizedBox(width: 20),
+            Expanded(
+              child: OptionCard(
+                selected: _option == Option.tryUbuntu,
+                imageAsset: 'assets/steering-wheel.png',
+                titleText: lang.tryUbuntu,
+                bodyText: lang.tryUbuntuDescription,
+                onSelected: () => selectOption(Option.tryUbuntu),
+              ),
+            ),
+            const SizedBox(width: 20),
+            Expanded(
+              child: OptionCard(
+                selected: _option == Option.installUbuntu,
+                imageAsset: 'assets/hard-drive.png',
+                titleText: lang.installUbuntu,
+                bodyText: lang.installUbuntuDescription,
+                onSelected: () => selectOption(Option.installUbuntu),
+              ),
+            ),
+          ],
         ),
-        body: Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            children: <Widget>[
-              const SizedBox(height: 50),
-              Expanded(
-                child: Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: OptionCard(
-                        selected: _option == Option.repairUbuntu,
-                        imageAsset: 'assets/repair-wrench.png',
-                        titleText: lang.repairInstallation,
-                        bodyText: lang.repairInstallationDescription,
-                        onSelected: () => selectOption(Option.repairUbuntu),
-                      ),
-                    ),
-                    const SizedBox(width: 20),
-                    Expanded(
-                      child: OptionCard(
-                        selected: _option == Option.tryUbuntu,
-                        imageAsset: 'assets/steering-wheel.png',
-                        titleText: lang.tryUbuntu,
-                        bodyText: lang.tryUbuntuDescription,
-                        onSelected: () => selectOption(Option.tryUbuntu),
-                      ),
-                    ),
-                    const SizedBox(width: 20),
-                    Expanded(
-                      child: OptionCard(
-                        selected: _option == Option.installUbuntu,
-                        imageAsset: 'assets/hard-drive.png',
-                        titleText: lang.installUbuntu,
-                        bodyText: lang.installUbuntuDescription,
-                        onSelected: () => selectOption(Option.installUbuntu),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 150),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                  Flexible(
-                    fit: FlexFit.tight,
-                    child: Html(
-                      data: lang.releaseNotesLabel(_releaseNotesURL),
-                      onLinkTap: (url, _, __, ___) => launch(url!),
-                    ),
-                  ),
-                  ButtonBar(
-                    children: <OutlinedButton>[
-                      OutlinedButton(
-                        child: Text(lang.backButtonText),
-                        onPressed: Navigator.of(context).pop,
-                      ),
-                      OutlinedButton(
-                        child: Text(lang.continueButtonText),
-                        onPressed: (_option != Option.none)
-                            ? continueWithSelectedOption
-                            : null,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
+        footer: Html(
+          data: lang.releaseNotesLabel(_releaseNotesURL),
+          onLinkTap: (url, _, __, ___) => launch(url!),
+        ),
+        actions: <WizardAction>[
+          WizardAction(
+            label: lang.backButtonText,
+            onActivated: Navigator.of(context).pop,
           ),
-        ),
+          WizardAction(
+            label: lang.continueButtonText,
+            enabled: _option != Option.none,
+            onActivated: continueWithSelectedOption,
+          ),
+        ],
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_html/style.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../widgets.dart';
+import 'wizard_page.dart';
 
 class TurnOffRSTPage extends StatelessWidget {
   const TurnOffRSTPage({
@@ -15,64 +16,49 @@ class TurnOffRSTPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return LocalizedView(
       builder: (context, lang) => Scaffold(
-        appBar: AppBar(
+        body: WizardPage(
           title: Text(lang.turnOffRST),
-          automaticallyImplyLeading: false,
-        ),
-        body: Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(
+          header: Text(lang.turnOffRSTDescription),
+          content: Column(
             children: <Widget>[
               Expanded(
-                  child: Column(children: <Widget>[
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(lang.turnOffRSTDescription),
-                ),
-                const SizedBox(height: 20),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Html(
-                    data: lang.instructionsForRST('help.ubuntu.com/rst'),
-                    style: {
-                      'body': Style(
-                        margin: EdgeInsets.all(0),
+                child: Column(
+                  children: <Widget>[
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Html(
+                        data: lang.instructionsForRST('help.ubuntu.com/rst'),
+                        style: {
+                          'body': Style(
+                            margin: EdgeInsets.all(0),
+                          ),
+                        },
+                        onLinkTap: (url, _, __, ___) => launch(url!),
                       ),
-                    },
-                    onLinkTap: (url, _, __, ___) => launch(url!),
-                  ),
+                    ),
+                    const SizedBox(height: 40),
+                    Image.asset(
+                      'assets/rst.png',
+                      color: Theme.of(context).textTheme.bodyText1!.color,
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 40),
-                Image.asset(
-                  'assets/rst.png',
-                  color: Theme.of(context).textTheme.bodyText1!.color,
-                ),
-              ])),
-              const SizedBox(height: 20),
-              ButtonBar(
-                children: <OutlinedButton>[
-                  OutlinedButton(
-                    child: Text(lang.backButtonText),
-                    onPressed: Navigator.of(context).pop,
-                  ),
-                  OutlinedButton(
-                    style: OutlinedButtonTheme.of(context).style!.copyWith(
-                          backgroundColor: MaterialStateColor.resolveWith(
-                            (states) => Color(0xFF0e8420),
-                          ),
-                          foregroundColor: MaterialStateColor.resolveWith(
-                            (states) => Colors.white,
-                          ),
-                        ),
-                    child: Text(lang.restartButtonText),
-                    onPressed: () {
-                      print('TODO: restart computer');
-                    },
-                  ),
-                ],
               ),
             ],
           ),
+          actions: <WizardAction>[
+            WizardAction(
+              label: lang.backButtonText,
+              onActivated: Navigator.of(context).pop,
+            ),
+            WizardAction(
+              label: lang.restartButtonText,
+              highlighted: true,
+              onActivated: () {
+                print('TODO: restart computer');
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome_page.dart
@@ -13,6 +13,7 @@ import '../app.dart';
 import '../keyboard_model.dart';
 import '../routes.dart';
 import '../widgets.dart';
+import 'wizard_page.dart';
 
 class WelcomePage extends StatefulWidget {
   const WelcomePage({
@@ -77,67 +78,48 @@ class _WelcomePageState extends State<WelcomePage> {
   @override
   Widget build(BuildContext context) {
     return LocalizedView(
-      builder: (context, lang) => Scaffold(
-        appBar: AppBar(title: Text(lang.welcome)),
-        body: Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            children: <Widget>[
-              Expanded(
-                child: Center(
-                  child: FractionallySizedBox(
-                    widthFactor: 0.5,
-                    child: RoundedListView.builder(
-                      controller: _languageListScrollController,
-                      itemCount: _languageList.length,
-                      itemBuilder: (context, index) {
-                        return AutoScrollTag(
-                            index: index,
-                            key: ValueKey(index),
-                            controller: _languageListScrollController,
-                            child: ListTile(
-                              title: Text(_languageList[index].item2),
-                              selected: index == _selectedLanguageIndex,
-                              onTap: () async {
-                                final locale = _languageList[index].item1;
-                                final subiquityClient =
-                                    Provider.of<SubiquityClient>(context,
-                                        listen: false);
-                                await subiquityClient
-                                    .switchLanguage(locale.languageCode);
-                                setState(() {
-                                  _selectedLanguageIndex = index;
-                                  UbuntuDesktopInstallerApp.locale = locale;
-                                  Provider.of<KeyboardModel>(context,
-                                          listen: false)
-                                      .load(subiquityClient);
-                                });
-                              },
-                            ));
-                      },
-                    ),
-                  ),
+      builder: (context, lang) => WizardPage(
+        title: Text(lang.welcome),
+        content: FractionallySizedBox(
+          widthFactor: 0.5,
+          child: RoundedListView.builder(
+            controller: _languageListScrollController,
+            itemCount: _languageList.length,
+            itemBuilder: (context, index) {
+              return AutoScrollTag(
+                index: index,
+                key: ValueKey(index),
+                controller: _languageListScrollController,
+                child: ListTile(
+                  title: Text(_languageList[index].item2),
+                  selected: index == _selectedLanguageIndex,
+                  onTap: () async {
+                    final locale = _languageList[index].item1;
+                    final subiquityClient =
+                        Provider.of<SubiquityClient>(context, listen: false);
+                    await subiquityClient.switchLanguage(locale.languageCode);
+                    setState(() {
+                      _selectedLanguageIndex = index;
+                      UbuntuDesktopInstallerApp.locale = locale;
+                      Provider.of<KeyboardModel>(context, listen: false)
+                          .load(subiquityClient);
+                    });
+                  },
                 ),
-              ),
-              const SizedBox(height: 20),
-              ButtonBar(
-                children: <OutlinedButton>[
-                  OutlinedButton(
-                    child: Text(lang.backButtonText),
-                    onPressed: null,
-                  ),
-                  OutlinedButton(
-                    child: Text(lang.continueButtonText),
-                    onPressed: () {
-                      // TODO: implement ubiquity's apply_keyboard() function and run it here
-                      Navigator.pushNamed(context, Routes.tryOrInstall);
-                    },
-                  ),
-                ],
-              ),
-            ],
+              );
+            },
           ),
         ),
+        actions: <WizardAction>[
+          WizardAction(label: lang.backButtonText),
+          WizardAction(
+            label: lang.continueButtonText,
+            onActivated: () {
+              // TODO: implement ubiquity's apply_keyboard() function and run it here
+              Navigator.pushNamed(context, Routes.tryOrInstall);
+            },
+          ),
+        ],
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/wizard_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/wizard_page.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+
+const _kButtonSpacing = 8.0;
+const _kContentSpacing = 20.0;
+const _kContentPadding = EdgeInsets.symmetric(horizontal: 24);
+const _kHeaderPadding = EdgeInsets.fromLTRB(24, 24, 24, 0);
+const _kFooterPadding = EdgeInsets.fromLTRB(24, 0, 24, 24);
+const _kHighlightBackground = Color(0xFF0e8420);
+const _kHighlightForeground = Colors.white;
+
+/// Defines a wizard action, such as _Back_ or _Continue_.
+class WizardAction {
+  /// Creates a wizard action.
+  const WizardAction({
+    this.label,
+    this.visible,
+    this.highlighted,
+    this.enabled,
+    this.onActivated,
+  });
+
+  /// Text label of the back button.
+  final String? label;
+
+  /// Determines whether the action is visible.
+  ///
+  /// The default value is `true`
+  final bool? visible;
+
+  /// Determines whether the action is highlighted (green);
+  ///
+  /// The default value is `false`.
+  final bool? highlighted;
+
+  /// Determines whether the action is enabled.
+  ///
+  /// The default value is `false`. If not specified, the action is implicitly
+  /// disabled if [onActivated] is `null`.
+  final bool? enabled;
+
+  /// Called when the action is triggered e.g. by pressing the action button.
+  ///
+  /// See also [enabled].
+  final VoidCallback? onActivated;
+}
+
+/// The base for wizard pages in the installer.
+///
+/// Provides the appropriate layout and the common building blocks for
+/// installation wizard pages.
+class WizardPage extends StatelessWidget {
+  /// Creates the wizard page.
+  const WizardPage({
+    Key? key,
+    this.title,
+    this.header,
+    this.content,
+    this.contentPadding = _kContentPadding,
+    this.footer,
+    this.actions = const <WizardAction>[],
+  }) : super(key: key);
+
+  /// The title widget in the app bar.
+  final Widget? title;
+
+  /// A header widget below the title.
+  final Widget? header;
+
+  /// A content widget laid out below the header.
+  final Widget? content;
+
+  /// Padding around the content widget.
+  final EdgeInsetsGeometry contentPadding;
+
+  /// A footer widget on the side of the buttons.
+  final Widget? footer;
+
+  /// A list of actions in the button bar.
+  final List<WizardAction> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: title, automaticallyImplyLeading: false),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: _kHeaderPadding,
+            child: header != null
+                ? Align(
+                    alignment: Alignment.centerLeft,
+                    child: header,
+                  )
+                : null,
+          ),
+          if (header != null) const SizedBox(height: _kContentSpacing),
+          Expanded(
+            child: Padding(padding: contentPadding, child: content),
+          ),
+          const SizedBox(height: _kContentSpacing),
+        ],
+      ),
+      bottomNavigationBar: Padding(
+        padding: _kFooterPadding,
+        child: Row(
+          mainAxisAlignment: footer != null
+              ? MainAxisAlignment.spaceBetween
+              : MainAxisAlignment.end,
+          children: <Widget>[
+            if (footer != null) Expanded(child: footer!),
+            const SizedBox(width: _kContentSpacing),
+            ButtonBar(
+              buttonPadding: EdgeInsets.zero,
+              children: <Widget>[
+                for (final action in actions)
+                  if (action.visible ?? true)
+                    Padding(
+                      padding: const EdgeInsets.only(left: _kButtonSpacing),
+                      child: OutlinedButton(
+                        onPressed:
+                            action.enabled ?? true ? action.onActivated : null,
+                        style: _buttonStyle(
+                          context,
+                          highlighted: action.highlighted ?? false,
+                        ),
+                        child: Text(action.label!),
+                      ),
+                    ),
+                const SizedBox(width: _kButtonSpacing),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  ButtonStyle? _buttonStyle(BuildContext context, {bool? highlighted}) {
+    if (highlighted != true) return null;
+    return OutlinedButtonTheme.of(context).style!.copyWith(
+          backgroundColor: MaterialStateColor.resolveWith(
+            (_) => _kHighlightBackground,
+          ),
+          foregroundColor: MaterialStateColor.resolveWith(
+            (_) => _kHighlightForeground,
+          ),
+        );
+  }
+}

--- a/packages/ubuntu_desktop_installer/test/wizard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/wizard_page_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_desktop_installer/pages/wizard_page.dart';
+
+void main() {
+  testWidgets('activation', (tester) async {
+    var activated = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardPage(
+          actions: <WizardAction>[
+            WizardAction(label: 'action', onActivated: () => activated = true),
+          ],
+        ),
+      ),
+    );
+
+    await tester.tap(find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.text('action'),
+    ));
+    expect(activated, isTrue);
+  });
+
+  testWidgets('layout', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardPage(
+          title: const Text('title'),
+          header: const Text('header'),
+          content: const Text('content'),
+          footer: const Text('footer'),
+          actions: <WizardAction>[
+            const WizardAction(label: 'back'),
+            const WizardAction(label: 'next'),
+          ],
+        ),
+      ),
+    );
+
+    final title = find.descendant(
+      of: find.byType(AppBar),
+      matching: find.text('title'),
+    );
+    expect(title, findsOneWidget);
+
+    final header = find.text('header');
+    expect(header, findsOneWidget);
+
+    final content = find.text('content');
+    expect(content, findsOneWidget);
+
+    final footer = find.text('footer');
+    expect(footer, findsOneWidget);
+
+    expect(tester.getCenter(title).dy, lessThan(tester.getCenter(header).dy));
+    expect(tester.getCenter(header).dy, lessThan(tester.getCenter(content).dy));
+    expect(tester.getCenter(content).dy, lessThan(tester.getCenter(footer).dy));
+  });
+
+  testWidgets('highlighted action', (tester) async {
+    final buttonTheme = OutlinedButtonThemeData(
+      style: ButtonStyle(
+        backgroundColor: MaterialStateColor.resolveWith((_) => Colors.red),
+        foregroundColor: MaterialStateColor.resolveWith((_) => Colors.blue),
+      ),
+    );
+
+    final button = find.widgetWithText(OutlinedButton, 'action');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(outlinedButtonTheme: buttonTheme),
+        home: WizardPage(
+          actions: <WizardAction>[
+            const WizardAction(label: 'action', highlighted: false),
+          ],
+        ),
+      ),
+    );
+    expect(tester.widget<OutlinedButton>(button).style, isNull);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(outlinedButtonTheme: buttonTheme),
+        home: WizardPage(
+          actions: <WizardAction>[
+            const WizardAction(label: 'action', highlighted: true),
+          ],
+        ),
+      ),
+    );
+    expect(tester.widget<OutlinedButton>(button).style, isNotNull);
+  });
+
+  testWidgets('disabled action', (tester) async {
+    var activated = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardPage(
+          actions: <WizardAction>[
+            WizardAction(
+              label: 'action',
+              enabled: false,
+              onActivated: () => activated = true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.tap(find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.text('action'),
+    ));
+    expect(activated, isFalse);
+  });
+
+  testWidgets('hidden action', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardPage(
+          actions: <WizardAction>[
+            WizardAction(label: 'action', visible: false),
+          ],
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byType(OutlinedButton),
+        matching: find.text('action'),
+      ),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
`WizardPage` provides the appropriate layout and the common building blocks for installation wizard pages.

```
 __________________
|                  |
| title (app bar)  |
|__________________|
|                  |
| header           |
|__________________|
|                  |
|                  |
|     content      |
|                  |
|__________________|
|                  |
| (footer) buttons |
|__________________|

```


In the current design, all other pages follow this structure except the last two pages (installation slides & installation complete).