### PR TITLE
install a desktop entry with the assets

### DIFF
--- a/packages/ubuntu_desktop_installer/assets/ubuntu-desktop-installer.desktop
+++ b/packages/ubuntu_desktop_installer/assets/ubuntu-desktop-installer.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+# Do not translate the word "RELEASE".  It is used as a marker by casper.
+Name=Install RELEASE
+Comment=Install this system permanently to your hard disk
+Keywords=ubiquity;
+#use sh because pkexec is broken under xfce/lxce http://pad.lv/1193526
+Exec=ubuntu-desktop-installer
+Icon=ubiquity
+Terminal=false
+Categories=GTK;System;Settings;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ architectures:
 apps:
   ubuntu-desktop-installer:
     command: bin/ubuntu_desktop_installer
+    desktop: bin/data/flutter_assets/assets/ubuntu-desktop-installer.desktop
     environment:
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri


### PR DESCRIPTION
The entry is inspired from the ubiquity one. It is currently not translatable but we need to figure out what's out story there and it shouldn't be a blocker to have a working on the live session. The desktop also still use 'ubiquity' for its icons which is provided by the theme