### PR TITLE
HttpUnixClient: exit busy data processing loop

### DIFF
--- a/packages/subiquity_client/lib/src/http_unix_client.dart
+++ b/packages/subiquity_client/lib/src/http_unix_client.dart
@@ -196,7 +196,7 @@ class HttpUnixClient extends BaseClient {
       _parserState = _HttpParserState.status;
     }
 
-    return false;
+    return _chunkLength != null && _chunkRead < _chunkLength!;
   }
 
   bool _processChunkHeader(_HttpRequest request) {


### PR DESCRIPTION
...when there's not enough content to read in the buffer.