### PR TITLE
subiquity: update, disable autoinstall

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -22,4 +22,6 @@ export SUBIQUITY_ROOT=$SNAP/bin/subiquity
 
 # run subiquity server
 cd $SCRIPT_DIR/subiquity
-$PYTHON -m subiquity.cmd.server
+# autoinstall is explicitly disabled until UI support is present.
+# Remove this autoinstall argument when that is resolved.
+$PYTHON -m subiquity.cmd.server --autoinstall=""

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 3673687e867eeb88a3e7fd72587a75d5fc811f5a
+    source-commit: 809817fdac257de1769e385a42aeaf3d5bcc2c60
     build-packages:
       - shared-mime-info
       - zlib1g-dev


### PR DESCRIPTION
Running ubuntu-desktop-installer with a subiquity autoinstall file does
work, but the UI has no knowledge of this interaction.  Disable it for
today until UI integration can be completed.

Update the version of subiquity.  Changes include
* support on the autoinstall argument needed to disable autoinstall
* WSL functionality
* pubsub refactor
* updated curtin