### PR TITLE
Update Yaru & adapt to changes

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -118,7 +118,6 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
             const SizedBox(height: 20),
             TextField(
               decoration: InputDecoration(
-                border: const OutlineInputBorder(),
                 hintText: lang.typeToTest,
               ),
             ),

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   tuple: ^2.0.0
   url_launcher: ^6.0.3
   wizard_router: ^0.1.0+1
-  yaru: ^0.1.0
+  yaru: ^0.1.2
   yaru_icons: ^0.0.3
 
 dev_dependencies:


### PR DESCRIPTION
Explicit input decoration borders are no longer required, because Yaru
provides them via input decoration according to the design.