### PR TITLE
Fix gen-l10n vs. build_runner build conflict

### DIFF
--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -34,7 +34,6 @@ dev_dependencies:
     path: ../ubuntu_test
 
 flutter:
-  generate: true
   plugin:
     platforms:
       linux:

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -26,5 +26,4 @@ dev_dependencies:
   wizard_router: ^0.1.0+1
 
 flutter:
-  generate: true
   uses-material-design: true


### PR DESCRIPTION
Disable l10n autogeneration for non-synthetic packages because it
breaks `pub run build_runner build`:

    Unhandled exception:
    Bad state: Unable to generate package graph, no `/path/to/.dart_tool/flutter_gen/pubspec.yaml` found.
    \#0      _pubspecForPath (package:build_runner_core/src/package_graph/package_graph.dart:232:5)
    \#1      _parsePackageDependencies (package:build_runner_core/src/package_graph/package_graph.dart:206:21)
    \#2      PackageGraph.forPath (package:build_runner_core/src/package_graph/package_graph.dart:101:33)
    <asynchronous suspension>
    \#3      main (file:///path/to/.pub-cache/hosted/pub.dartlang.org/build_runner-2.1.1/bin/build_runner.dart:27:30)

If `pubspec.yaml` contains `flutter: generate: true`, the flutter tool
add `flutter_gen` as a dependency to `.dart_tool/package_config.json`.
However, there's no `flutter_gen` package generated into `.dart_tool`
when `l10n.yaml` has `synthetic-package: false`.

For non-synthetic packages, the l10n files are manually generated into
the source tree by running `flutter gen-l10n`. The l10n sources are
referenced/imported/exported as any other source file, not via the
`flutter_gen` package which is autogenerated for synthetic packages.