### PR TITLE
Fix initial selection for languages with multiple countries

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -55,13 +55,11 @@ class WelcomeModel extends ChangeNotifier {
   /// Returns the name of the language at the given [index].
   String language(int index) => _languageList[index].name;
 
-  /// Selects the given [locale].
-  void selectLocale(String locale) {
-    for (var i = 0; i < _languageList.length; ++i) {
-      if (locale.contains(this.locale(i).languageCode)) {
-        selectedLanguageIndex = i;
-        break;
-      }
-    }
+  /// Selects the best match for the given [locale].
+  ///
+  /// See also:
+  /// * [LocalizedLanguageMatcher.findBestMatch]
+  void selectLocale(Locale locale) {
+    _selectedLanguageIndex = _languageList.findBestMatch(locale);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -60,6 +60,6 @@ class WelcomeModel extends ChangeNotifier {
   /// See also:
   /// * [LocalizedLanguageMatcher.findBestMatch]
   void selectLocale(Locale locale) {
-    _selectedLanguageIndex = _languageList.findBestMatch(locale);
+    _selectedLanguageIndex = _languageList.findBestMatch(locale) ?? 0;
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -60,6 +60,6 @@ class WelcomeModel extends ChangeNotifier {
   /// See also:
   /// * [LocalizedLanguageMatcher.findBestMatch]
   void selectLocale(Locale locale) {
-    _selectedLanguageIndex = _languageList.findBestMatch(locale) ?? 0;
+    _selectedLanguageIndex = _languageList.findBestMatch(locale);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -40,7 +39,8 @@ class _WelcomePageState extends State<WelcomePage> {
     model.loadKeyboards();
 
     model.loadLanguages().then((_) {
-      model.selectLocale(Intl.defaultLocale!);
+      final settings = Settings.of(context, listen: false);
+      model.selectLocale(settings.locale);
 
       _languageListScrollController.scrollToIndex(model.selectedLanguageIndex,
           preferPosition: AutoScrollPosition.middle,

--- a/packages/ubuntu_desktop_installer/test/welcome_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_model_test.dart
@@ -55,14 +55,17 @@ void main() {
     expect(model.languageCount, greaterThan(1));
     expect(model.selectedLanguageIndex, equals(0));
 
-    model.selectLocale('foo');
+    model.selectLocale(Locale('foo'));
     expect(model.selectedLanguageIndex, equals(0));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);
     expect(firstLocale, isNot(equals(lastLocale)));
 
-    model.selectLocale('$lastLocale.UTF-8');
+    model.selectLocale(Locale.fromSubtags(
+        languageCode: lastLocale.languageCode,
+        countryCode: lastLocale.countryCode,
+        scriptCode: 'bar'));
     expect(model.selectedLanguageIndex, equals(model.languageCount - 1));
   });
 

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -63,7 +63,7 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
 
 /// A helper to match locales.
 extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
-  /// Returns the index of the best match for the given [locale] or -1 if not
+  /// Returns the index of the best match for the given [locale] or null if not
   /// found.
   ///
   /// The best matching locale is determined by the following rules:
@@ -71,11 +71,10 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
   /// - Full match (language + country + script)
   /// - Matching language and country
   /// - Matching language
-  int findBestMatch(Locale locale) {
+  int? findBestMatch(Locale locale) {
     return _indexOfLocaleOrNull(locale) ??
         _indexOfLanguageAndCountryOrNull(locale) ??
-        _indexOfLanguageOrNull(locale) ??
-        -1;
+        _indexOfLanguageOrNull(locale);
   }
 
   // full match (language, country, and script)

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -49,6 +49,7 @@ class LocalizedLanguage {
 /// Builds a sorted list of localized languages.
 Future<List<LocalizedLanguage>> loadLocalizedLanguages(
     List<Locale> locales) async {
+  assert(locales.contains(_kFallbackLocale));
   final languages = <LocalizedLanguage>[];
   for (final locale in locales) {
     final localization = await UbuntuLocalizations.delegate.load(locale);
@@ -60,6 +61,9 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
       (a, b) => removeDiacritics(a.name).compareTo(removeDiacritics(b.name)));
   return languages;
 }
+
+// A base locale that must always exist (same as the template .arb).
+const _kFallbackLocale = Locale('en', 'US');
 
 /// A helper to match locales.
 extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
@@ -76,7 +80,7 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
     return _indexOfLocaleOrNull(locale) ??
         _indexOfNeutralLocaleOrNull(locale) ??
         _indexOfParentLocaleOrNull(locale) ??
-        _indexOfParentLocaleOrNull(Locale('en'))!;
+        _indexOfLocaleOrNull(_kFallbackLocale)!;
   }
 
   // full match (language, country, and script)

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:diacritic/diacritic.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -57,6 +59,45 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
   languages.sort(
       (a, b) => removeDiacritics(a.name).compareTo(removeDiacritics(b.name)));
   return languages;
+}
+
+/// A helper to match locales.
+extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
+  /// Returns the index of the best match for the given [locale] or -1 if not
+  /// found.
+  ///
+  /// The best matching locale is determined by the following rules:
+  ///
+  /// - Full match (language + country + script)
+  /// - Matching language and country
+  /// - Matching language
+  int findBestMatch(Locale locale) {
+    return _indexOfLocaleOrNull(locale) ??
+        _indexOfLanguageAndCountryOrNull(locale) ??
+        _indexOfLanguageOrNull(locale) ??
+        -1;
+  }
+
+  // full match (language, country, and script)
+  int? _indexOfLocaleOrNull(Locale locale) {
+    final index = indexWhere((lang) => lang.locale == locale);
+    return index != -1 ? index : null;
+  }
+
+  // match language and country
+  int? _indexOfLanguageAndCountryOrNull(Locale locale) {
+    final index = indexWhere((lang) =>
+        lang.locale.languageCode == locale.languageCode &&
+        lang.locale.countryCode == locale.countryCode);
+    return index != -1 ? index : null;
+  }
+
+  // match language only
+  int? _indexOfLanguageOrNull(Locale locale) {
+    final index =
+        indexWhere((lang) => lang.locale.languageCode == locale.languageCode);
+    return index != -1 ? index : null;
+  }
 }
 
 /// The translations for Occitan  (`oc`).

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -63,18 +63,20 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
 
 /// A helper to match locales.
 extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
-  /// Returns the index of the best match for the given [locale] or null if not
-  /// found.
+  /// Returns the index of the best match for the given [locale] or falls back
+  /// to `en` if the given locale is not found.
   ///
   /// The best matching locale is determined by the following rules:
   ///
   /// - Full match (language + country + script)
   /// - Matching language and country
   /// - Matching language
-  int? findBestMatch(Locale locale) {
+  /// - Fall back to `en`
+  int findBestMatch(Locale locale) {
     return _indexOfLocaleOrNull(locale) ??
         _indexOfLanguageAndCountryOrNull(locale) ??
-        _indexOfLanguageOrNull(locale);
+        _indexOfLanguageOrNull(locale) ??
+        _indexOfLanguageOrNull(Locale('en'))!;
   }
 
   // full match (language, country, and script)

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -70,7 +70,7 @@ const _kBaseLocale = Locale('en', 'US');
 /// A helper to match locales.
 extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
   /// Returns the index of the best match for the given [locale] or falls back
-  /// to `en` if the given locale is not found.
+  /// to the base locale if the given locale is not found.
   ///
   /// The best matching locale is determined by the following rules:
   ///

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -74,9 +74,9 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
   /// - Fall back to `en`
   int findBestMatch(Locale locale) {
     return _indexOfLocaleOrNull(locale) ??
-        _indexOfLanguageAndCountryOrNull(locale) ??
-        _indexOfLanguageOrNull(locale) ??
-        _indexOfLanguageOrNull(Locale('en'))!;
+        _indexOfNeutralLocaleOrNull(locale) ??
+        _indexOfParentLocaleOrNull(locale) ??
+        _indexOfParentLocaleOrNull(Locale('en'))!;
   }
 
   // full match (language, country, and script)
@@ -86,19 +86,24 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
   }
 
   // match language and country
-  int? _indexOfLanguageAndCountryOrNull(Locale locale) {
-    final index = indexWhere((lang) =>
-        lang.locale.languageCode == locale.languageCode &&
-        lang.locale.countryCode == locale.countryCode);
+  int? _indexOfNeutralLocaleOrNull(Locale locale) {
+    final index = indexWhere((lang) => lang.locale == locale.neutral);
     return index != -1 ? index : null;
   }
 
   // match language only
-  int? _indexOfLanguageOrNull(Locale locale) {
-    final index =
-        indexWhere((lang) => lang.locale.languageCode == locale.languageCode);
+  int? _indexOfParentLocaleOrNull(Locale locale) {
+    final index = indexWhere((lang) => lang.locale == locale.parent);
     return index != -1 ? index : null;
   }
+}
+
+extension _LocaleExtension on Locale {
+  // not associated to a specific country
+  Locale get parent => Locale(languageCode);
+
+  // not associated to a specific script
+  Locale get neutral => Locale(languageCode, countryCode);
 }
 
 /// The translations for Occitan  (`oc`).

--- a/packages/ubuntu_wizard/lib/l10n.dart
+++ b/packages/ubuntu_wizard/lib/l10n.dart
@@ -47,9 +47,11 @@ class LocalizedLanguage {
 }
 
 /// Builds a sorted list of localized languages.
+///
+/// [locales] must contain the base locale i.e. the template .arb locale.
 Future<List<LocalizedLanguage>> loadLocalizedLanguages(
     List<Locale> locales) async {
-  assert(locales.contains(_kFallbackLocale));
+  assert(locales.contains(_kBaseLocale));
   final languages = <LocalizedLanguage>[];
   for (final locale in locales) {
     final localization = await UbuntuLocalizations.delegate.load(locale);
@@ -62,8 +64,8 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
   return languages;
 }
 
-// A base locale that must always exist (same as the template .arb).
-const _kFallbackLocale = Locale('en', 'US');
+// A fallback locale that must always exist (same as the template .arb).
+const _kBaseLocale = Locale('en', 'US');
 
 /// A helper to match locales.
 extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
@@ -75,12 +77,12 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
   /// - Full match (language + country + script)
   /// - Matching language and country
   /// - Matching language
-  /// - Fall back to `en`
+  /// - Fall back to the base locale i.e. the template .arb locale.
   int findBestMatch(Locale locale) {
     return _indexOfLocaleOrNull(locale) ??
         _indexOfNeutralLocaleOrNull(locale) ??
         _indexOfParentLocaleOrNull(locale) ??
-        _indexOfLocaleOrNull(_kFallbackLocale)!;
+        _indexOfLocaleOrNull(_kBaseLocale)!;
   }
 
   // full match (language, country, and script)
@@ -103,10 +105,10 @@ extension LocalizedLanguageMatcher on List<LocalizedLanguage> {
 }
 
 extension _LocaleExtension on Locale {
-  // not associated to a specific country
+  // not associated to any specific country
   Locale get parent => Locale(languageCode);
 
-  // not associated to a specific script
+  // not associated to any specific script
   Locale get neutral => Locale(languageCode, countryCode);
 }
 

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -23,7 +23,7 @@ void main() {
   });
 
   test('find best matching locale', () {
-    const localeEn = Locale('en');
+    const localeEnUS = Locale('en', 'US');
     const localeEs = Locale('es');
     const localeFr = Locale('fr');
     const localeFrCA = Locale('fr', 'CA');
@@ -39,7 +39,7 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeEnUS),
         LocalizedLanguage('', localeFrFReuro),
         LocalizedLanguage('', localeFrCA),
         LocalizedLanguage('', localeFrFR),
@@ -51,7 +51,7 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeEnUS),
         LocalizedLanguage('', localeFrCA),
         LocalizedLanguage('', localeFrFR),
       ].findBestMatch(localeFrFReuro),
@@ -62,7 +62,7 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeEnUS),
         LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeFrFReuro),
       equals(0),
@@ -72,7 +72,7 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeEnUS),
         LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeEs),
       equals(1),
@@ -82,7 +82,7 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFrFR),
-        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeEnUS),
         LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeFrBE),
       equals(1),

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -23,6 +23,7 @@ void main() {
   });
 
   test('find best matching locale', () {
+    const localeEn = Locale('en');
     const localeFr = Locale('fr');
     const localeFrCA = Locale('fr', 'CA');
     const localeFrFR = Locale('fr', 'FR');
@@ -36,39 +37,43 @@ void main() {
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeEn),
         LocalizedLanguage('', localeFrFReuro),
-        LocalizedLanguage('', localeFrCA),
-        LocalizedLanguage('', localeFrFR),
-      ].findBestMatch(localeFrFReuro),
-      equals(1),
-    );
-
-    // matching language and country
-    expect(
-      <LocalizedLanguage>[
-        LocalizedLanguage('', localeFr),
         LocalizedLanguage('', localeFrCA),
         LocalizedLanguage('', localeFrFR),
       ].findBestMatch(localeFrFReuro),
       equals(2),
     );
 
+    // matching language and country
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeFrCA),
+        LocalizedLanguage('', localeFrFR),
+      ].findBestMatch(localeFrFReuro),
+      equals(3),
+    );
+
     // matching language
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeEn),
         LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeFrFReuro),
       equals(0),
     );
 
-    // no match
+    // no match -> en
     expect(
       <LocalizedLanguage>[
         LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeEn),
         LocalizedLanguage('', localeFrCA),
-      ].findBestMatch(Locale('en')),
-      equals(isNull),
+      ].findBestMatch(Locale('es')),
+      equals(1),
     );
   });
 }

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -24,8 +24,10 @@ void main() {
 
   test('find best matching locale', () {
     const localeEn = Locale('en');
+    const localeEs = Locale('es');
     const localeFr = Locale('fr');
     const localeFrCA = Locale('fr', 'CA');
+    const localeFrBE = Locale('fr', 'BE');
     const localeFrFR = Locale('fr', 'FR');
     const localeFrFReuro = Locale.fromSubtags(
       languageCode: 'fr',
@@ -72,7 +74,17 @@ void main() {
         LocalizedLanguage('', localeFr),
         LocalizedLanguage('', localeEn),
         LocalizedLanguage('', localeFrCA),
-      ].findBestMatch(Locale('es')),
+      ].findBestMatch(localeEs),
+      equals(1),
+    );
+
+    // country mismatch -> en
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFrFR),
+        LocalizedLanguage('', localeEn),
+        LocalizedLanguage('', localeFrCA),
+      ].findBestMatch(localeFrBE),
       equals(1),
     );
   });

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -21,4 +21,45 @@ void main() {
       ]),
     );
   });
+
+  test('find best matching locale', () {
+    const localeFr = Locale('fr');
+    const localeFrCA = Locale('fr', 'CA');
+    const localeFrFR = Locale('fr', 'FR');
+    const localeFrFReuro = Locale.fromSubtags(
+      languageCode: 'fr',
+      countryCode: 'FR',
+      scriptCode: 'euro',
+    );
+
+    // full match
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeFrFReuro),
+        LocalizedLanguage('', localeFrCA),
+        LocalizedLanguage('', localeFrFR),
+      ].findBestMatch(localeFrFReuro),
+      equals(1),
+    );
+
+    // matching language and country
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeFrCA),
+        LocalizedLanguage('', localeFrFR),
+      ].findBestMatch(localeFrFReuro),
+      equals(2),
+    );
+
+    // matching language
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeFrCA),
+      ].findBestMatch(localeFrFReuro),
+      equals(0),
+    );
+  });
 }

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -61,5 +61,14 @@ void main() {
       ].findBestMatch(localeFrFReuro),
       equals(0),
     );
+
+    // no match
+    expect(
+      <LocalizedLanguage>[
+        LocalizedLanguage('', localeFr),
+        LocalizedLanguage('', localeFrCA),
+      ].findBestMatch(Locale('en')),
+      equals(isNull),
+    );
   });
 }


### PR DESCRIPTION
We can't compare the language code only, because then e.g. `fr_CA` would be always chosen over `fr_FR`. We can't expect a full match either, so find the best possible match (full => lang+country => lang).

Close: #241 
