### PR TITLE
Use translated window title and make it configurable for WSL

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/app.dart
+++ b/packages/ubuntu_desktop_installer/lib/app.dart
@@ -1,7 +1,6 @@
 import 'dart:io' as io;
 
 import 'package:args/args.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:path/path.dart' as p;
@@ -13,6 +12,7 @@ import 'keyboard_service.dart';
 
 import 'l10n/app_localizations.dart';
 import 'settings.dart';
+import 'utils.dart';
 
 /// Initializes and runs the given [app].
 ///
@@ -48,16 +48,9 @@ Future<void> runWizardApp(
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();
 
-  final eventChannel = EventChannel('ubuntu-desktop-installer');
-  eventChannel.receiveBroadcastStream().listen((event) async {
-    switch (event) {
-      case 'deleteEvent':
-        await subiquityClient!.close();
-        await subiquityServer!.stop();
-        break;
-      default:
-        print('Warning: event $event ignored');
-    }
+  onWindowClosed().then((_) async {
+    await subiquityClient!.close();
+    await subiquityServer!.stop();
   });
 
   runApp(MultiProvider(

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en_US.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en_US.arb
@@ -6,7 +6,7 @@
     "description": "The display name for the language. Leave empty to exclude the language from the list of languages on the welcome screen."
   },
 
-  "appTitle": "Ubuntu Desktop Installer",
+  "appTitle": "Install Ubuntu",
 
   "backButtonText": "Go Back",
   "continueButtonText": "Continue",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en_US.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en_US.arb
@@ -6,7 +6,8 @@
     "description": "The display name for the language. Leave empty to exclude the language from the list of languages on the welcome screen."
   },
 
-  "appTitle": "Install Ubuntu",
+  "appTitle": "Ubuntu Desktop Installer",
+  "windowTitle": "Install Ubuntu",
 
   "backButtonText": "Go Back",
   "continueButtonText": "Continue",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_es_ES.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_es_ES.arb
@@ -4,6 +4,7 @@
   "languageName": "Español",
 
   "appTitle": "Instalador de Ubuntu para escritorio",
+  "windowTitle": "Instalar Ubuntu",
 
   "backButtonText": "Volver",
   "continueButtonText": "Continuar",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_fr_FR.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_fr_FR.arb
@@ -4,6 +4,7 @@
   "languageName": "Français",
 
   "appTitle": "Programme d’installation du bureau Ubuntu",
+  "windowTitle": "Installer Ubuntu",
 
   "backButtonText": "Retour",
   "continueButtonText": "Continuer",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_it_IT.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_it_IT.arb
@@ -4,6 +4,7 @@
   "languageName": "Italiano",
 
   "appTitle": "Installer di Ubuntu Desktop",
+  "windowTitle": "Installa Ubuntu",
 
   "backButtonText": "Torna indietro",
   "continueButtonText": "Continua",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_nl_NL.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_nl_NL.arb
@@ -4,6 +4,7 @@
   "languageName": "Nederlands",
 
   "appTitle": "Ubuntu Desktop instalatie programma",
+  "windowTitle": "Ubuntu installeren",
 
   "backButtonText": "Terug",
   "continueButtonText": "Volgende",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_oc_FR.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_oc_FR.arb
@@ -4,6 +4,7 @@
   "languageName": "Occitan",
 
   "appTitle": "Programa d'installacion del burèu Ubuntu",
+  "windowTitle": "Installar Ubuntu",
 
   "backButtonText": "Tornar",
   "continueButtonText": "Contunhar",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
@@ -4,6 +4,7 @@
   "languageName": "Português do Brasil",
 
   "appTitle": "Instalador do Ubuntu Desktop",
+  "windowTitle": "Instalar o Ubuntu",
 
   "backButtonText": "Voltar",
   "continueButtonText": "Continuar",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_ru_RU.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_ru_RU.arb
@@ -4,6 +4,7 @@
   "languageName": "Русский",
 
   "appTitle": "Установка Ubuntu",
+  "windowTitle": "Установить Ubuntu",
 
   "backButtonText": "Назад",
   "continueButtonText": "Продолжить",

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -36,9 +36,9 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
     return MaterialApp(
       locale: Settings.of(context).locale,
       onGenerateTitle: (context) {
-        final appTitle = AppLocalizations.of(context)!.appTitle;
-        setWindowTitle(appTitle);
-        return appTitle;
+        final lang = AppLocalizations.of(context)!;
+        setWindowTitle(lang.windowTitle);
+        return lang.appTitle;
       },
       theme: yaru.lightTheme,
       darkTheme: yaru.darkTheme,

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -9,6 +9,7 @@ import 'l10n/app_localizations.dart';
 import 'pages.dart';
 import 'routes.dart';
 import 'settings.dart';
+import 'utils.dart';
 
 void main(List<String> args) {
   final options = parseCommandLine(args, showMachineConfig: true)!;
@@ -34,7 +35,11 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       locale: Settings.of(context).locale,
-      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+      onGenerateTitle: (context) {
+        final appTitle = AppLocalizations.of(context)!.appTitle;
+        setWindowTitle(appTitle);
+        return appTitle;
+      },
       theme: yaru.lightTheme,
       darkTheme: yaru.darkTheme,
       themeMode: Settings.of(context).theme,

--- a/packages/ubuntu_desktop_installer/lib/utils.dart
+++ b/packages/ubuntu_desktop_installer/lib/utils.dart
@@ -1,2 +1,3 @@
 export 'utils/equal_validator.dart';
 export 'utils/password.dart';
+export 'utils/window.dart';

--- a/packages/ubuntu_desktop_installer/lib/utils/window.dart
+++ b/packages/ubuntu_desktop_installer/lib/utils/window.dart
@@ -3,7 +3,8 @@ import 'dart:ui';
 
 import 'package:flutter/services.dart';
 
-final _eventChannel = EventChannel('ubuntu-desktop-installer');
+final _methodChannel = MethodChannel('ubuntu-desktop-installer');
+final _eventChannel = EventChannel('ubuntu-desktop-installer/events');
 
 void _listenEvent(String event, VoidCallback callback) {
   _eventChannel.receiveBroadcastStream().listen((ev) {
@@ -16,4 +17,9 @@ Future<void> onWindowClosed() {
   final completer = Completer();
   _listenEvent('deleteEvent', completer.complete);
   return completer.future;
+}
+
+/// Sets the window title.
+Future<void> setWindowTitle(String title) {
+  return _methodChannel.invokeMethod('setWindowTitle', [title]);
 }

--- a/packages/ubuntu_desktop_installer/lib/utils/window.dart
+++ b/packages/ubuntu_desktop_installer/lib/utils/window.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+
+final _eventChannel = EventChannel('ubuntu-desktop-installer');
+
+void _listenEvent(String event, VoidCallback callback) {
+  _eventChannel.receiveBroadcastStream().listen((ev) {
+    if (event == ev) callback();
+  });
+}
+
+/// Completes when the window is closed.
+Future<void> onWindowClosed() {
+  final completer = Completer();
+  _listenEvent('deleteEvent', completer.complete);
+  return completer.future;
+}


### PR DESCRIPTION
Note: Setting the window title from Dart when the Dart entry-point is called introduces a small delay for when the window title appears.