### PR TITLE
Subiquity client: synchronize socket creation

### DIFF
--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   http: ^0.13.1
   json_annotation: ^4.0.1
   path: ^1.8.0
+  synchronized: ^3.0.0
   xdg_directories: ^0.2.0
 
 dev_dependencies:


### PR DESCRIPTION
This change fixes the issue that multiple sockets were created on startup. Concurrent requests (mark configured, keyboard, locale...) ended up awaiting a new socket connection because the `_socket` member variable is set after the socket has connected.