### PR TITLE
Separate TryOrInstallPage's business logic to TryOrInstallModel

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/app.dart
+++ b/packages/ubuntu_desktop_installer/lib/app.dart
@@ -9,7 +9,7 @@ import 'l10n/app_localizations.dart';
 import 'pages/allocate_disk_space_page.dart';
 import 'pages/choose_your_look_page.dart';
 import 'pages/keyboard_layout_page.dart';
-import 'pages/try_or_install_page.dart';
+import 'pages/try_or_install/try_or_install_page.dart';
 import 'pages/turn_off_rst_page.dart';
 import 'pages/updates_other_software/updates_other_software_page.dart';
 import 'pages/welcome/welcome_page.dart';
@@ -48,7 +48,7 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         initialRoute: Routes.welcome,
         routes: <String, WidgetBuilder>{
           Routes.welcome: WelcomePage.create,
-          Routes.tryOrInstall: (context) => TryOrInstallPage(),
+          Routes.tryOrInstall: TryOrInstallPage.create,
           Routes.turnOffRST: (context) => const TurnOffRSTPage(),
           Routes.keyboardLayout: (context) => KeyboardLayoutPage(),
           Routes.updatesOtherSoftware: UpdatesOtherSoftwarePage.create,

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -1,0 +1,63 @@
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+/// The available options on the Try Or Install page.
+enum Option {
+  /// No option is selected.
+  none,
+
+  /// The user wants to repair Ubuntu.
+  repairUbuntu,
+
+  /// The user wants to try Ubuntu.
+  tryUbuntu,
+
+  /// The user wants to install Ubuntu.
+  installUbuntu,
+}
+
+/// Implements the business logic of the Try Or Install page.
+class TryOrInstallModel extends ChangeNotifier {
+  /// The currently selected option.
+  Option get option => _option;
+  Option _option = Option.none;
+
+  /// Selects the given [option].
+  void selectOption(Option option) {
+    if (_option == option) return;
+    _option = option;
+    notifyListeners();
+  }
+
+  /// Returns the URL of the release notes for the given [locale].
+  String releaseNotesURL(
+    Locale locale, {
+    @visibleForTesting FileSystem fs = const LocalFileSystem(),
+  }) {
+    final fileOnCdrom = fs.file('/cdrom/.disk/release_notes_url');
+    if (fileOnCdrom.existsSync()) {
+      try {
+        final url = fileOnCdrom
+            .readAsLinesSync()
+            .firstWhere((line) => line.trim().isNotEmpty);
+        return url.replaceAll(r'${LANG}', locale.languageCode);
+        // ignore: avoid_catches_without_on_clauses
+      } catch (e) {}
+    }
+    try {
+      final lines =
+          fs.file('/usr/share/distro-info/ubuntu.csv').readAsLinesSync();
+      final last = lines.lastWhere((line) => line.trim().isNotEmpty);
+      final codeName = last.split(',')[1].replaceAll(RegExp('\\s+'), '');
+      assert(codeName.isNotEmpty);
+      return 'https://wiki.ubuntu.com/$codeName/ReleaseNotes';
+      // ignore: avoid_catches_without_on_clauses
+    } catch (e) {
+      // Those are not actual release notes,
+      // but it's a better fallback than a non-existent wiki page.
+      return 'https://ubuntu.com/download/desktop';
+    }
+  }
+}

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -1,44 +1,38 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:provider/provider.dart';
 
-import '../app.dart';
-import '../routes.dart';
-import '../widgets.dart';
-import 'wizard_page.dart';
-
-enum Option { none, repairUbuntu, tryUbuntu, installUbuntu }
+import '../../app.dart';
+import '../../routes.dart';
+import '../../widgets.dart';
+import '../wizard_page.dart';
+import 'try_or_install_model.dart';
 
 class TryOrInstallPage extends StatefulWidget {
   const TryOrInstallPage({
     Key? key,
   }) : super(key: key);
 
+  static Widget create(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => TryOrInstallModel(),
+      child: TryOrInstallPage(),
+    );
+  }
+
   @override
   TryOrInstallPageState createState() => TryOrInstallPageState();
 }
 
 class TryOrInstallPageState extends State<TryOrInstallPage> {
-  Option _option = Option.none;
-
-  void selectOption(Option option) {
-    assert(option != Option.none);
-    if (option != _option) {
-      setState(() {
-        _option = option;
-      });
-    }
-  }
-
   void continueWithSelectedOption() {
-    if (_option == Option.repairUbuntu) {
+    final model = Provider.of<TryOrInstallModel>(context, listen: false);
+    if (model.option == Option.repairUbuntu) {
       Navigator.pushNamed(context, Routes.repairUbuntu);
-    } else if (_option == Option.tryUbuntu) {
+    } else if (model.option == Option.tryUbuntu) {
       Navigator.pushNamed(context, Routes.tryUbuntu);
-    } else if (_option == Option.installUbuntu) {
+    } else if (model.option == Option.installUbuntu) {
       // TODO: detect if we need to show the "Turn off RST" page,
       // or if we can proceed directly to installation
       //Navigator.pushNamed(context, Routes.turnOffRST);
@@ -48,34 +42,9 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
     }
   }
 
-  String get _releaseNotesURL {
-    final fileOnCdrom = File('/cdrom/.disk/release_notes_url');
-    if (fileOnCdrom.existsSync()) {
-      try {
-        final url = fileOnCdrom
-            .readAsLinesSync()
-            .firstWhere((line) => line.trim().isNotEmpty);
-        return url.replaceAll(
-            r'${LANG}', UbuntuDesktopInstallerApp.locale.languageCode);
-        // ignore: avoid_catches_without_on_clauses
-      } catch (e) {}
-    }
-    try {
-      final lines = File('/usr/share/distro-info/ubuntu.csv').readAsLinesSync();
-      final last = lines.lastWhere((line) => line.trim().isNotEmpty);
-      final codeName = last.split(',')[1].replaceAll(RegExp('\\s+'), '');
-      assert(codeName.isNotEmpty);
-      return 'https://wiki.ubuntu.com/$codeName/ReleaseNotes';
-      // ignore: avoid_catches_without_on_clauses
-    } catch (e) {
-      // Those are not actual release notes,
-      // but it's a better fallback than a non-existent wiki page.
-      return 'https://ubuntu.com/download/desktop';
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
+    final model = Provider.of<TryOrInstallModel>(context);
     return LocalizedView(
       builder: (context, lang) => WizardPage(
         title: Text(lang.tryOrInstallPageTitle),
@@ -84,37 +53,38 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
           children: [
             Expanded(
               child: OptionCard(
-                selected: _option == Option.repairUbuntu,
+                selected: model.option == Option.repairUbuntu,
                 imageAsset: 'assets/repair-wrench.png',
                 titleText: lang.repairInstallation,
                 bodyText: lang.repairInstallationDescription,
-                onSelected: () => selectOption(Option.repairUbuntu),
+                onSelected: () => model.selectOption(Option.repairUbuntu),
               ),
             ),
             const SizedBox(width: 20),
             Expanded(
               child: OptionCard(
-                selected: _option == Option.tryUbuntu,
+                selected: model.option == Option.tryUbuntu,
                 imageAsset: 'assets/steering-wheel.png',
                 titleText: lang.tryUbuntu,
                 bodyText: lang.tryUbuntuDescription,
-                onSelected: () => selectOption(Option.tryUbuntu),
+                onSelected: () => model.selectOption(Option.tryUbuntu),
               ),
             ),
             const SizedBox(width: 20),
             Expanded(
               child: OptionCard(
-                selected: _option == Option.installUbuntu,
+                selected: model.option == Option.installUbuntu,
                 imageAsset: 'assets/hard-drive.png',
                 titleText: lang.installUbuntu,
                 bodyText: lang.installUbuntuDescription,
-                onSelected: () => selectOption(Option.installUbuntu),
+                onSelected: () => model.selectOption(Option.installUbuntu),
               ),
             ),
           ],
         ),
         footer: Html(
-          data: lang.releaseNotesLabel(_releaseNotesURL),
+          data: lang.releaseNotesLabel(
+              model.releaseNotesURL(UbuntuDesktopInstallerApp.locale)),
           onLinkTap: (url, _, __, ___) => launch(url!),
         ),
         actions: <WizardAction>[
@@ -124,7 +94,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
           ),
           WizardAction(
             label: lang.continueButtonText,
-            enabled: _option != Option.none,
+            enabled: model.option != Option.none,
             onActivated: continueWithSelectedOption,
           ),
         ],

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../app.dart';
 import '../../routes.dart';

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
     path: ../subiquity_client
   crypt: ^4.0.0
   diacritic: ^0.1.3
+  file: ^6.1.2
   filesize: ^2.0.0
   flutter_html: ^2.0.0-nullsafety
   gsettings: ^0.1.2+1

--- a/packages/ubuntu_desktop_installer/test/try_or_install_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_model_test.dart
@@ -1,0 +1,61 @@
+import 'dart:ui';
+
+import 'package:file/memory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_desktop_installer/pages/try_or_install/try_or_install_model.dart';
+
+void main() {
+  test('selected option', () {
+    final model = TryOrInstallModel();
+
+    var wasNotified = false;
+    model.addListener(() => wasNotified = true);
+
+    expect(model.option, equals(Option.none));
+    model.selectOption(Option.none);
+    expect(model.option, equals(Option.none));
+    expect(wasNotified, isFalse);
+
+    model.selectOption(Option.installUbuntu);
+    expect(model.option, equals(Option.installUbuntu));
+    expect(wasNotified, isTrue);
+  });
+
+  test('release notes URL from cdrom', () {
+    final model = TryOrInstallModel();
+
+    final fs = MemoryFileSystem.test();
+    final file = fs.file('/cdrom/.disk/release_notes_url');
+    file.createSync(recursive: true);
+    file.writeAsStringSync('''
+https://wiki.ubuntu.com/WartyWarthog
+    ''');
+
+    final url = model.releaseNotesURL(Locale('en'), fs: fs);
+    expect(url, equals('https://wiki.ubuntu.com/WartyWarthog'));
+  });
+
+  test('release notes URL from distro-info', () {
+    final model = TryOrInstallModel();
+
+    final fs = MemoryFileSystem.test();
+    final file = fs.file('/usr/share/distro-info/ubuntu.csv');
+    file.createSync(recursive: true);
+    file.writeAsStringSync('''
+version,codename,series,created,release,eol,eol-server,eol-esm
+4.10,Warty Warthog,warty,2004-03-05,2004-10-20,2006-04-30
+5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31
+    ''');
+
+    final url = model.releaseNotesURL(Locale('en'), fs: fs);
+    expect(url, equals('https://wiki.ubuntu.com/HoaryHedgehog/ReleaseNotes'));
+  });
+
+  test('release notes URL fallback', () {
+    final model = TryOrInstallModel();
+
+    final fs = MemoryFileSystem.test();
+    final url = model.releaseNotesURL(Locale('en'), fs: fs);
+    expect(url, equals('https://ubuntu.com/download/desktop'));
+  });
+}

--- a/packages/ubuntu_desktop_installer/test/try_or_install_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_model_test.dart
@@ -28,11 +28,11 @@ void main() {
     final file = fs.file('/cdrom/.disk/release_notes_url');
     file.createSync(recursive: true);
     file.writeAsStringSync('''
-https://wiki.ubuntu.com/WartyWarthog
+https://wiki.ubuntu.com/IntrepidReleaseNotes/\${LANG}
     ''');
 
-    final url = model.releaseNotesURL(Locale('en'), fs: fs);
-    expect(url, equals('https://wiki.ubuntu.com/WartyWarthog'));
+    final url = model.releaseNotesURL(Locale('fr'), fs: fs);
+    expect(url, equals('https://wiki.ubuntu.com/IntrepidReleaseNotes/fr'));
   });
 
   test('release notes URL from distro-info', () {

--- a/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ubuntu_desktop_installer/pages/try_or_install_page.dart';
+import 'package:ubuntu_desktop_installer/pages/try_or_install/try_or_install_page.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 

--- a/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
@@ -20,9 +20,10 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       locale: Locale('en'),
-      home: TryOrInstallPage(),
+      initialRoute: Routes.tryOrInstall,
       navigatorObservers: [observer],
       routes: <String, WidgetBuilder>{
+        Routes.tryOrInstall: TryOrInstallPage.create,
         Routes.repairUbuntu: (context) => Container(),
         Routes.tryUbuntu: (context) => Container(),
         Routes.keyboardLayout: (context) => Container(),
@@ -30,7 +31,7 @@ void main() {
     );
     await tester.pumpWidget(app);
     expect(observer.pushed.length, 1);
-    expect(observer.pushed.first.settings.name, '/');
+    expect(observer.pushed.first.settings.name, Routes.tryOrInstall);
   }
 
   testWidgets('should open release notes', (tester) async {


### PR DESCRIPTION
This simplifies TryOrInstallPage, and makes the business logic testable.

Ref: #147