### PR TITLE
[tests] speedup welcome page tests

### DIFF
--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -73,14 +73,12 @@ void main() {
           findsOneWidget);
     }
 
-    final itemEnglish = find.descendant(
-        of: languageList, matching: find.widgetWithText(ListTile, 'English'));
+    final itemEnglish = find.widgetWithText(ListTile, 'English');
     expect(itemEnglish, findsOneWidget);
     expect((itemEnglish.evaluate().single.widget as ListTile).selected, true);
     expect(UbuntuDesktopInstallerApp.locale.languageCode, 'en');
 
-    final itemFrench = find.descendant(
-        of: languageList, matching: find.widgetWithText(ListTile, 'Français'));
+    final itemFrench = find.widgetWithText(ListTile, 'Français');
     expect(itemFrench, findsOneWidget);
     expect((itemFrench.evaluate().single.widget as ListTile).selected, false);
 


### PR DESCRIPTION
I'd propose dropping `find.descendant` because for some reason it slows down the test a lot, to a degree that it gets inconvenient to run them as a whole. Plain `find.byType(ListTile)` seems to do the right thing because there's only one `ListTile` for each language. This small change makes a huge difference in the execution time of tests.

Before:
```
$ flutter test
[...]
00:39 +78: All tests passed!
```

After:
```
$ flutter test
[...]
00:05 +78: All tests passed!
```