### PR TITLE
Update yaru to 0.0.8

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   scroll_to_index: ^2.0.0
   tuple: ^2.0.0
   url_launcher: ^6.0.3
-  yaru: ^0.0.7
+  yaru: ^0.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- AppBar elevation now down to 1.0

![grafik](https://user-images.githubusercontent.com/15329494/124658362-f700ea80-dea3-11eb-8417-7a694529da3c.png)
![grafik](https://user-images.githubusercontent.com/15329494/124658631-4810de80-dea4-11eb-86ee-1250de236c0d.png)

Closes #128 

Design acked in this comment: https://github.com/canonical/ubuntu-desktop-installer/issues/84#issuecomment-874571843