### PR TITLE
AllocateDiskSpace: do not hardcode text colors

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space_page.dart
@@ -62,14 +62,8 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
                     child: Column(children: <Widget>[
                   RoundedContainer(
                     child: DataTable(
-                      headingTextStyle: Theme.of(context)
-                          .textTheme
-                          .caption!
-                          .apply(fontWeightDelta: 3, color: Colors.black),
-                      dataTextStyle: Theme.of(context)
-                          .textTheme
-                          .caption!
-                          .apply(color: Colors.black),
+                      headingTextStyle: Theme.of(context).textTheme.subtitle2,
+                      dataTextStyle: Theme.of(context).textTheme.bodyText2,
                       columns: <DataColumn>[
                         DataColumn(
                           label: Text(lang.diskHeadersDevice),


### PR DESCRIPTION
- use the themes subtitle and bodytext theme for the datatable headers and data text


Before:
![](https://user-images.githubusercontent.com/1143994/124792188-b1482e80-df44-11eb-9ad3-e8657e40feb9.png)

After:
![image](https://user-images.githubusercontent.com/15329494/124801327-02611e00-df57-11eb-85c0-e95a79d298ca.png)
![image](https://user-images.githubusercontent.com/15329494/124801631-57049900-df57-11eb-87d3-f9b8796877a1.png)

Closes #136