### PR TITLE
Remove default identity in favor of the Who are you page

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -38,15 +38,6 @@ Future<void> main() async {
     'timezone',
   ]);
 
-  // Define a default identity until a UI page is implemented
-  // for it.
-  final identity = IdentityData(
-      realname: 'Ubuntu',
-      username: 'ubuntu',
-      cryptedPassword: Crypt.sha512('ubuntu').toString(),
-      hostname: 'ubuntu-desktop');
-  subiquityClient.setIdentity(identity);
-
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();
 


### PR DESCRIPTION
The comment suggests that this could be removed now that the _Who are you_ page exists:

> Define a default identity until a UI page is implemented for it.

The commit message of a8c5f66 makes me feel a bit unsure, though:

> Instruct subiquity to use default values for various endpoints earlier in the app's lifecycle.

Are these contradicting or did I misunderstand? Can the default identity be cleaned up?