### PR TITLE
Share and unify constants

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -11,14 +11,8 @@ import 'who_are_you_model.dart';
 
 part 'who_are_you_widgets.dart';
 
-// The spacing between text form fields and checkmark icons.
-const _kIconSpacing = 10.0;
-
 // The horizontal indentation of the radio button.
 const _kRadioButtonIndentation = 36.0;
-
-// The fraction of the content width in relation to the page.
-const _kContentWidthFraction = 0.7;
 
 /// The installer page for setting up the user data.
 ///
@@ -61,7 +55,7 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
           final fieldPadding = EdgeInsets.symmetric(
               horizontal: kContentPadding.left, vertical: 10);
           final fieldWidth = (constraints.maxWidth - fieldPadding.horizontal) *
-              _kContentWidthFraction;
+              kContentWidthFraction;
 
           return Form(
             key: _whoAreYouFormKey,

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
@@ -16,7 +16,6 @@ class _RealNameFormField extends StatelessWidget {
 
       return ValidatedFormField(
         fieldWidth: fieldWidth,
-        spacing: _kIconSpacing,
         labelText: lang.whoAreYouPageRealNameLabel,
         successWidget: const SuccessIcon(),
         initialValue: realName,
@@ -48,7 +47,6 @@ class _HostNameFormField extends StatelessWidget {
 
       return ValidatedFormField(
         fieldWidth: fieldWidth,
-        spacing: _kIconSpacing,
         labelText: lang.whoAreYouPageComputerNameLabel,
         helperText: lang.whoAreYouPageComputerNameInfo,
         successWidget: const SuccessIcon(),
@@ -87,7 +85,6 @@ class _UsernameFormField extends StatelessWidget {
 
       return ValidatedFormField(
         fieldWidth: fieldWidth,
-        spacing: _kIconSpacing,
         labelText: lang.whoAreYouPageUsernameLabel,
         successWidget: const SuccessIcon(),
         initialValue: username,
@@ -127,7 +124,6 @@ class _PasswordFormField extends StatelessWidget {
 
       return ValidatedFormField(
         fieldWidth: fieldWidth,
-        spacing: _kIconSpacing,
         labelText: lang.whoAreYouPagePasswordLabel,
         obscureText: true,
         successWidget: PasswordStrengthLabel(strength: passwordStrength),
@@ -163,7 +159,6 @@ class _ConfirmPasswordFormField extends StatelessWidget {
       return ValidatedFormField(
         obscureText: true,
         fieldWidth: fieldWidth,
-        spacing: _kIconSpacing,
         labelText: lang.whoAreYouPageConfirmPasswordLabel,
         successWidget: SuccessIcon(),
         initialValue: confirmedPassword,

--- a/packages/ubuntu_wizard/lib/constants.dart
+++ b/packages/ubuntu_wizard/lib/constants.dart
@@ -14,3 +14,6 @@ const kHeaderPadding = EdgeInsets.fromLTRB(24, 24, 24, 0);
 
 /// The padding around the footer.
 const kFooterPadding = EdgeInsets.fromLTRB(24, 0, 24, 24);
+
+/// The fraction of content width in relation to the page.
+const kContentWidthFraction = 0.7;

--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 
+// The spacing between the form field and the success icon.
+const _kIconSpacing = 10.0;
+
 /// A [TextFormField] rewarding a validated input with a specific widget.
 ///
 /// See also:
@@ -59,7 +62,7 @@ class ValidatedFormField extends StatefulWidget {
     this.helperText,
     this.obscureText = false,
     this.successWidget,
-    this.spacing,
+    this.spacing = _kIconSpacing,
     this.fieldWidth,
   })  : validator = validator ?? _NoValidator(),
         super(key: key);

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -84,6 +84,7 @@ void main() {
         home: Material(
           child: ValidatedFormField(
             fieldWidth: 123,
+            spacing: 45,
           ),
         ),
       ),
@@ -100,7 +101,7 @@ void main() {
           child: Center(
             child: SizedBox(
               width: 123,
-              child: ValidatedFormField(),
+              child: ValidatedFormField(spacing: 45),
             ),
           ),
         ),
@@ -108,7 +109,7 @@ void main() {
     );
 
     final field = find.byType(TextFormField);
-    expect(tester.getRect(field).width, equals(123));
+    expect(tester.getRect(field).width, equals(123 - 45));
   });
 
   testWidgets('icon baseline alignment', (tester) async {

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -11,12 +11,6 @@ import 'advanced_setup_model.dart';
 part 'advanced_setup_utils.dart';
 part 'advanced_setup_widgets.dart';
 
-// The spacing between text form fields and checkmark icons.
-const _kIconSpacing = 10.0;
-
-// The fraction of the content width in relation to the page.
-const _kContentWidthFraction = 0.7;
-
 /// WSL Advanced setup page.
 ///
 /// See also:
@@ -59,7 +53,7 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
       title: Text(lang.advancedSetupTitle),
       header: Text(lang.advancedSetupHeader),
       content: LayoutBuilder(builder: (context, constraints) {
-        final fieldWidth = constraints.maxWidth * _kContentWidthFraction;
+        final fieldWidth = constraints.maxWidth * kContentWidthFraction;
         final fieldPadding =
             EdgeInsets.symmetric(horizontal: kContentPadding.left);
         return ListView(

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
@@ -14,7 +14,6 @@ class _MountLocationFormField extends StatelessWidget {
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
-      spacing: _kIconSpacing,
       labelText: lang.advancedSetupMountLocationHint,
       helperText: lang.advancedSetupMountLocationHelper,
       initialValue: mountLocation,
@@ -44,7 +43,6 @@ class _MountOptionFormField extends StatelessWidget {
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
-      spacing: _kIconSpacing,
       labelText: lang.advancedSetupMountOptionHint,
       helperText: lang.advancedSetupMountOptionHelper,
       initialValue: mountOption,

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -13,12 +13,6 @@ import 'profile_setup_model.dart';
 
 part 'profile_setup_widgets.dart';
 
-// The spacing between text form fields and checkmark icons.
-const _kIconSpacing = 10.0;
-
-// The fraction of the content width in relation to the page.
-const _kContentWidthFraction = 0.7;
-
 /// WSL Profile setup page.
 ///
 /// See also:
@@ -66,7 +60,7 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
         final fieldPadding = EdgeInsets.symmetric(
             horizontal: kContentPadding.left, vertical: 12);
         final fieldWidth = (constraints.maxWidth - fieldPadding.horizontal) *
-            _kContentWidthFraction;
+            kContentWidthFraction;
 
         return ListView(
           children: <Widget>[

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
@@ -16,7 +16,6 @@ class _UsernameFormField extends StatelessWidget {
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
-      spacing: _kIconSpacing,
       labelText: lang.profileSetupUsernameHint,
       helperText: lang.profileSetupUsernameHelper,
       successWidget: const SuccessIcon(),
@@ -55,7 +54,6 @@ class _PasswordFormField extends StatelessWidget {
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
-      spacing: _kIconSpacing,
       labelText: lang.profileSetupPasswordHint,
       obscureText: true,
       successWidget: PasswordStrengthLabel(strength: passwordStrength),
@@ -89,7 +87,6 @@ class _ConfirmPasswordFormField extends StatelessWidget {
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
-      spacing: _kIconSpacing,
       obscureText: true,
       labelText: lang.profileSetupConfirmPasswordHint,
       successWidget: const SuccessIcon(),


### PR DESCRIPTION
- Share the page content width fraction commonly used on pages with
  input form fields.

- Set the common icon spacing as the default for ValidatedFormField
  instead of repeating it all around.