### PR TITLE
Update yaru dependency to 0.0.7

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   scroll_to_index: ^2.0.0
   tuple: ^2.0.0
   url_launcher: ^6.0.3
-  yaru: ^0.0.2
+  yaru: ^0.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updating yaru dependency to 0.0.7 since many changes happend since 0.0.2:
https://github.com/ubuntu/yaru.dart/blob/main/CHANGELOG.md

Especially replacing all aubergine elements with orange elements syncing with the canonical design team rebranding