### PR TITLE
Non-nullable l18n getter

### DIFF
--- a/packages/ubuntu_desktop_installer/l10n.yaml
+++ b/packages/ubuntu_desktop_installer/l10n.yaml
@@ -1,2 +1,3 @@
 arb-dir: lib/l10n
 template-arb-file: app_en_US.arb
+nullable-getter: false

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -20,7 +20,7 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
     return MaterialApp(
       locale: Settings.of(context).locale,
       onGenerateTitle: (context) {
-        final lang = AppLocalizations.of(context)!;
+        final lang = AppLocalizations.of(context);
         setWindowTitle(lang.windowTitle);
         return lang.appTitle;
       },

--- a/packages/ubuntu_desktop_installer/lib/widgets/localized_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/localized_view.dart
@@ -23,5 +23,5 @@ class LocalizedView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) =>
-      builder(context, AppLocalizations.of(context)!);
+      builder(context, AppLocalizations.of(context));
 }

--- a/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
@@ -14,7 +14,7 @@ import 'choose_your_look_page_test.mocks.dart';
 void main() {
   AppLocalizations lang(WidgetTester tester) {
     final page = tester.element(find.byType(ChooseYourLookPage));
-    return AppLocalizations.of(page)!;
+    return AppLocalizations.of(page);
   }
 
   testWidgets('ChooseYourLookPage applies theme', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
@@ -25,7 +25,7 @@ import 'package:ubuntu_desktop_installer/widgets.dart';
 extension LangTester on WidgetTester {
   AppLocalizations get lang {
     final view = element(find.byType(LocalizedView).first);
-    return AppLocalizations.of(view)!;
+    return AppLocalizations.of(view);
   }
 }
 


### PR DESCRIPTION
By default, `Localizations.of(context)` returns a nullable value for backwards compatibility reasons. Let the generator make it non-nullable to remove the need for null checking in user code.