### PR TITLE
inject-snap: add test script

### DIFF
--- a/scripts/inject-snap
+++ b/scripts/inject-snap
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# inject-snap - install a snap into a live iso
+# inject-snap source_iso destination_iso file.snap
+
+set -eux
+
+src=$1
+dst=$2
+snap=$3
+
+LIVEFS_EDITOR="${LIVEFS_EDITOR-$(readlink -f "$(dirname $(dirname ${0}))/livefs-editor")}"
+[ -d "$LIVEFS_EDITOR" ] || git clone https://github.com/mwhudson/livefs-editor $LIVEFS_EDITOR
+
+sudo PYTHONPATH=$LIVEFS_EDITOR \
+    python3 -m livefs_edit $src $dst --inject-snap $snap


### PR DESCRIPTION
This inject-snap script can be used to modify an existing iso to inject
a snap into it.  This process is used often in subiquity development and
can be a convenient method of testing changes.