### PR TITLE
Allow resizing the window in debug mode for testing purposes

### DIFF
--- a/packages/ubuntu_desktop_installer/linux/my_application.cc
+++ b/packages/ubuntu_desktop_installer/linux/my_application.cc
@@ -22,7 +22,11 @@ static void my_application_activate(GApplication* application) {
   gtk_header_bar_set_decoration_layout(header_bar, ":close");
   gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   gtk_window_set_default_size(window, 960, 680);
+#ifdef NDEBUG
+  // The window has a fixed size in production/release mode, but resizing
+  // the window is allowed in debug mode for testing purposes.
   gtk_window_set_resizable(window, FALSE);
+#endif
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();

--- a/packages/ubuntu_wsl_setup/linux/my_application.cc
+++ b/packages/ubuntu_wsl_setup/linux/my_application.cc
@@ -22,7 +22,11 @@ static void my_application_activate(GApplication* application) {
   gtk_header_bar_set_decoration_layout(header_bar, ":close");
   gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   gtk_window_set_default_size(window, 960, 680);
+#ifdef NDEBUG
+  // The window has a fixed size in production/release mode, but resizing
+  // the window is allowed in debug mode for testing purposes.
   gtk_window_set_resizable(window, FALSE);
+#endif
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();


### PR DESCRIPTION
A fixed window size makes it tempting to hard-code geometries for UI
elements. Putting in the little extra effor to keep things scalable pays
off if and when the design changes or if we ever decide to change the
default window size in the future.

This change keeps the window size fixed in production/release mode but
makes it resizable in debug mode to motivate scalable layouts.