### PR TITLE
Fix an exception and an assertion on the "Write changes to disk" page.

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
@@ -37,7 +37,7 @@ class _DiskObject {
         serial = json['serial'] ?? '',
         path = json['path'],
         name = json['name'],
-        wipe = json['wipe'],
+        wipe = json['wipe'] ?? '',
         preserve = json['preserve'],
         grubDevice = json['grub_device'];
 
@@ -149,7 +149,7 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
           _mounts.add(_MountObject.fromJson(entry));
           break;
         default:
-          assert(false, 'Unexpected storage config type');
+          print('Unexpected storage config type: ${entry['type']}');
       }
     }
     for (var partition in _partitions) {


### PR DESCRIPTION
Those happen when the storage config has unexpected values, and can be reproduced in dry run mode by using the examples/existing-partitions.json machine config for the subiquity server.
Unhandled storage config types include:
 - lvm_volgroup
 - lvm_partition
 - raid