### PR TITLE
Replace custom-highlighted OutlinedButton with ElevatedButton

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/app_theme.dart
+++ b/packages/ubuntu_desktop_installer/lib/app_theme.dart
@@ -2,9 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
 
-const _kHighlightBackground = Color(0xFF0e8420);
-const _kHighlightForeground = Colors.white;
-
 class AppTheme extends ValueNotifier<ThemeMode> {
   AppTheme(this._settings) : super(ThemeMode.system);
   final GSettings _settings;
@@ -27,22 +24,5 @@ class AppTheme extends ValueNotifier<ThemeMode> {
   void dispose() {
     super.dispose();
     _settings.dispose();
-  }
-}
-
-/// Application-specific theming extensions.
-extension AppThemeData on ThemeData {
-  /// A theme for (green) highlighted [OutlinedButton]s.
-  OutlinedButtonThemeData get highlightedButtonTheme {
-    return OutlinedButtonThemeData(
-      style: outlinedButtonTheme.style!.copyWith(
-        backgroundColor: MaterialStateColor.resolveWith(
-          (_) => _kHighlightBackground,
-        ),
-        foregroundColor: MaterialStateColor.resolveWith(
-          (_) => _kHighlightForeground,
-        ),
-      ),
-    );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/wizard_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/wizard_page.dart
@@ -112,14 +112,7 @@ class WizardPage extends StatelessWidget {
                   if (action.visible ?? true)
                     Padding(
                       padding: const EdgeInsets.only(left: kButtonBarSpacing),
-                      child: OutlinedButton(
-                        onPressed:
-                            action.enabled ?? true ? action.onActivated : null,
-                        style: action.highlighted == true
-                            ? Theme.of(context).highlightedButtonTheme.style
-                            : null,
-                        child: Text(action.label!),
-                      ),
+                      child: _createButton(action),
                     ),
                 const SizedBox(width: kButtonBarSpacing),
               ],
@@ -128,5 +121,12 @@ class WizardPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _createButton(WizardAction action) {
+    final maybeActivate = action.enabled ?? true ? action.onActivated : null;
+    return action.highlighted == true
+        ? ElevatedButton(onPressed: maybeActivate, child: Text(action.label!))
+        : OutlinedButton(onPressed: maybeActivate, child: Text(action.label!));
   }
 }

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   scroll_to_index: ^2.0.0
   tuple: ^2.0.0
   url_launcher: ^6.0.3
-  yaru: ^0.0.9
+  yaru: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   scroll_to_index: ^2.0.0
   tuple: ^2.0.0
   url_launcher: ^6.0.3
-  yaru: ^0.0.8
+  yaru: ^0.0.9
 
 dev_dependencies:
   flutter_test:

--- a/packages/ubuntu_desktop_installer/test/wizard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/wizard_page_test.dart
@@ -60,18 +60,8 @@ void main() {
   });
 
   testWidgets('highlighted action', (tester) async {
-    final buttonTheme = OutlinedButtonThemeData(
-      style: ButtonStyle(
-        backgroundColor: MaterialStateColor.resolveWith((_) => Colors.red),
-        foregroundColor: MaterialStateColor.resolveWith((_) => Colors.blue),
-      ),
-    );
-
-    final button = find.widgetWithText(OutlinedButton, 'action');
-
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(outlinedButtonTheme: buttonTheme),
         home: WizardPage(
           actions: <WizardAction>[
             const WizardAction(label: 'action', highlighted: false),
@@ -79,11 +69,11 @@ void main() {
         ),
       ),
     );
-    expect(tester.widget<OutlinedButton>(button).style, isNull);
+    expect(find.widgetWithText(OutlinedButton, 'action'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'action'), findsNothing);
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(outlinedButtonTheme: buttonTheme),
         home: WizardPage(
           actions: <WizardAction>[
             const WizardAction(label: 'action', highlighted: true),
@@ -91,7 +81,8 @@ void main() {
         ),
       ),
     );
-    expect(tester.widget<OutlinedButton>(button).style, isNotNull);
+    expect(find.widgetWithText(OutlinedButton, 'action'), findsNothing);
+    expect(find.widgetWithText(ElevatedButton, 'action'), findsOneWidget);
   });
 
   testWidgets('disabled action', (tester) async {


### PR DESCRIPTION
As @Feichtmeier suggested in https://github.com/canonical/ubuntu-desktop-installer/pull/142#issuecomment-877309149, let the Yaru theme decide theme colors instead of hard-coding a specific green shade in the installer.