### PR TITLE
Stage python3-requests-unixsocket

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ parts:
       - python3-aiohttp
       - python3-bson
       - python3-curtin
+      - python3-requests-unixsocket
       - python3-pyudev
       - python3-urwid
     prime:


### PR DESCRIPTION
It was pulled it on the default installation by software-properties until hirsute so testing on focal didn't show it was needed, but it isn't anymore since https://launchpad.net/ubuntu/+source/software-properties/0.99.6