### PR TITLE
subiquity_client: allow local dependencies from path

### DIFF
--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -2,6 +2,7 @@ name: subiquity_client
 description: Subiquity Client
 version: 0.0.1
 homepage: https://github.com/canonical/ubuntu-desktop-installer
+publish_to: 'none'
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Must be marked as non-publishable package:

> Publishable packages can't have 'path' dependencies. Try adding a
> 'publish_to: none' entry to mark the package as not for publishing
> or remove the path dependency. - invalid_dependency