### PR TITLE
Fix keyboard layout variant selection

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout_page.dart
@@ -47,8 +47,8 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
           return layout.code == info.layout;
         });
         if (_selectedLayoutIndex > -1) {
-          _selectedVariantIndex = _selectedLayout!.variants
-                  ?.indexWhere((variant) => variant.code == info.variant) ??
+          _selectedVariantIndex = _selectedLayout!.variants?.indexWhere(
+                  (variant) => variant.code == (info.variant ?? '')) ??
               -1;
           if (_selectedVariantIndex > -1) {
             SchedulerBinding.instance!.addPostFrameCallback((_) =>


### PR DESCRIPTION
Subiquity defines the default variant as an empty string: https://github.com/canonical/subiquity/blob/main/kbds/C.jsonl

vs.

The variant reported by keyboard_info is null when there's no variant defined in org.gnome.desktop.input-sources.sources:

> For “xkb” sources the second string is “xkb_layout+xkb_variant” or just “xkb_layout” if a XKB variant isn’t needed.