### PR TITLE
Fix alignment of checkbuttons on the Who are you? page

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -82,11 +82,11 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
                 padding: fieldPadding,
                 child: _ConfirmPasswordFormField(fieldWidth: fieldWidth),
               ),
+              const SizedBox(height: kContentSpacing),
               _LoginStrategyTile(
                 value: LoginStrategy.autoLogin,
                 label: lang.whoAreYouPageAutoLogin,
               ),
-              const SizedBox(height: kContentSpacing),
               _LoginStrategyTile(
                 value: LoginStrategy.requirePassword,
                 label: lang.whoAreYouPageRequirePassword,


### PR DESCRIPTION
Spacing slipped between wrong UI elements in the column.