### PR TITLE
Fix multiple u-d-i/subiquity/curtin integration issues

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# store current script and snap directories
+# store current script directories
 SCRIPT_DIR=`dirname $0`
-SNAP_DIR=$SNAP
 
 # configure python environment
 export PYTHONIOENCODING=utf-8
@@ -10,13 +9,17 @@ PYTHONPATH=$SNAP/usr/lib/python3/site-packages:$PYTHONPATH
 PYTHONPATH=$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
 PYTHONPATH=$SNAP/lib/python3.8/site-packages:$PYTHONPATH
 export PYTHONPATH
+export PYTHON=$SNAP/usr/bin/python3.8
 
-# set the PATH before changing $SNAP so subiquity finds curtin
+# ensure curtin points at PYTHON
+export PY3OR2_PYTHON=$PYTHON
+
+# set the PATH so subiquity finds curtin
 export PATH=$PATH:$SNAP/bin
 
-# subiquity is unhappy if $SNAP doesn't point to itself
-export SNAP=$SNAP/bin/subiquity
+# base directory for subiquity to locate resources
+export SUBIQUITY_ROOT=$SNAP/bin/subiquity
 
 # run subiquity server
 cd $SCRIPT_DIR/subiquity
-$SNAP_DIR/usr/bin/python3.8 -m subiquity.cmd.server
+$PYTHON -m subiquity.cmd.server


### PR DESCRIPTION
* set PY3OR2_PYTHON so that curtin finds the python bin we want it to
* point to a newer subiquity which uses SUBIQUITY_ROOT to find resources, which means we don't have to do a dance with SNAP anymore
