### PR TITLE
Downgrade file package dependency

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   ubuntu_wizard:
     path: ../ubuntu_wizard
   diacritic: ^0.1.3
-  file: ^6.1.2
+  file: ^6.1.0
   filesize: ^2.0.0
   flutter_html: ^2.1.1
   flutter_svg: ^0.22.0


### PR DESCRIPTION
This is necessary for compatibility with `integration_test` from the Flutter stable SDK:

    ERR : Because every version of integration_test from sdk depends on file 6.1.0 and ubuntu_desktop_installer depends on file ^6.1.2, integration_test from sdk is forbidden.
        | So, because ubuntu_desktop_installer depends on integration_test any from sdk, version solving failed.