### PR TITLE
Subiquity client: don't await response for /reboot

### DIFF
--- a/packages/subiquity_client/lib/src/http_unix_client.dart
+++ b/packages/subiquity_client/lib/src/http_unix_client.dart
@@ -57,8 +57,8 @@ class HttpUnixClient extends BaseClient {
   /// Creates a new HTTP client that communicates on a Unix domain socket on [path].
   HttpUnixClient(this.path);
 
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
+  //// Writes a request to the socket without awaiting response.
+  Future<void> write(BaseRequest request) async {
     // synchronize to prevent concurrent requests creating multiple sockets
     await _lock.synchronized(() async {
       if (_socket == null) {
@@ -81,7 +81,13 @@ class HttpUnixClient extends BaseClient {
     });
     message += '\r\n';
     _socket?.write(message);
+  }
 
+  /// Sends a request to the server and returns a future that completes when the
+  /// response is received.
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    await write(request);
     if (request is Request) {
       _socket?.write(request.body);
     } else if (request is MultipartRequest) {

--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -233,7 +233,6 @@ class SubiquityClient {
 
   Future<void> reboot() async {
     final request = Request('POST', Uri.http('localhost', 'reboot'));
-    final response = await _client.send(request);
-    await checkStatus("reboot()", response);
+    await _client.write(request);
   }
 }


### PR DESCRIPTION
Split `write()` and `send()` to be able to await `write()` but ignore any response. For `/reboot`, there's no response at all.

Ref: #224