### PR TITLE
OptionCard: improve the look

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/widgets/option_card.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/option_card.dart
@@ -67,15 +67,21 @@ class OptionCardState extends State<OptionCard> {
   @override
   Widget build(BuildContext context) {
     return Card(
+      color: Theme.of(context).cardColor,
       shape: RoundedRectangleBorder(
           side: BorderSide(
               color: widget.selected
-                  ? Theme.of(context).primaryColor.withOpacity(0.4)
-                  : Theme.of(context).colorScheme.onSurface.withAlpha(20),
-              width: 1),
-          borderRadius: BorderRadius.circular(4.0)),
-      elevation: widget.selected ? 0 : 1,
+                  ? Theme.of(context).primaryColor.withOpacity(0.5)
+                  : Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withAlpha(hovered ? 60 : 20),
+              width: 2),
+          borderRadius: BorderRadius.circular(6)),
+      elevation: 0,
       child: InkWell(
+        hoverColor: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(6),
         child: Container(
           padding: const EdgeInsets.all(20),
           child: Column(children: <Widget>[
@@ -95,25 +101,25 @@ class OptionCardState extends State<OptionCard> {
                   fontWeight: FontWeight.bold,
                   fontSize: 19,
                   color: widget.selected
-                      ? Theme.of(context).primaryColor
-                      : Theme.of(context).colorScheme.onSurface.withAlpha(190),
+                      ? Theme.of(context).colorScheme.onSurface
+                      : Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.5),
                 ),
               ),
             ),
             const SizedBox(height: 10),
             Expanded(
-              child: Opacity(
-                opacity: 0.9,
-                child: Text(widget.bodyText ?? '',
-                    style: TextStyle(
-                      color: widget.selected
-                          ? Theme.of(context).primaryColor
-                          : Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withAlpha(190),
-                    )),
-              ),
+              child: Text(widget.bodyText ?? '',
+                  style: TextStyle(
+                    color: widget.selected
+                        ? Theme.of(context).colorScheme.onSurface
+                        : Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withOpacity(0.5),
+                  )),
             ),
           ]),
         ),

--- a/packages/ubuntu_desktop_installer/lib/widgets/option_card.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/option_card.dart
@@ -100,26 +100,12 @@ class OptionCardState extends State<OptionCard> {
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 19,
-                  color: widget.selected
-                      ? Theme.of(context).colorScheme.onSurface
-                      : Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withOpacity(0.5),
                 ),
               ),
             ),
             const SizedBox(height: 10),
             Expanded(
-              child: Text(widget.bodyText ?? '',
-                  style: TextStyle(
-                    color: widget.selected
-                        ? Theme.of(context).colorScheme.onSurface
-                        : Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withOpacity(0.5),
-                  )),
+              child: Text(widget.bodyText ?? ''),
             ),
           ]),
         ),


### PR DESCRIPTION
- axe the elevation in all states
- do not use accent color colored text on selection
- add a semi transparent border

![Peek 2021-07-12 11-52](https://user-images.githubusercontent.com/15329494/125268133-b2dc7280-e307-11eb-9cd6-28052cd5991f.gif)

Closes #139 

Acked by design in this comment: https://github.com/canonical/ubuntu-desktop-installer/issues/139#issuecomment-878344437