### PR TITLE
Tweak subiquity paths

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -11,6 +11,9 @@ PYTHONPATH=$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
 PYTHONPATH=$SNAP/lib/python3.8/site-packages:$PYTHONPATH
 export PYTHONPATH
 
+# set the PATH before changing $SNAP so subiquity finds curtin
+export PATH=$PATH:$SNAP/bin
+
 # subiquity is unhappy if $SNAP doesn't point to itself
 export SNAP=$SNAP/bin/subiquity
 


### PR DESCRIPTION
The subiquity util.py find_path logic fails to find curtin without the change