### PR TITLE
.gitignore: add .vscode/ for workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 .idea/
 *.iml
+.vscode/


### PR DESCRIPTION
For example, [peacock](https://www.peacockcode.dev/) is an awesome VS Code extension that stores settings per workspace.