### PR TITLE
[tests] replace NavigatorObserver with UI verifications

### DIFF
--- a/packages/ubuntu_desktop_installer/test/simple_navigator_observer.dart
+++ b/packages/ubuntu_desktop_installer/test/simple_navigator_observer.dart
@@ -1,8 +1,0 @@
-import 'package:flutter/widgets.dart';
-
-class SimpleNavigatorObserver extends NavigatorObserver {
-  List<Route> pushed = [];
-
-  @override
-  void didPush(Route route, Route? previousRoute) => pushed.add(route);
-}

--- a/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
@@ -8,30 +8,24 @@ import 'package:ubuntu_desktop_installer/pages/try_or_install/try_or_install_pag
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 
-import 'simple_navigator_observer.dart';
-
 void main() {
-  late SimpleNavigatorObserver observer;
   late MaterialApp app;
 
   Future<void> setUpApp(WidgetTester tester) async {
-    observer = SimpleNavigatorObserver();
     app = MaterialApp(
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       locale: Locale('en'),
       initialRoute: Routes.tryOrInstall,
-      navigatorObservers: [observer],
       routes: <String, WidgetBuilder>{
         Routes.tryOrInstall: TryOrInstallPage.create,
-        Routes.repairUbuntu: (context) => Container(),
-        Routes.tryUbuntu: (context) => Container(),
-        Routes.keyboardLayout: (context) => Container(),
+        Routes.repairUbuntu: (context) => Text(Routes.repairUbuntu),
+        Routes.tryUbuntu: (context) => Text(Routes.tryUbuntu),
+        Routes.keyboardLayout: (context) => Text(Routes.keyboardLayout),
       },
     );
     await tester.pumpWidget(app);
-    expect(observer.pushed.length, 1);
-    expect(observer.pushed.first.settings.name, Routes.tryOrInstall);
+    expect(find.byType(TryOrInstallPage), findsOneWidget);
   }
 
   testWidgets('should open release notes', (tester) async {
@@ -111,9 +105,10 @@ void main() {
       await tester.pump();
 
       await tester.tap(continueButton);
+      await tester.pumpAndSettle();
 
-      expect(observer.pushed.length, 2);
-      expect(observer.pushed.last.settings.name, key);
+      expect(find.byType(TryOrInstallPage), findsNothing);
+      expect(find.text(key), findsOneWidget);
     });
   });
 }

--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -10,8 +10,6 @@ import 'package:ubuntu_desktop_installer/l10n/app_localizations.dart';
 import 'package:ubuntu_desktop_installer/pages/welcome/welcome_page.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 
-import 'simple_navigator_observer.dart';
-
 class SubiquityClientMock extends SubiquityClient {
   @override
   Future<String> setLocale(String code) async {
@@ -25,7 +23,6 @@ class SubiquityClientMock extends SubiquityClient {
 }
 
 void main() {
-  late SimpleNavigatorObserver observer;
   late MaterialApp app;
 
   setUpAll(() async {
@@ -33,16 +30,14 @@ void main() {
   });
 
   Future<void> setUpApp(WidgetTester tester) async {
-    observer = SimpleNavigatorObserver();
     app = MaterialApp(
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       locale: Locale('en'),
       initialRoute: Routes.welcome,
-      navigatorObservers: [observer],
       routes: <String, WidgetBuilder>{
         Routes.welcome: WelcomePage.create,
-        Routes.tryOrInstall: (context) => Container(),
+        Routes.tryOrInstall: (context) => Text(Routes.tryOrInstall),
       },
     );
     await tester.pumpWidget(
@@ -54,8 +49,7 @@ void main() {
         ChangeNotifierProvider(create: (context) => KeyboardModel()),
       ], child: app),
     );
-    expect(observer.pushed.length, 1);
-    expect(observer.pushed.first.settings.name, Routes.welcome);
+    expect(find.byType(WelcomePage), findsOneWidget);
   }
 
   testWidgets('should display a list of languages', (tester) async {
@@ -98,8 +92,9 @@ void main() {
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);
+    await tester.pumpAndSettle();
 
-    expect(observer.pushed.length, 2);
-    expect(observer.pushed.last.settings.name, Routes.tryOrInstall);
+    expect(find.byType(WelcomePage), findsNothing);
+    expect(find.text(Routes.tryOrInstall), findsOneWidget);
   });
 }


### PR DESCRIPTION
Observing explicit push calls is not compatible with the upcoming wizard routing, which is based on the declarative Navigator 2.0 pages API (#133).