### PR TITLE
Add RadioIconTile to help aligning icons with radio list tiles

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets.dart
@@ -4,5 +4,6 @@ export 'widgets/dropdown_builder.dart';
 export 'widgets/localized_view.dart';
 export 'widgets/menu_button_builder.dart';
 export 'widgets/option_card.dart';
+export 'widgets/radio_icon_tile.dart';
 export 'widgets/rounded_container.dart';
 export 'widgets/rounded_list_view.dart';

--- a/packages/ubuntu_desktop_installer/lib/widgets/radio_icon_tile.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/radio_icon_tile.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+const _kRadioSize = Size.square(kMinInteractiveDimension - 8);
+
+/// List tile with an icon that matches the geometry of [RadioListTile]'s radio
+/// indicator.
+class RadioIconTile extends StatelessWidget {
+  /// Creates a radio icon tile.
+  const RadioIconTile({
+    Key? key,
+    this.icon,
+    this.title,
+    this.contentPadding,
+  }) : super(key: key);
+
+  /// An icon shown centered within the bounding box of [RadioListTile]'s radio
+  /// indicator.
+  final Widget? icon;
+
+  /// The primary content of the list tile.
+  final Widget? title;
+
+  /// The tile's internal padding.
+  final EdgeInsetsGeometry? contentPadding;
+
+  Size _calculateIconSize(BuildContext context) {
+    final theme = Theme.of(context);
+    final visualDensity = theme.radioTheme.visualDensity ?? theme.visualDensity;
+    return _kRadioSize + visualDensity.baseSizeAdjustment;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: contentPadding,
+      leading: SizedBox.fromSize(
+        size: _calculateIconSize(context),
+        child: Center(child: icon),
+      ),
+      title: title,
+    );
+  }
+}

--- a/packages/ubuntu_desktop_installer/test/radio_icon_tile_test.dart
+++ b/packages/ubuntu_desktop_installer/test/radio_icon_tile_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ubuntu_desktop_installer/widgets.dart';
+
+void main() {
+  testWidgets('icon & radio geometries match ', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              RadioIconTile(icon: Icon(Icons.close)),
+              RadioListTile<dynamic>(
+                value: 1,
+                groupValue: 1,
+                onChanged: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final iconTile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.byType(RadioIconTile),
+        matching: find.byType(ListTile),
+      ),
+    );
+
+    final radioTile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.byType(RadioListTile),
+        matching: find.byType(ListTile),
+      ),
+    );
+
+    expect(iconTile.leading, isNotNull);
+    expect(radioTile.leading, isNotNull);
+
+    final iconRect = tester.getRect(find.byWidget(iconTile.leading!));
+    final radioRect = tester.getRect(find.byWidget(radioTile.leading!));
+
+    expect(iconRect.size, equals(radioRect.size));
+    expect(iconRect.left, equals(radioRect.left));
+    expect(iconRect.right, equals(radioRect.right));
+  });
+}


### PR DESCRIPTION
This is essentially a `ListTile` with a leading icon that matches the geometry of `RadioListTile`'s radio indicator. This helps to align the widgets in #77 according to the design presented in #30.