### PR TITLE
Kill existing Subiquity test server on startup

### DIFF
--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -32,6 +32,13 @@ class SubiquityServer {
     var subiquityPath = p.join(Directory.current.path, 'subiquity');
     var socketPath = p.join(Directory.current.path, 'test/socket');
 
+    // kill the existing test server if it's already running, so they don't pile
+    // up on hot restarts
+    final pid = await _readPidFile();
+    if (pid != null) {
+      Process.killPid(pid);
+    }
+
     _serverProcess = await Process.start('/usr/bin/python3', subiquityCmd,
         workingDirectory: subiquityPath,
         // so subiquity doesn't think it's the installer or flutter snap...
@@ -46,12 +53,6 @@ class SubiquityServer {
       return process;
     });
 
-    // kill the existing test server if it's already running, so they don't pile
-    // up on hot restarts
-    final pid = await _readPidFile();
-    if (pid != null) {
-      Process.killPid(pid);
-    }
     await _writePidFile(_serverProcess.pid);
 
     final client = HttpUnixClient(socketPath);

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:http/http.dart';
 import 'package:path/path.dart' as p;
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import '../src/http_unix_client.dart';
 
 enum ServerMode { LIVE, DRY_RUN }
@@ -45,6 +46,14 @@ class SubiquityServer {
       return process;
     });
 
+    // kill the existing test server if it's already running, so they don't pile
+    // up on hot restarts
+    final pid = await _readPidFile();
+    if (pid != null) {
+      Process.killPid(pid);
+    }
+    await _writePidFile(_serverProcess.pid);
+
     final client = HttpUnixClient(socketPath);
     final request = Request('GET', Uri.http('localhost', 'meta/status'));
 
@@ -61,7 +70,34 @@ class SubiquityServer {
     return socketPath;
   }
 
+  static File _pidFile() {
+    return File('${xdg.runtimeDir?.path}/subiquity-test-server.pid');
+  }
+
+  static Future<int?> _readPidFile() async {
+    final file = _pidFile();
+    if (!await file.exists()) {
+      return null;
+    }
+    final content = await file.readAsString();
+    return int.tryParse(content.trim());
+  }
+
+  static Future<void> _writePidFile(int pid) async {
+    final file = _pidFile();
+    try {
+      await file.create(recursive: true);
+      await file.writeAsString(pid.toString());
+    } on FileSystemException catch (e) {
+      print('WARNING: Error writing ${file.path} (${e.message}). '
+          'Hot restarts may cause multiple Subiquity test servers to run.');
+    }
+  }
+
   Future<void> stop() async {
+    try {
+      await _pidFile().delete();
+    } on FileSystemException catch (_) {}
     _serverProcess.kill();
     await _serverProcess.exitCode;
   }

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   http: ^0.13.1
   json_annotation: ^4.0.1
   path: ^1.8.0
+  xdg_directories: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.0.1


### PR DESCRIPTION
Kill the existing test server if it's already running, so they don't pile up on hot restarts.

P.S. The path of the .pid file is `/var/run/user/1000/subiquity-test-server.pid` or similar depending on uid and XDG_RUNTIME_DIR.