### PR TITLE
Define the source type to git

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ parts:
 
   ubuntu-desktop-installer:
     source: .
+    source-type: git
     plugin: nil
     build-environment:
       - C_INCLUDE_PATH: /snap/flutter/current/usr/include


### PR DESCRIPTION
It's needed for snapcraft to pull subcomponents

Launchpad is doing that by default but without it set local builds are relying on the checkout to be done in the current directory