### PR TITLE
Include missing stage package and define pythonpath

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,6 +106,8 @@ parts:
       - libegl-mesa0
       - libegl1
       - libgl1
+      - libglib2.0-0
+      - libglib2.0-dev
       - libgtk-3-0
       - libpango-1.0-0
       - libpangocairo-1.0-0
@@ -130,8 +132,7 @@ parts:
       - usr/lib/*/libcairo*.so.*
       - usr/lib/*/libe*.so.*
       - usr/lib/*/libf*.so.*
-      - usr/lib/*/libgdk*.so.*
-      - usr/lib/*/libgtk*.so.*
+      - usr/lib/*/libg*.so.*
       - usr/lib/*/libharfbuzz*.so.*
       - usr/lib/*/libpango*.so.*
       - usr/lib/*/libpixman*.so.*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ apps:
   subiquity-server:
     command: bin/subiquity-server
     daemon: simple
+    environment:
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
     restart-condition: always
 
   ubuntu-desktop-installer:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,7 +61,14 @@ parts:
       - iso-codes
       - lsb-release
       - ssh-import-id
-      - probert
+      - probert-common
+      - probert-network
+      - probert-storage
+      - python3-aiohttp
+      - python3-bson
+      - python3-curtin
+      - python3-pyudev
+      - python3-urwid
     prime:
       - -lib/systemd/system/*
 


### PR DESCRIPTION
In case you wonder, the probert stage-package got split because snapcraft isn't pulling the depends (expected or bug?). The libglib dev is staged because flutter tries to load libgio-2.0.so and not .so.0. 

A locally built snap now gives a working subiquity service on a new installation and the gobject type errors are resolved on focal