### PR TITLE
Unify system shutdown, reboot and app cleanup routines

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_model.dart
@@ -3,14 +3,10 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 /// View model for [InstallationCompletePage].
-class InstallationCompleteModel {
+class InstallationCompleteModel with SystemShutdown {
   /// Creates an instance with the given client.
-  InstallationCompleteModel(this._client);
+  InstallationCompleteModel(this.client);
 
-  final SubiquityClient _client;
-
-  /// Requests system reboot.
-  Future<void> reboot() {
-    return _client.reboot().then((_) => closeWindow());
-  }
+  @override
+  final SubiquityClient client;
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -71,8 +71,9 @@ class InstallationCompletePage extends StatelessWidget {
                   ),
                   OutlinedButton(
                     onPressed: () {
-                      // TODO: request shutdown
-                      io.exit(0);
+                      Provider.of<InstallationCompleteModel>(context,
+                              listen: false)
+                          .shutdown();
                     },
                     child: Text(lang.shutdown),
                   ),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -61,7 +61,7 @@ class InstallationCompletePage extends StatelessWidget {
                       onPressed: () {
                         Provider.of<InstallationCompleteModel>(context,
                                 listen: false)
-                            .reboot();
+                            .reboot(immediate: false);
                       },
                       child: Text(
                         lang.restartInto(
@@ -73,7 +73,7 @@ class InstallationCompletePage extends StatelessWidget {
                     onPressed: () {
                       Provider.of<InstallationCompleteModel>(context,
                               listen: false)
-                          .shutdown();
+                          .shutdown(immediate: false);
                     },
                     child: Text(lang.shutdown),
                   ),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -5,11 +5,13 @@ import 'package:ubuntu_wizard/utils.dart';
 export 'package:subiquity_client/subiquity_client.dart' show ApplicationState;
 
 /// View model for [InstallationSlidesPage].
-class InstallationSlidesModel extends ChangeNotifier {
+class InstallationSlidesModel extends ChangeNotifier with SystemShutdown {
   /// Creates an instance with the given client.
-  InstallationSlidesModel(this._client);
+  InstallationSlidesModel(this.client);
 
-  final SubiquityClient _client;
+  @override
+  final SubiquityClient client;
+
   ApplicationStatus? _status;
 
   /// The current installation state.
@@ -53,7 +55,7 @@ class InstallationSlidesModel extends ChangeNotifier {
 
   /// Initializes and starts monitoring the status of the installation.
   Future<void> init() {
-    return _client.status().then((status) {
+    return client.status().then((status) {
       _updateStatus(status);
       _monitorStatus();
     });
@@ -61,12 +63,12 @@ class InstallationSlidesModel extends ChangeNotifier {
 
   Future<void> _monitorStatus() async {
     while (!isDone && !hasError) {
-      await _client.status(current: state).then(_updateStatus);
+      await client.status(current: state).then(_updateStatus);
     }
   }
 
-  /// Requests system reboot.
-  Future<void> reboot() {
-    return _client.reboot(immediate: true).then((_) => closeWindow());
+  /// Requests an immediate system reboot.
+  Future<void> reboot({bool immediate = true}) {
+    return super.reboot(immediate: immediate);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart
@@ -8,9 +8,4 @@ class TurnOffBitLockerModel with SystemShutdown {
 
   @override
   final SubiquityClient client;
-
-  /// Requests an immediate system reboot.
-  Future<void> reboot({bool immediate = true}) {
-    return super.reboot(immediate: immediate);
-  }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart
@@ -2,14 +2,15 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 /// View model for [TurnOffBitLockerPage].
-class TurnOffBitLockerModel {
+class TurnOffBitLockerModel with SystemShutdown {
   /// Creates an instance with the given client.
-  TurnOffBitLockerModel(this._client);
+  TurnOffBitLockerModel(this.client);
 
-  final SubiquityClient _client;
+  @override
+  final SubiquityClient client;
 
-  /// Requests system reboot.
-  Future<void> reboot() {
-    return _client.reboot(immediate: true).then((_) => closeWindow());
+  /// Requests an immediate system reboot.
+  Future<void> reboot({bool immediate = true}) {
+    return super.reboot(immediate: immediate);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -49,7 +49,7 @@ class TurnOffBitLockerPage extends StatelessWidget {
           WizardAction(
             label: lang.restartIntoWindows,
             highlighted: true,
-            onActivated: model.reboot,
+            onActivated: () => model.reboot(immediate: true),
           ),
         ],
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_model.dart
@@ -8,9 +8,4 @@ class TurnOffRSTModel with SystemShutdown {
 
   @override
   final SubiquityClient client;
-
-  /// Requests an immediate system reboot.
-  Future<void> reboot({bool immediate = true}) {
-    return super.reboot(immediate: immediate);
-  }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_model.dart
@@ -2,14 +2,15 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 /// View model for [TurnOffRSTPage].
-class TurnOffRSTModel {
+class TurnOffRSTModel with SystemShutdown {
   /// Creates an instance with the given client.
-  TurnOffRSTModel(this._client);
+  TurnOffRSTModel(this.client);
 
-  final SubiquityClient _client;
+  @override
+  final SubiquityClient client;
 
-  /// Requests system reboot.
-  Future<void> reboot() {
-    return _client.reboot(immediate: true).then((_) => closeWindow());
+  /// Requests an immediate system reboot.
+  Future<void> reboot({bool immediate = true}) {
+    return super.reboot(immediate: immediate);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -58,7 +58,7 @@ class TurnOffRSTPage extends StatelessWidget {
             WizardAction(
               label: lang.restartButtonText,
               highlighted: true,
-              onActivated: model.reboot,
+              onActivated: () => model.reboot(immediate: true),
             ),
           ],
         ),

--- a/packages/ubuntu_desktop_installer/test/installation_complete_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete_model_test.dart
@@ -18,7 +18,7 @@ void main() async {
     final client = MockSubiquityClient();
     final model = InstallationCompleteModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: false);
     verify(client.reboot(immediate: false)).called(1);
     expect(windowClosed, isTrue);
   });
@@ -36,7 +36,7 @@ void main() async {
     final client = MockSubiquityClient();
     final model = InstallationCompleteModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: false);
     verify(client.reboot(immediate: false)).called(1);
     expect(windowClosed, isTrue);
   });

--- a/packages/ubuntu_desktop_installer/test/installation_complete_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete_model_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_model.dart';
+import 'package:ubuntu_test/mocks.dart';
+
+void main() async {
+  test('reboot', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    var windowClosed = false;
+    final methodChannel = MethodChannel('ubuntu_wizard');
+    methodChannel.setMockMethodCallHandler((call) {
+      expect(call.method, equals('closeWindow'));
+      windowClosed = true;
+    });
+
+    final client = MockSubiquityClient();
+    final model = InstallationCompleteModel(client);
+
+    await model.reboot();
+    verify(client.reboot(immediate: false)).called(1);
+    expect(windowClosed, isTrue);
+  });
+
+  test('shutdown', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    var windowClosed = false;
+    final methodChannel = MethodChannel('ubuntu_wizard');
+    methodChannel.setMockMethodCallHandler((call) {
+      expect(call.method, equals('closeWindow'));
+      windowClosed = true;
+    });
+
+    final client = MockSubiquityClient();
+    final model = InstallationCompleteModel(client);
+
+    await model.reboot();
+    verify(client.reboot(immediate: false)).called(1);
+    expect(windowClosed, isTrue);
+  });
+}

--- a/packages/ubuntu_desktop_installer/test/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides_model_test.dart
@@ -111,7 +111,7 @@ void main() async {
     final client = MockSubiquityClient();
     final model = InstallationSlidesModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: true);
     verify(client.reboot(immediate: true)).called(1);
     expect(windowClosed, isTrue);
   });

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_model_test.dart
@@ -18,7 +18,7 @@ void main() async {
     final client = MockSubiquityClient();
     final model = TurnOffBitLockerModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: true);
     verify(client.reboot(immediate: true)).called(1);
     expect(windowClosed, isTrue);
   });

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
@@ -40,6 +40,6 @@ void main() {
     expect(restartButton, findsOneWidget);
 
     await tester.tap(restartButton);
-    verify(model.reboot()).called(1);
+    verify(model.reboot(immediate: true)).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.mocks.dart
@@ -33,14 +33,14 @@ class MockTurnOffBitLockerModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#client),
           returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
   @override
-  _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
+  String toString() => super.toString();
+  @override
+  _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  String toString() => super.toString();
-  @override
-  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+  _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#shutdown, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.mocks.dart
@@ -2,11 +2,12 @@
 // in ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_desktop_installer/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart'
-    as _i2;
+    as _i3;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -16,20 +17,31 @@ import 'package:ubuntu_desktop_installer/pages/turn_off_bitlocker/turn_off_bitlo
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeSubiquityClient_0 extends _i1.Fake implements _i2.SubiquityClient {}
+
 /// A class which mocks [TurnOffBitLockerModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTurnOffBitLockerModel extends _i1.Mock
-    implements _i2.TurnOffBitLockerModel {
+    implements _i3.TurnOffBitLockerModel {
   MockTurnOffBitLockerModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> reboot() =>
-      (super.noSuchMethod(Invocation.method(#reboot, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
+  _i2.SubiquityClient get client =>
+      (super.noSuchMethod(Invocation.getter(#client),
+          returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
+  @override
+  _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
+      Invocation.method(#reboot, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
   String toString() => super.toString();
+  @override
+  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+      Invocation.method(#shutdown, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_model_test.dart
@@ -19,7 +19,7 @@ void main() async {
     final client = MockSubiquityClient();
     final model = TurnOffRSTModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: true);
     verify(client.reboot(immediate: true)).called(1);
     expect(windowClosed, isTrue);
   });

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
@@ -40,6 +40,6 @@ void main() {
     expect(restartButton, findsOneWidget);
 
     await tester.tap(restartButton);
-    verify(model.reboot()).called(1);
+    verify(model.reboot(immediate: true)).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.mocks.dart
@@ -2,11 +2,12 @@
 // in ubuntu_desktop_installer/test/turn_off_rst_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_desktop_installer/pages/turn_off_rst/turn_off_rst_model.dart'
-    as _i2;
+    as _i3;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -16,19 +17,30 @@ import 'package:ubuntu_desktop_installer/pages/turn_off_rst/turn_off_rst_model.d
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeSubiquityClient_0 extends _i1.Fake implements _i2.SubiquityClient {}
+
 /// A class which mocks [TurnOffRSTModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTurnOffRSTModel extends _i1.Mock implements _i2.TurnOffRSTModel {
+class MockTurnOffRSTModel extends _i1.Mock implements _i3.TurnOffRSTModel {
   MockTurnOffRSTModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> reboot() =>
-      (super.noSuchMethod(Invocation.method(#reboot, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
+  _i2.SubiquityClient get client =>
+      (super.noSuchMethod(Invocation.getter(#client),
+          returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
+  @override
+  _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
+      Invocation.method(#reboot, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
   String toString() => super.toString();
+  @override
+  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+      Invocation.method(#shutdown, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.mocks.dart
@@ -32,14 +32,14 @@ class MockTurnOffRSTModel extends _i1.Mock implements _i3.TurnOffRSTModel {
       (super.noSuchMethod(Invocation.getter(#client),
           returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
   @override
-  _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
+  String toString() => super.toString();
+  @override
+  _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  String toString() => super.toString();
-  @override
-  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+  _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#shutdown, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);

--- a/packages/ubuntu_wizard/lib/src/utils/system_shutdown.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/system_shutdown.dart
@@ -13,7 +13,7 @@ mixin SystemShutdown {
   ///
   /// The [immediate] argument should be `true` if the system should be rebooted
   /// immediately before the installation has finished.
-  Future<void> reboot({bool immediate = false}) {
+  Future<void> reboot({required bool immediate}) {
     return client.reboot(immediate: immediate).then((_) => closeWindow());
   }
 
@@ -21,7 +21,7 @@ mixin SystemShutdown {
   ///
   /// The [immediate] argument should be `true` if the system should be shut
   /// down immediately before the installation has finished.
-  Future<void> shutdown({bool immediate = false}) {
+  Future<void> shutdown({required bool immediate}) {
     return client.shutdown(immediate: immediate).then((_) => closeWindow());
   }
 }

--- a/packages/ubuntu_wizard/lib/src/utils/system_shutdown.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/system_shutdown.dart
@@ -1,0 +1,27 @@
+import 'package:subiquity_client/subiquity_client.dart';
+
+import 'window.dart';
+
+/// Provides system shutdown and reboot functionality, and performs the
+/// appropriate application cleanup routines to close the window, subiquity
+/// socket, and the server if was started by this UI instance.
+mixin SystemShutdown {
+  /// The client to send shutdown and reboot requests to.
+  SubiquityClient get client;
+
+  /// Request system reboot and close the window.
+  ///
+  /// The [immediate] argument should be `true` if the system should be rebooted
+  /// immediately before the installation has finished.
+  Future<void> reboot({bool immediate = false}) {
+    return client.reboot(immediate: immediate).then((_) => closeWindow());
+  }
+
+  /// Request system shutdown and close the window.
+  ///
+  /// The [immediate] argument should be `true` if the system should be shut
+  /// down immediately before the installation has finished.
+  Future<void> shutdown({bool immediate = false}) {
+    return client.shutdown(immediate: immediate).then((_) => closeWindow());
+  }
+}

--- a/packages/ubuntu_wizard/lib/utils.dart
+++ b/packages/ubuntu_wizard/lib/utils.dart
@@ -2,4 +2,5 @@ export 'src/utils/equal_validator.dart';
 export 'src/utils/list_extensions.dart';
 export 'src/utils/password.dart';
 export 'src/utils/product_info_extractor.dart';
+export 'src/utils/system_shutdown.dart';
 export 'src/utils/window.dart';

--- a/packages/ubuntu_wizard/test/system_shutdown_test.dart
+++ b/packages/ubuntu_wizard/test/system_shutdown_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/src/utils/system_shutdown.dart';
+import 'package:ubuntu_test/mocks.dart';
+
+typedef SystemShutdownTester = Future<void> Function(SystemShutdown system);
+
+class TestSystemShutdown with SystemShutdown {
+  TestSystemShutdown(this.client);
+
+  final SubiquityClient client;
+}
+
+void main() async {
+  setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+  Future<void> testSystemShutdown(SystemShutdownTester tester) async {
+    var windowClosed = false;
+    final methodChannel = MethodChannel('ubuntu_wizard');
+    methodChannel.setMockMethodCallHandler((call) {
+      expect(call.method, equals('closeWindow'));
+      windowClosed = true;
+    });
+    await tester(TestSystemShutdown(MockSubiquityClient()));
+    expect(windowClosed, isTrue);
+  }
+
+  test('reboot', () async {
+    // immediate (before installation)
+    await testSystemShutdown((system) async {
+      await system.reboot(immediate: true);
+      verify(system.client.reboot(immediate: true)).called(1);
+    });
+
+    // non-immediate (after installation)
+    await testSystemShutdown((system) async {
+      await system.reboot(immediate: false);
+      verify(system.client.reboot(immediate: false)).called(1);
+    });
+  });
+
+  test('shutdown', () async {
+    // immediate (before installation)
+    await testSystemShutdown((system) async {
+      await system.shutdown(immediate: true);
+      verify(system.client.shutdown(immediate: true)).called(1);
+    });
+
+    // non-immediate (after installation)
+    await testSystemShutdown((system) async {
+      await system.shutdown(immediate: false);
+      verify(system.client.shutdown(immediate: false)).called(1);
+    });
+  });
+}

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
@@ -1,16 +1,17 @@
-import 'dart:io' as io;
-
 import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
 /// Implements the business logic of the WSL Setup complete page.
-class SetupCompleteModel extends ChangeNotifier {
+class SetupCompleteModel extends ChangeNotifier with SystemShutdown {
   /// Creates a setup complete model.
-  SetupCompleteModel(this._client) {
+  SetupCompleteModel(this.client) {
     _identity.addListener(notifyListeners);
   }
 
-  final SubiquityClient _client;
+  @override
+  final SubiquityClient client;
+
   final _identity = ValueNotifier(IdentityData());
 
   /// The username for the profile.
@@ -18,15 +19,6 @@ class SetupCompleteModel extends ChangeNotifier {
 
   /// Initializes the model.
   Future<void> init() {
-    return _client.identity().then((identity) => _identity.value = identity);
-  }
-
-  /// Requests system reboot.
-  Future<void> reboot({
-    @visibleForTesting void Function(int exitCode) exit = io.exit,
-  }) async {
-    // TODO: use SystemShutdown from ubuntu_wizard/utils when available
-    _client.reboot();
-    exit(0);
+    return client.identity().then((identity) => _identity.value = identity);
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -67,7 +67,7 @@ class _SetupCompletePageState extends State<SetupCompletePage> {
       actions: <WizardAction>[
         WizardAction(
           label: lang.finishButton,
-          onActivated: model.reboot,
+          onActivated: () => model.reboot(immediate: false),
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -19,13 +20,21 @@ void main() {
   });
 
   test('reboot', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    var windowClosed = false;
+    final methodChannel = MethodChannel('ubuntu_wizard');
+    methodChannel.setMockMethodCallHandler((call) {
+      expect(call.method, equals('closeWindow'));
+      windowClosed = true;
+    });
+
     final client = MockSubiquityClient();
     final model = SetupCompleteModel(client);
 
-    var exited = false;
-    await model.reboot(exit: (_) => exited = true);
-    verify(client.reboot()).called(1);
-    expect(exited, isTrue);
+    await model.reboot();
+    verify(client.reboot(immediate: false)).called(1);
+    expect(windowClosed, isTrue);
   });
 
   test('notify changes', () async {

--- a/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
@@ -32,7 +32,7 @@ void main() {
     final client = MockSubiquityClient();
     final model = SetupCompleteModel(client);
 
-    await model.reboot();
+    await model.reboot(immediate: false);
     verify(client.reboot(immediate: false)).called(1);
     expect(windowClosed, isTrue);
   });

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
@@ -65,7 +65,7 @@ void main() {
     expect(finishButton, findsOneWidget);
 
     await tester.tap(finishButton);
-    verify(model.reboot()).called(1);
+    verify(model.reboot(immediate: false)).called(1);
   });
 
   testWidgets('creates a model', (tester) async {

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
@@ -2,13 +2,13 @@
 // in ubuntu_wsl_setup/test/setup_complete_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
-import 'dart:io' as _i4;
+import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_wsl_setup/pages/setup_complete/setup_complete_model.dart'
-    as _i2;
+    as _i3;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -18,15 +18,21 @@ import 'package:ubuntu_wsl_setup/pages/setup_complete/setup_complete_model.dart'
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeSubiquityClient_0 extends _i1.Fake implements _i2.SubiquityClient {}
+
 /// A class which mocks [SetupCompleteModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSetupCompleteModel extends _i1.Mock
-    implements _i2.SetupCompleteModel {
+    implements _i3.SetupCompleteModel {
   MockSetupCompleteModel() {
     _i1.throwOnMissingStub(this);
   }
 
+  @override
+  _i2.SubiquityClient get client =>
+      (super.noSuchMethod(Invocation.getter(#client),
+          returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
   @override
   String get username =>
       (super.noSuchMethod(Invocation.getter(#username), returnValue: '')
@@ -36,14 +42,9 @@ class MockSetupCompleteModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
-  @override
-  _i3.Future<void> reboot({void Function(int)? exit = _i4.exit}) =>
-      (super.noSuchMethod(Invocation.method(#reboot, [], {#exit: exit}),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
@@ -61,4 +62,14 @@ class MockSetupCompleteModel extends _i1.Mock
           returnValueForMissingStub: null);
   @override
   String toString() => super.toString();
+  @override
+  _i4.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
+      Invocation.method(#reboot, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+  @override
+  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+      Invocation.method(#shutdown, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
@@ -63,12 +63,12 @@ class MockSetupCompleteModel extends _i1.Mock
   @override
   String toString() => super.toString();
   @override
-  _i4.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
+  _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+  _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#shutdown, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);


### PR DESCRIPTION
Share the common functionality, needed for several pages, with a `SystemShutdown` mixin available in `ubuntu_wizard` utils.

Close: #224