### PR TITLE
Update instruction with missing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cd subiquity
 make install_deps
 cd ../../ubuntu_desktop_installer
 flutter pub get
+sudo apt install liblzma-dev
 ```
 
 Run:


### PR DESCRIPTION
Add missing liblzma package needed for ubuntu-desktop-installer