### PR TITLE
AppTheme: Add successColor as ThemeData extension

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/app_theme.dart
+++ b/packages/ubuntu_desktop_installer/lib/app_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
+import 'package:yaru/yaru.dart' as yaru;
 
 class AppTheme extends ValueNotifier<ThemeMode> {
   AppTheme(this._settings) : super(ThemeMode.system);
@@ -25,4 +26,15 @@ class AppTheme extends ValueNotifier<ThemeMode> {
     super.dispose();
     _settings.dispose();
   }
+}
+
+/// Application-specific theming extensions.
+extension AppThemeData on ThemeData {
+  /// The color to indicate success. For example used for
+  /// Widgets that are shown on successful validation.
+  /// It can be loaded via
+  /// ```dart
+  /// Theme.of(context).successColor
+  /// ```
+  Color get successColor => yaru.Colors.green;
 }


### PR DESCRIPTION
AppTheme: Add successColor as ThemeData extension

The color to indicate success. For example used for
It can be loaded via
```dart
Theme.of(context).successColor
```

Useful to get yaru dependencies out of pages (for example WhoAreYouPage in #144 )