### PR TITLE
Use check- and radio buttons in Allocate disk space dialogs

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -64,17 +64,32 @@ Future<void> showCreatePartitionDialog(BuildContext context, DiskModel disk) {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  _PartitionDialogLabel(lang.partitionSizeLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionSizeLabel,
+                    height: tileHeight,
+                  ),
                   const SizedBox(height: kContentSpacing),
-                  _PartitionDialogLabel(lang.partitionTypeLabel),
-                  ListTile(),
+                  _PartitionDialogLabel(
+                    lang.partitionTypeLabel,
+                    height: kRadioSize.height,
+                  ),
+                  SizedBox(height: kRadioSize.height),
                   const SizedBox(height: kContentSpacing),
-                  _PartitionDialogLabel(lang.partitionLocationLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionLocationLabel,
+                    height: kRadioSize.height,
+                  ),
+                  SizedBox(height: kRadioSize.height),
                   const SizedBox(height: kContentSpacing),
-                  ListTile(),
-                  _PartitionDialogLabel(lang.partitionFormatLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionFormatLabel,
+                    height: tileHeight,
+                  ),
                   const SizedBox(height: kContentSpacing),
-                  _PartitionDialogLabel(lang.partitionMountPointLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionMountPointLabel,
+                    height: tileHeight,
+                  ),
                 ],
               ),
             ),
@@ -156,17 +171,22 @@ double _defaultTileHeight(BuildContext context) {
 }
 
 class _PartitionDialogLabel extends StatelessWidget {
-  const _PartitionDialogLabel(this.text, {Key? key}) : super(key: key);
+  const _PartitionDialogLabel(this.text, {Key? key, this.height})
+      : super(key: key);
 
   final String text;
+  final double? height;
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      contentPadding: kContentPadding,
-      title: Align(
-        alignment: Alignment.topRight,
-        child: Text(text),
+    return SizedBox(
+      height: height,
+      child: Padding(
+        padding: kContentPadding,
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: Text(text),
+        ),
       ),
     );
   }
@@ -191,7 +211,7 @@ class _RadioValueTile<T> extends StatelessWidget {
     return ValueListenableBuilder<T>(
       valueListenable: groupValue,
       builder: (context, groupValue, child) {
-        return RadioListTile<T>(
+        return RadioButton<T>(
           title: title,
           value: value,
           groupValue: groupValue,
@@ -325,11 +345,17 @@ Future<void> showEditPartitionDialog(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  _PartitionDialogLabel(lang.partitionFormatLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionFormatLabel,
+                    height: tileHeight,
+                  ),
                   const SizedBox(height: kContentSpacing),
-                  ListTile(),
+                  SizedBox(height: kRadioSize.height),
                   const SizedBox(height: kContentSpacing),
-                  _PartitionDialogLabel(lang.partitionMountPointLabel),
+                  _PartitionDialogLabel(
+                    lang.partitionMountPointLabel,
+                    height: tileHeight,
+                  ),
                 ],
               ),
             ),
@@ -347,9 +373,8 @@ Future<void> showEditPartitionDialog(
                   ValueListenableBuilder<bool>(
                     valueListenable: partitionErase,
                     builder: (context, erase, child) {
-                      return CheckboxListTile(
+                      return CheckButton(
                         title: Text(lang.partitionErase),
-                        controlAffinity: ListTileControlAffinity.leading,
                         value: erase,
                         onChanged: (v) => partitionErase.value = v!,
                       );

--- a/packages/ubuntu_wizard/lib/constants.dart
+++ b/packages/ubuntu_wizard/lib/constants.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/painting.dart';
+import 'package:flutter/material.dart';
 
 /// The spacing between Continue and Back buttons.
 const kButtonBarSpacing = 8.0;
@@ -17,3 +17,6 @@ const kFooterPadding = EdgeInsets.fromLTRB(24, 0, 24, 24);
 
 /// The fraction of content width in relation to the page.
 const kContentWidthFraction = 0.7;
+
+/// The size of a radio indicator.
+const kRadioSize = Size.square(kMinInteractiveDimension - 8);

--- a/packages/ubuntu_wizard/lib/src/widgets/check_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/check_button.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../constants.dart';
+
 const _kHorizontalSpacing = 8.0;
-const _kRadioSize = Size.square(kMinInteractiveDimension - 8);
 const _kVerticalSpacing = 2.0;
 
 /// A desktop style checkbox with an interactive label.
@@ -45,8 +46,8 @@ class CheckButton extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               SizedBox(
-                width: _kRadioSize.width,
-                height: _kRadioSize.height,
+                width: kRadioSize.width,
+                height: kRadioSize.height,
                 child: Checkbox(
                   value: value,
                   onChanged: onChanged,

--- a/packages/ubuntu_wizard/lib/src/widgets/radio_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/radio_button.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../constants.dart';
+
 const _kHorizontalSpacing = 8.0;
-const _kRadioSize = Size.square(kMinInteractiveDimension - 8);
 const _kVerticalSpacing = 2.0;
 
 /// A desktop style radio button with an interactive label.
@@ -49,8 +50,8 @@ class RadioButton<T> extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               SizedBox(
-                width: _kRadioSize.width,
-                height: _kRadioSize.height,
+                width: kRadioSize.width,
+                height: kRadioSize.height,
                 child: Radio<T>(
                   value: value,
                   groupValue: groupValue,

--- a/packages/ubuntu_wizard/lib/src/widgets/radio_icon_tile.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/radio_icon_tile.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-const _kRadioSize = Size.square(kMinInteractiveDimension - 8);
+import '../../constants.dart';
 
 /// List tile with an icon that matches the geometry of [RadioListTile]'s radio
 /// indicator.
@@ -26,7 +26,7 @@ class RadioIconTile extends StatelessWidget {
   Size _calculateIconSize(BuildContext context) {
     final theme = Theme.of(context);
     final visualDensity = theme.radioTheme.visualDensity ?? theme.visualDensity;
-    return _kRadioSize + visualDensity.baseSizeAdjustment;
+    return kRadioSize + visualDensity.baseSizeAdjustment;
   }
 
   @override


### PR DESCRIPTION
To get rid of the highlight background which is meant for list views
and looks a bit awkward on a frameless background. Our custom desktop
oriented check and radio buttons were added for exactly this reason.