### PR TITLE
Upgrade dependencies to fix Flutter master compatibility

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -18,13 +18,13 @@ dependencies:
   diacritic: ^0.1.3
   file: ^6.1.2
   filesize: ^2.0.0
-  flutter_html: ^2.0.0-nullsafety
+  flutter_html: ^2.1.1
   flutter_svg: ^0.22.0
   form_field_validator: ^1.1.0
   gsettings: ^0.1.2+1
   intl: ^0.17.0
   keyboard_info: ^0.1.0
-  provider: ^5.0.0
+  provider: ^6.0.0
   flutter_markdown: ^0.6.2
   scroll_to_index: ^2.0.0
   tuple: ^2.0.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -17,10 +17,10 @@ dependencies:
   gsettings: ^0.1.2+1
   intl: ^0.17.0
   password_strength: ^0.2.0
-  provider: ^5.0.0
+  provider: ^6.0.0
   subiquity_client:
     path: ../subiquity_client
-  wizard_router: ^0.1.0+1
+  wizard_router: ^0.2.0
   yaru: ^0.1.2
 
 dev_dependencies:

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -9,10 +9,12 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_html: ^2.1.1
+  provider: ^6.0.0
   scroll_to_index: ^2.0.0
   ubuntu_wizard:
     path: ../ubuntu_wizard
   url_launcher: ^6.0.9
+  wizard_router: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.1.1
@@ -20,10 +22,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: 5.0.14
-  provider: ^5.0.0
   ubuntu_test:
     path: ../ubuntu_test
-  wizard_router: ^0.1.0+1
 
 flutter:
   generate: true


### PR DESCRIPTION
Flutter master compatibility for `flutter_math_fork` was fixed: https://github.com/simpleclub-extended/flutter_math_fork/pull/8, but 0.4.0 depends on `provider` ^0.6.0.

Allow the transitive `flutter_math_fork` dependency to be resolved as 0.4.0 by:

- upgrading `provider` to ^6.0.0
- upgrading `wizard_router` to 0.2.0 (0.1.0 depends on provider ^5.0.0)

Note: The backward-incompatible change in `provider` 6.0.0 is irrelevant to us. We are not providing nullable and non-nullable variants of the same type: https://pub.dev/packages/provider/changelog#600