### PR TITLE
UDI: switch to manual gen-l10n

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,30 @@ Bugs are also tracked as [GitHub issues](https://github.com/canonical/ubuntu-des
 
 ## Translations
 
-Translations for the Ubuntu desktop installer are managed with [Flutter's tools for internationalization](https://flutter.dev/docs/development/accessibility-and-localization/internationalization).
+Translations are managed with [Flutter's tools for internationalization](https://flutter.dev/docs/development/accessibility-and-localization/internationalization).
 
-The templates containing all the messages to be translated live in `packages/ubuntu_desktop_installer/lib/l10n/app_en.arb` and `packages/ubuntu_wizard/lib/l10n/ubuntu_en.arb`.
-When starting translations for a new language, those files need to be copied to `app_LANGCODE.arb` in the respective directories (e.g. `app_fr.arb` and `ubuntu_fr.arb`), and messages should be translated in these new files.
+The templates containing all the messages to be translated live in:
+- `packages/ubuntu_desktop_installer/lib/l10n/app_en.arb`
+- `packages/ubuntu_wizard/lib/src/l10n/ubuntu_en.arb`
+- `packages/ubuntu_wsl_setup/lib/l10n/app_en.arb`
 
-When new messages are added in the source code, they also need to be added to the appropriate translation template.
+When starting translations for a new language, those files need to be copied to `NAME_LANGCODE.arb` in the respective directories (e.g. `app_fr.arb` and `ubuntu_fr.arb`), and messages should be translated in these new files.
 
-The `ubuntu_wizard` library requires re-generating `ubuntu_localizations.dart` and `ubuntu_localizations_LANGCODE.dart` by running `flutter gen-l10n`.
-The `ubuntu_desktop_installer` application requires no further steps as it auto-generates `app_localizations.dart` and `app_localizations_LANGCODE.dart` at build time.
+When new messages are added in the source code, they also need to be added to the appropriate translation template, and the translation files need to be re-generated.
 
-The `app_en.arb` translation template has one special string (`languageName`) that is used to determine whether that language should be offered to the user on the welcome screen. If a translation isn't complete enough, or of insufficient quality, just make `languageName` an empty string (by default it inherits the value from the English template, so it's not empty), and it won't show up as available in the UI.
+You can run either
+
+```
+melos run gen-l10n
+```
+to re-generate translations for all packages, or
+
+```
+flutter gen-l10n
+```
+in a package directory to generate translations for a specific package.
+
+The `ubuntu_en.arb` translation template has one special string (`languageName`) that is used to determine whether that language should be offered to the user on the welcome screen. If a translation isn't complete enough, or of insufficient quality, just make `languageName` an empty string (by default it inherits the value from the English template, so it's not empty), and it won't show up as available in the UI.
 
 
 ## Code Generation

--- a/packages/ubuntu_desktop_installer/l10n.yaml
+++ b/packages/ubuntu_desktop_installer/l10n.yaml
@@ -1,3 +1,4 @@
 arb-dir: lib/l10n
 template-arb-file: app_en_US.arb
+synthetic-package: false
 nullable-getter: false

--- a/packages/ubuntu_desktop_installer/lib/l10n.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:ubuntu_wizard/l10n.dart';
+import 'l10n/app_localizations.dart';
 
-export 'package:flutter_gen/gen_l10n/app_localizations.dart';
 export 'package:ubuntu_wizard/l10n.dart';
+export 'l10n/app_localizations.dart';
 
 /// All localization delegates for the Ubuntu Desktop Installer.
 const localizationsDelegates = <LocalizationsDelegate<dynamic>>[

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1,0 +1,901 @@
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
+import 'app_localizations_fr.dart';
+import 'app_localizations_it.dart';
+import 'app_localizations_nl.dart';
+import 'app_localizations_oc.dart';
+import 'app_localizations_pt.dart';
+import 'app_localizations_ru.dart';
+
+/// Callers can lookup localized strings with an instance of AppLocalizations returned
+/// by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// localizationDelegates list, and the locales they support in the app's
+/// supportedLocales list. For example:
+///
+/// ```
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('en', 'US'),
+    Locale('es'),
+    Locale('es', 'ES'),
+    Locale('fr'),
+    Locale('fr', 'FR'),
+    Locale('it'),
+    Locale('it', 'IT'),
+    Locale('nl'),
+    Locale('nl', 'NL'),
+    Locale('oc'),
+    Locale('oc', 'FR'),
+    Locale('pt'),
+    Locale('pt', 'BR'),
+    Locale('ru'),
+    Locale('ru', 'RU')
+  ];
+
+  /// No description provided for @appTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Ubuntu Desktop Installer'**
+  String get appTitle;
+
+  /// No description provided for @windowTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Install Ubuntu'**
+  String get windowTitle;
+
+  /// No description provided for @cancelButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Cancel'**
+  String get cancelButtonText;
+
+  /// No description provided for @changeButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Change'**
+  String get changeButtonText;
+
+  /// No description provided for @okButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'OK'**
+  String get okButtonText;
+
+  /// No description provided for @noButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'No'**
+  String get noButtonText;
+
+  /// No description provided for @restartButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Restart'**
+  String get restartButtonText;
+
+  /// No description provided for @revertButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Revert'**
+  String get revertButtonText;
+
+  /// No description provided for @yesButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Yes'**
+  String get yesButtonText;
+
+  /// No description provided for @welcome.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Welcome'**
+  String get welcome;
+
+  /// No description provided for @tryOrInstallPageTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Try or install'**
+  String get tryOrInstallPageTitle;
+
+  /// No description provided for @repairInstallation.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Repair installation'**
+  String get repairInstallation;
+
+  /// No description provided for @repairInstallationDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Repairing will reinstall all installed software without touching documents or settings.'**
+  String get repairInstallationDescription;
+
+  /// No description provided for @tryUbuntu.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Try Ubuntu'**
+  String get tryUbuntu;
+
+  /// No description provided for @tryUbuntuDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'You can try Ubuntu without making any changes to your computer.'**
+  String get tryUbuntuDescription;
+
+  /// No description provided for @installUbuntu.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Install Ubuntu'**
+  String get installUbuntu;
+
+  /// No description provided for @installUbuntuDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.'**
+  String get installUbuntuDescription;
+
+  /// No description provided for @releaseNotesLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'You may wish to read the <a href=\"{url}\">release notes</a>.'**
+  String releaseNotesLabel(Object url);
+
+  /// No description provided for @turnOffRST.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Turn off RST'**
+  String get turnOffRST;
+
+  /// No description provided for @turnOffRSTDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.'**
+  String get turnOffRSTDescription;
+
+  /// No description provided for @instructionsForRST.
+  ///
+  /// In en_US, this message translates to:
+  /// **'For instructions, open this page on a phone or other device: <a href=\"https://{url}\">{url}</a>'**
+  String instructionsForRST(Object url);
+
+  /// No description provided for @keyboardLayoutPageTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Keyboard layout'**
+  String get keyboardLayoutPageTitle;
+
+  /// No description provided for @chooseYourKeyboardLayout.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Choose your keyboard layout:'**
+  String get chooseYourKeyboardLayout;
+
+  /// No description provided for @typeToTest.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Type here to test your keyboard'**
+  String get typeToTest;
+
+  /// No description provided for @detectLayout.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Detect Keyboard Layout'**
+  String get detectLayout;
+
+  /// No description provided for @pressOneKey.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Please press one of the following keys:'**
+  String get pressOneKey;
+
+  /// No description provided for @isKeyPresent.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Is the following key present on your keyboard?'**
+  String get isKeyPresent;
+
+  /// No description provided for @updatesOtherSoftwarePageTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Updates and other software'**
+  String get updatesOtherSoftwarePageTitle;
+
+  /// No description provided for @updatesOtherSoftwarePageDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'What apps would you like to install to start with?'**
+  String get updatesOtherSoftwarePageDescription;
+
+  /// No description provided for @normalInstallationTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Normal installation'**
+  String get normalInstallationTitle;
+
+  /// No description provided for @normalInstallationSubtitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Web browser, utilities, office software, games and media players.'**
+  String get normalInstallationSubtitle;
+
+  /// No description provided for @minimalInstallationTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Minimal installation'**
+  String get minimalInstallationTitle;
+
+  /// No description provided for @minimalInstallationSubtitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Web browser and basic utilities.'**
+  String get minimalInstallationSubtitle;
+
+  /// No description provided for @otherOptions.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Other options'**
+  String get otherOptions;
+
+  /// No description provided for @installThirdPartyTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats'**
+  String get installThirdPartyTitle;
+
+  /// No description provided for @installThirdPartySubtitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'This software is subject to license terms included with its documentation. Some are proprietary.'**
+  String get installThirdPartySubtitle;
+
+  /// No description provided for @allocateDiskSpace.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Allocate disk space'**
+  String get allocateDiskSpace;
+
+  /// No description provided for @startInstallingButtonText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Start Installing'**
+  String get startInstallingButtonText;
+
+  /// No description provided for @diskHeadersDevice.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Device'**
+  String get diskHeadersDevice;
+
+  /// No description provided for @diskHeadersType.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Type'**
+  String get diskHeadersType;
+
+  /// No description provided for @diskHeadersMountPoint.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Mount point'**
+  String get diskHeadersMountPoint;
+
+  /// No description provided for @diskHeadersSize.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Size'**
+  String get diskHeadersSize;
+
+  /// No description provided for @diskHeadersUsed.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Used'**
+  String get diskHeadersUsed;
+
+  /// No description provided for @diskHeadersSystem.
+  ///
+  /// In en_US, this message translates to:
+  /// **'System'**
+  String get diskHeadersSystem;
+
+  /// No description provided for @diskHeadersFormat.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Format'**
+  String get diskHeadersFormat;
+
+  /// No description provided for @freeDiskSpace.
+  ///
+  /// In en_US, this message translates to:
+  /// **'free space'**
+  String get freeDiskSpace;
+
+  /// No description provided for @newPartitionTable.
+  ///
+  /// In en_US, this message translates to:
+  /// **'New partition table'**
+  String get newPartitionTable;
+
+  /// No description provided for @bootLoaderDevice.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Device for boot loader installation'**
+  String get bootLoaderDevice;
+
+  /// No description provided for @partitionCreateTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Create partition'**
+  String get partitionCreateTitle;
+
+  /// No description provided for @partitionEditTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Edit partition'**
+  String get partitionEditTitle;
+
+  /// No description provided for @partitionSizeLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Size:'**
+  String get partitionSizeLabel;
+
+  /// No description provided for @partitionUnitB.
+  ///
+  /// In en_US, this message translates to:
+  /// **'B'**
+  String get partitionUnitB;
+
+  /// No description provided for @partitionUnitKB.
+  ///
+  /// In en_US, this message translates to:
+  /// **'KB'**
+  String get partitionUnitKB;
+
+  /// No description provided for @partitionUnitMB.
+  ///
+  /// In en_US, this message translates to:
+  /// **'MB'**
+  String get partitionUnitMB;
+
+  /// No description provided for @partitionUnitGB.
+  ///
+  /// In en_US, this message translates to:
+  /// **'GB'**
+  String get partitionUnitGB;
+
+  /// No description provided for @partitionTypeLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Type for the new partition:'**
+  String get partitionTypeLabel;
+
+  /// No description provided for @partitionTypePrimary.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Primary'**
+  String get partitionTypePrimary;
+
+  /// No description provided for @partitionTypeLogical.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Logical'**
+  String get partitionTypeLogical;
+
+  /// No description provided for @partitionLocationLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Location for the new partition:'**
+  String get partitionLocationLabel;
+
+  /// No description provided for @partitionLocationBeginning.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Beginning of this space'**
+  String get partitionLocationBeginning;
+
+  /// No description provided for @partitionLocationEnd.
+  ///
+  /// In en_US, this message translates to:
+  /// **'End of this space'**
+  String get partitionLocationEnd;
+
+  /// No description provided for @partitionFormatLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Used as:'**
+  String get partitionFormatLabel;
+
+  /// No description provided for @partitionFormatExt4.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Ext4 journaling file system'**
+  String get partitionFormatExt4;
+
+  /// No description provided for @partitionFormatExt3.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Ext3 journaling file system'**
+  String get partitionFormatExt3;
+
+  /// No description provided for @partitionFormatExt2.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Ext2 file system'**
+  String get partitionFormatExt2;
+
+  /// No description provided for @partitionFormatBtrfs.
+  ///
+  /// In en_US, this message translates to:
+  /// **'btrfs journaling file system'**
+  String get partitionFormatBtrfs;
+
+  /// No description provided for @partitionFormatJfs.
+  ///
+  /// In en_US, this message translates to:
+  /// **'JFS journaling file system'**
+  String get partitionFormatJfs;
+
+  /// No description provided for @partitionFormatXfs.
+  ///
+  /// In en_US, this message translates to:
+  /// **'XFS journaling file system'**
+  String get partitionFormatXfs;
+
+  /// No description provided for @partitionFormatFat16.
+  ///
+  /// In en_US, this message translates to:
+  /// **'FAT16 file system'**
+  String get partitionFormatFat16;
+
+  /// No description provided for @partitionFormatFat32.
+  ///
+  /// In en_US, this message translates to:
+  /// **'FAT32 file system'**
+  String get partitionFormatFat32;
+
+  /// No description provided for @partitionFormatSwap.
+  ///
+  /// In en_US, this message translates to:
+  /// **'swap area'**
+  String get partitionFormatSwap;
+
+  /// No description provided for @partitionFormatBios.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Reserved BIOS boot area'**
+  String get partitionFormatBios;
+
+  /// No description provided for @partitionFormatEfi.
+  ///
+  /// In en_US, this message translates to:
+  /// **'EFI System Partition'**
+  String get partitionFormatEfi;
+
+  /// No description provided for @partitionFormatPhysical.
+  ///
+  /// In en_US, this message translates to:
+  /// **'physical volume for encryption'**
+  String get partitionFormatPhysical;
+
+  /// No description provided for @partitionFormatNone.
+  ///
+  /// In en_US, this message translates to:
+  /// **'do not use the partition'**
+  String get partitionFormatNone;
+
+  /// No description provided for @partitionErase.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Format the partition'**
+  String get partitionErase;
+
+  /// No description provided for @partitionMountPointLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Mount point:'**
+  String get partitionMountPointLabel;
+
+  /// No description provided for @whoAreYouPageTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Who are you?'**
+  String get whoAreYouPageTitle;
+
+  /// No description provided for @whoAreYouPageAutoLogin.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Log in automatically'**
+  String get whoAreYouPageAutoLogin;
+
+  /// No description provided for @whoAreYouPageRequirePassword.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Require my password to log in'**
+  String get whoAreYouPageRequirePassword;
+
+  /// No description provided for @whoAreYouPageRealNameLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Your name'**
+  String get whoAreYouPageRealNameLabel;
+
+  /// No description provided for @whoAreYouPageRealNameRequired.
+  ///
+  /// In en_US, this message translates to:
+  /// **'A name is required'**
+  String get whoAreYouPageRealNameRequired;
+
+  /// No description provided for @whoAreYouPageComputerNameLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Your computer\'s name'**
+  String get whoAreYouPageComputerNameLabel;
+
+  /// No description provided for @whoAreYouPageComputerNameInfo.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The name it uses when it talks to other computers.'**
+  String get whoAreYouPageComputerNameInfo;
+
+  /// No description provided for @whoAreYouPageComputerNameRequired.
+  ///
+  /// In en_US, this message translates to:
+  /// **'A computer name is required'**
+  String get whoAreYouPageComputerNameRequired;
+
+  /// No description provided for @whoAreYouPageInvalidComputerName.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The computer name is invalid'**
+  String get whoAreYouPageInvalidComputerName;
+
+  /// No description provided for @whoAreYouPageUsernameLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Pick a username'**
+  String get whoAreYouPageUsernameLabel;
+
+  /// No description provided for @whoAreYouPageUsernameRequired.
+  ///
+  /// In en_US, this message translates to:
+  /// **'A username is required'**
+  String get whoAreYouPageUsernameRequired;
+
+  /// No description provided for @whoAreYouPageInvalidUsername.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The username is invalid'**
+  String get whoAreYouPageInvalidUsername;
+
+  /// No description provided for @whoAreYouPagePasswordLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Choose a password'**
+  String get whoAreYouPagePasswordLabel;
+
+  /// No description provided for @whoAreYouPagePasswordRequired.
+  ///
+  /// In en_US, this message translates to:
+  /// **'A password is required'**
+  String get whoAreYouPagePasswordRequired;
+
+  /// No description provided for @whoAreYouPageConfirmPasswordLabel.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Confirm your password'**
+  String get whoAreYouPageConfirmPasswordLabel;
+
+  /// No description provided for @whoAreYouPagePasswordMismatch.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The passwords do not match'**
+  String get whoAreYouPagePasswordMismatch;
+
+  /// No description provided for @writeChangesToDisk.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Write changes to disk'**
+  String get writeChangesToDisk;
+
+  /// Default display name for a disk without a serial (unlikely)
+  ///
+  /// In en_US, this message translates to:
+  /// **'disk'**
+  String get writeChangesFallbackSerial;
+
+  /// No description provided for @writeChangesDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.'**
+  String get writeChangesDescription;
+
+  /// No description provided for @writeChangesPartitionTablesHeader.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The partition tables of the following devices are changed:'**
+  String get writeChangesPartitionTablesHeader;
+
+  /// An entry for a disk whose partition table is being changed
+  ///
+  /// In en_US, this message translates to:
+  /// **'{serial} ({path})'**
+  String writeChangesPartitionTablesEntry(Object serial, Object path);
+
+  /// No description provided for @writeChangesPartitionsHeader.
+  ///
+  /// In en_US, this message translates to:
+  /// **'The following partitions are going to be formatted:'**
+  String get writeChangesPartitionsHeader;
+
+  /// An entry for a primary partition without secondary partitions
+  ///
+  /// In en_US, this message translates to:
+  /// **'partition #{partitionNumber} of {diskSerial} ({diskPath}) as {fstype} used for {mountPath}'**
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath);
+
+  /// An entry for a primary partition with secondary partitions
+  ///
+  /// In en_US, this message translates to:
+  /// **'partition #{partitionNumber} of {diskSerial} ({diskPath}) as'**
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath);
+
+  /// An entry for a secondary partition
+  ///
+  /// In en_US, this message translates to:
+  /// **'        partition # as {fstype} used for {mountPath}'**
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath);
+
+  /// No description provided for @chooseYourLookPageTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Choose your look'**
+  String get chooseYourLookPageTitle;
+
+  /// No description provided for @chooseYourLookPageHeader.
+  ///
+  /// In en_US, this message translates to:
+  /// **'You can always change this later in the appearance settings.'**
+  String get chooseYourLookPageHeader;
+
+  /// No description provided for @chooseYourLookPageDarkSetting.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Dark'**
+  String get chooseYourLookPageDarkSetting;
+
+  /// No description provided for @chooseYourLookPageLightSetting.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Light'**
+  String get chooseYourLookPageLightSetting;
+
+  /// No description provided for @chooseYourLookPageLightBodyText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Everything is light and bright'**
+  String get chooseYourLookPageLightBodyText;
+
+  /// No description provided for @chooseYourLookPageDarkBodyText.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Hello darkness my old friend'**
+  String get chooseYourLookPageDarkBodyText;
+
+  /// No description provided for @installationCompleteTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Installation complete'**
+  String get installationCompleteTitle;
+
+  /// No description provided for @readyToUse.
+  ///
+  /// In en_US, this message translates to:
+  /// **'**{system}** is installed and ready to use.'**
+  String readyToUse(Object system);
+
+  /// No description provided for @restartInto.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Restart into {system}'**
+  String restartInto(Object system);
+
+  /// No description provided for @shutdown.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Shut Down'**
+  String get shutdown;
+
+  /// No description provided for @turnOffBitlockerTitle.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Turn off BitLocker'**
+  String get turnOffBitlockerTitle;
+
+  /// No description provided for @turnOffBitlockerDescription.
+  ///
+  /// In en_US, this message translates to:
+  /// **'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.'**
+  String get turnOffBitlockerDescription;
+
+  /// No description provided for @turnOffBitlockerLinkInstructions.
+  ///
+  /// In en_US, this message translates to:
+  /// **'For instructions, open this page on a phone or other device: <a href=\"https://{url}\">{url}</a>'**
+  String turnOffBitlockerLinkInstructions(Object url);
+
+  /// No description provided for @restartIntoWindows.
+  ///
+  /// In en_US, this message translates to:
+  /// **'Restart Into Windows'**
+  String get restartIntoWindows;
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['en', 'es', 'fr', 'it', 'nl', 'oc', 'pt', 'ru'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+
+  // Lookup logic when language+country codes are specified.
+  switch (locale.languageCode) {
+    case 'en': {
+  switch (locale.countryCode) {
+    case 'US': return AppLocalizationsEnUs();
+   }
+  break;
+   }
+    case 'es': {
+  switch (locale.countryCode) {
+    case 'ES': return AppLocalizationsEsEs();
+   }
+  break;
+   }
+    case 'fr': {
+  switch (locale.countryCode) {
+    case 'FR': return AppLocalizationsFrFr();
+   }
+  break;
+   }
+    case 'it': {
+  switch (locale.countryCode) {
+    case 'IT': return AppLocalizationsItIt();
+   }
+  break;
+   }
+    case 'nl': {
+  switch (locale.countryCode) {
+    case 'NL': return AppLocalizationsNlNl();
+   }
+  break;
+   }
+    case 'oc': {
+  switch (locale.countryCode) {
+    case 'FR': return AppLocalizationsOcFr();
+   }
+  break;
+   }
+    case 'pt': {
+  switch (locale.countryCode) {
+    case 'BR': return AppLocalizationsPtBr();
+   }
+  break;
+   }
+    case 'ru': {
+  switch (locale.countryCode) {
+    case 'RU': return AppLocalizationsRuRu();
+   }
+  break;
+   }
+  }
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'fr': return AppLocalizationsFr();
+    case 'it': return AppLocalizationsIt();
+    case 'nl': return AppLocalizationsNl();
+    case 'oc': return AppLocalizationsOc();
+    case 'pt': return AppLocalizationsPt();
+    case 'ru': return AppLocalizationsRu();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,746 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for English, as used in the United States (`en_US`).
+class AppLocalizationsEnUs extends AppLocalizationsEn {
+  AppLocalizationsEnUs(): super('en_US');
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -1,0 +1,548 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Spanish Castilian (`es`).
+class AppLocalizationsEs extends AppLocalizations {
+  AppLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Spanish Castilian, as used in Spain (`es_ES`).
+class AppLocalizationsEsEs extends AppLocalizationsEs {
+  AppLocalizationsEsEs(): super('es_ES');
+
+  @override
+  String get appTitle => 'Instalador de Ubuntu para escritorio';
+
+  @override
+  String get windowTitle => 'Instalar Ubuntu';
+
+  @override
+  String get restartButtonText => 'Reiniciar';
+
+  @override
+  String get welcome => 'Bienvenido';
+
+  @override
+  String get tryOrInstallPageTitle => 'Probar o instalar';
+
+  @override
+  String get repairInstallation => 'Reparar instalación';
+
+  @override
+  String get repairInstallationDescription => 'Al reparar se reinstalarán todos los programas instalados sin tocar los documentos ni la configuración.';
+
+  @override
+  String get tryUbuntu => 'Probar Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Puede probar Ubuntu sin hacer ningún cambio en su equipo.';
+
+  @override
+  String get installUbuntu => 'Instalar Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Instalar Ubuntu junto con (o reemplazando) su sistema operativo actual. No debería tardar mucho.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Aquí puede leer las <a href=\"$url\">notas de lanzamiento</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Desactivar RST';
+
+  @override
+  String get turnOffRSTDescription => 'Este equipo utiliza Intel RST (Rapid Storage Technology). Es necesario desactivar RST en Windows antes de instalar Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Para seguir las instrucciones, abra esta página en un dispositivo móvil u otro dispositivo: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Distribución del teclado';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Elija la distribución del teclado:';
+
+  @override
+  String get typeToTest => 'Escriba aquí para probar el teclado';
+
+  @override
+  String get detectLayout => 'Detectar la distribución del teclado';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Actualizaciones y otro software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => '¿Qué aplicaciones le gustaría instalar para comenzar?';
+
+  @override
+  String get normalInstallationTitle => 'Instalación normal';
+
+  @override
+  String get normalInstallationSubtitle => 'Navegador web, utilidades, aplicaciones de oficina, juegos y reproductores de contenido.';
+
+  @override
+  String get minimalInstallationTitle => 'Instalación mínima';
+
+  @override
+  String get minimalInstallationSubtitle => 'Navegador web y utilidades básicas.';
+
+  @override
+  String get otherOptions => 'Otras opciones';
+
+  @override
+  String get installThirdPartyTitle => 'Instalar software de terceros para controladores de gráficos y WiFi, así como formatos de contenido adicionales';
+
+  @override
+  String get installThirdPartySubtitle => 'Este software está sujeto a términos de licencia incluidos en su documentación. Algunos son propietarios.';
+
+  @override
+  String get allocateDiskSpace => 'Asignar espacio de disco';
+
+  @override
+  String get startInstallingButtonText => 'Comenzar la instalación';
+
+  @override
+  String get diskHeadersDevice => 'Dispositivo';
+
+  @override
+  String get diskHeadersType => 'Tipo';
+
+  @override
+  String get diskHeadersMountPoint => 'Punto de montaje';
+
+  @override
+  String get diskHeadersSize => 'Tamaño';
+
+  @override
+  String get diskHeadersUsed => 'Usado';
+
+  @override
+  String get diskHeadersSystem => 'Sistema';
+
+  @override
+  String get diskHeadersFormat => 'Formato';
+
+  @override
+  String get writeChangesToDisk => 'Escribir cambios en el disco';
+
+  @override
+  String get writeChangesFallbackSerial => 'disco';
+
+  @override
+  String get writeChangesDescription => 'Si continúa, los cambios listados más abajo se escribirán en los discos. Podrá hacer más cambios manualmente.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'Las tablas de partición de los siguientes dispositivos se modifican:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'Las particiones siguientes se van a formatear:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partición #$partitionNumber de $diskSerial ($diskPath) como $fstype usada para $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partición #$partitionNumber de $diskSerial ($diskPath) como';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partición # como $fstype usada para $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Seleccione el aspecto';
+
+  @override
+  String get chooseYourLookPageHeader => 'Puede cambiarlo después en la configuración de apariencia.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Oscuro';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Luminoso';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Luminoso y brillante';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Oscuro';
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -1,0 +1,548 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for French (`fr`).
+class AppLocalizationsFr extends AppLocalizations {
+  AppLocalizationsFr([String locale = 'fr']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for French, as used in France (`fr_FR`).
+class AppLocalizationsFrFr extends AppLocalizationsFr {
+  AppLocalizationsFrFr(): super('fr_FR');
+
+  @override
+  String get appTitle => 'Programme d’installation du bureau Ubuntu';
+
+  @override
+  String get windowTitle => 'Installer Ubuntu';
+
+  @override
+  String get restartButtonText => 'Redémarrer';
+
+  @override
+  String get welcome => 'Bienvenue';
+
+  @override
+  String get tryOrInstallPageTitle => 'Essayer ou installer';
+
+  @override
+  String get repairInstallation => 'Réparer l’installation';
+
+  @override
+  String get repairInstallationDescription => 'La réparation réinstallera tous les logiciels installés en conservant les documents et les paramètres.';
+
+  @override
+  String get tryUbuntu => 'Essayer Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Vous pouvez essayer Ubuntu sans appliquer aucun changement à votre ordinateur.';
+
+  @override
+  String get installUbuntu => 'Installer Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Installer Ubuntu à côté (ou en remplacement) de votre système d’exploitation actuel. Ceci ne devrait pas prendre trop longtemps.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Vous pouvez éventuellement lire les <a href=\"$url\">notes de publication</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Désactiver RST';
+
+  @override
+  String get turnOffRSTDescription => 'Cet ordinateur utilise la technologie RST (Rapid Storage Technology) d’Intel. Il est nécessaire de désactiver RST sous Windows avant d’installer Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Pour des instructions détaillées, veuillez ouvrir ce lien sur un téléphone ou un autre appareil : <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Disposition du clavier';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Indiquez la disposition de votre clavier :';
+
+  @override
+  String get typeToTest => 'Saisissez du texte ici pour tester votre clavier';
+
+  @override
+  String get detectLayout => 'Détecter la disposition du clavier';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Mises à jour et logiciels supplémentaires';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'Quelles applications souhaitez-vous installer pour commencer?';
+
+  @override
+  String get normalInstallationTitle => 'Installation normale';
+
+  @override
+  String get normalInstallationSubtitle => 'Navigateur internet, utilitaires, bureautique, jeux et lecteurs multimédia.';
+
+  @override
+  String get minimalInstallationTitle => 'Installation minimale';
+
+  @override
+  String get minimalInstallationSubtitle => 'Navigateur internet et utilitaires de base.';
+
+  @override
+  String get otherOptions => 'Autres options';
+
+  @override
+  String get installThirdPartyTitle => 'Installer des logiciels tiers pour le support du matériel graphique et Wi-Fi, ainsi que des formats multimédia supplémentaires';
+
+  @override
+  String get installThirdPartySubtitle => 'Ce logiciel est soumis à des termes de licence inclus dans sa documentation. Certains sont propriétaires.';
+
+  @override
+  String get allocateDiskSpace => 'Allouer de l’espace disque';
+
+  @override
+  String get startInstallingButtonText => 'Commencer l’installation';
+
+  @override
+  String get diskHeadersDevice => 'Disque';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Point de montage';
+
+  @override
+  String get diskHeadersSize => 'Taille';
+
+  @override
+  String get diskHeadersUsed => 'Utilisé';
+
+  @override
+  String get diskHeadersSystem => 'Système';
+
+  @override
+  String get diskHeadersFormat => 'Formatter';
+
+  @override
+  String get writeChangesToDisk => 'Appliquer les changements sur les disques';
+
+  @override
+  String get writeChangesFallbackSerial => 'disque';
+
+  @override
+  String get writeChangesDescription => 'Si vous continuez, les changements ci-dessous seront écrits sur les disques. Vous pourrez faire des changements ultérieurs manuellement.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'Les tables de partitions des périphériques suivants seront modifiées :';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'Les partitions suivantes seront formattées :';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition n° $partitionNumber de $diskSerial ($diskPath) de type $fstype en tant que $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition n° $partitionNumber de $diskSerial ($diskPath) en tant que';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition n° de type $fstype en tant que $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choisissez l’apparence';
+
+  @override
+  String get chooseYourLookPageHeader => 'Vous pourrez la changer ultérieurement dans les préférences d’apparence.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Sombre';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Clair';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Clair et brillant';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Sombre et foncé';
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -1,0 +1,429 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Italian (`it`).
+class AppLocalizationsIt extends AppLocalizations {
+  AppLocalizationsIt([String locale = 'it']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Italian, as used in Italy (`it_IT`).
+class AppLocalizationsItIt extends AppLocalizationsIt {
+  AppLocalizationsItIt(): super('it_IT');
+
+  @override
+  String get appTitle => 'Installer di Ubuntu Desktop';
+
+  @override
+  String get windowTitle => 'Installa Ubuntu';
+
+  @override
+  String get restartButtonText => 'Riavvia';
+
+  @override
+  String get welcome => 'Benvenuto';
+
+  @override
+  String get tryOrInstallPageTitle => 'Prova o installa';
+
+  @override
+  String get repairInstallation => 'Ripara installazione';
+
+  @override
+  String get repairInstallationDescription => 'La riparazione reinstallerá tutti i programmi senza toccare alcun documento o impostazione.';
+
+  @override
+  String get tryUbuntu => 'Prova Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Puoi provare Ubuntu senza apportare alcuna modifica al tuo computer.';
+
+  @override
+  String get installUbuntu => 'Installa Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Installa Ubuntu accanto (o al posto di) al tuo sistema operativo attuale. Questo non dovrebbe durare molto.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Forse vorresti leggere le <a href=\"$url\">informazioni di rilascio</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Disattiva RST';
+
+  @override
+  String get turnOffRSTDescription => 'Questo computer usa Intel RST (Rapid Storage Technology). Devi disattivare RST da Windows prima di poter installare Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Per istruzioni, apri questa pagina da un telefono o un altro dispositivo: <a href=\"https://$url\">$url</a>';
+  }
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -1,0 +1,441 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Dutch Flemish (`nl`).
+class AppLocalizationsNl extends AppLocalizations {
+  AppLocalizationsNl([String locale = 'nl']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Dutch Flemish, as used in Netherlands (`nl_NL`).
+class AppLocalizationsNlNl extends AppLocalizationsNl {
+  AppLocalizationsNlNl(): super('nl_NL');
+
+  @override
+  String get appTitle => 'Ubuntu Desktop instalatie programma';
+
+  @override
+  String get windowTitle => 'Ubuntu installeren';
+
+  @override
+  String get restartButtonText => 'Opnieuw opstarten';
+
+  @override
+  String get welcome => 'Welkom';
+
+  @override
+  String get tryOrInstallPageTitle => 'Uitproberen of installeren';
+
+  @override
+  String get repairInstallation => 'Repareer de installatie';
+
+  @override
+  String get repairInstallationDescription => 'Reparatie zal opnieuw alles installeren, zonder de bestaande documenten of instellingen aan te passen.';
+
+  @override
+  String get tryUbuntu => 'Ubuntu uitproberen';
+
+  @override
+  String get tryUbuntuDescription => 'U kunt Ubuntu uitproberen, zonder dat er aanpassingen op de bestaande installatie wordt gemaakt.';
+
+  @override
+  String get installUbuntu => 'Ubuntu installeren';
+
+  @override
+  String get installUbuntuDescription => 'Installeer Ubuntu naast (of in plaats van) het huidige besturingssysteem, dit zal niet lang duren.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'De wijzigingen in deze uitgave kunt U <a href=\"$url\">hier, in het Engels, lezen</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'RST uitschakelen';
+
+  @override
+  String get turnOffRSTDescription => 'Deze computer maakt gebruik van Intel RST (Rapid Storage Technology). Om Ubuntu te installeren, is het noodzakelijk om dit uit te schakelen.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Voor instructies, open de volgende website op uw telefoon of op een ander apparaat: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Toetsenbordindeling';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Kies uw toetsenbordindeling:';
+
+  @override
+  String get typeToTest => 'Type hieronder om het toetsenbord te testen';
+
+  @override
+  String get detectLayout => 'Toetsenbordindeling bepalen';
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -1,0 +1,548 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Occitan (`oc`).
+class AppLocalizationsOc extends AppLocalizations {
+  AppLocalizationsOc([String locale = 'oc']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Occitan, as used in France (`oc_FR`).
+class AppLocalizationsOcFr extends AppLocalizationsOc {
+  AppLocalizationsOcFr(): super('oc_FR');
+
+  @override
+  String get appTitle => 'Programa d\'installacion del burèu Ubuntu';
+
+  @override
+  String get windowTitle => 'Installar Ubuntu';
+
+  @override
+  String get restartButtonText => 'Reaviar';
+
+  @override
+  String get welcome => 'La benvenguda';
+
+  @override
+  String get tryOrInstallPageTitle => 'Ensajar o installar';
+
+  @override
+  String get repairInstallation => 'Reparar l\'installacion';
+
+  @override
+  String get repairInstallationDescription => 'La reparacion tornarà installar totes los logicials installats en servant los documents e los paramètres.';
+
+  @override
+  String get tryUbuntu => 'Ensajar Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Podètz ensajar Ubuntu sens aplicar cap de modificacion a vòstre ordenador.';
+
+  @override
+  String get installUbuntu => 'Installar Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Installar Ubuntu a costat (o a la plaça) de vòstre sistèma operatiu actual. Aquò deuriá pas trigar.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Podètz tanben legir las <a href=\"$url\">nòtas de version</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Desactivar RST';
+
+  @override
+  String get turnOffRSTDescription => 'Aqueste ordenador utiliza la tecnologia RST (Rapid Storage Technology) d\'Intel. Cal desactivar RST jos Windows abans d\'installar Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Per las consignas detalhadas, mercés de dobrir aqueste ligam sus un mobil o un autre aparelh : <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Agençament del clavièr';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Indicatz l\'agençament del clavièr :';
+
+  @override
+  String get typeToTest => 'Picatz de tèxt aquí per ensajar lo clavièr';
+
+  @override
+  String get detectLayout => 'Detectar l\'agençament del clavièr';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Mesas a jorn e logicials suplementaris';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'Quinas aplicacions volètz installar per començar ?';
+
+  @override
+  String get normalInstallationTitle => 'Installacion normala';
+
+  @override
+  String get normalInstallationSubtitle => 'Navegador internet, utilitaris, logicials de burèu, jòcs e lector multimèdia.';
+
+  @override
+  String get minimalInstallationTitle => 'Installacion minimala';
+
+  @override
+  String get minimalInstallationSubtitle => 'Navegador internet e utilitari de basa.';
+
+  @override
+  String get otherOptions => 'Autras opcions';
+
+  @override
+  String get installThirdPartyTitle => 'Installar de logicials tèrces pel material grafic e Wi-Fi e dels formats de mèdia suplementaris';
+
+  @override
+  String get installThirdPartySubtitle => 'Aqueste logicial es somés a de tèrmes de licéncia incluses dins sa documentacion. Certans son proprietaris.';
+
+  @override
+  String get allocateDiskSpace => 'Atribuir l\'espaci disc';
+
+  @override
+  String get startInstallingButtonText => 'Començar l\'installacion';
+
+  @override
+  String get diskHeadersDevice => 'Disc';
+
+  @override
+  String get diskHeadersType => 'Tipe';
+
+  @override
+  String get diskHeadersMountPoint => 'Punt de montatge';
+
+  @override
+  String get diskHeadersSize => 'Talha';
+
+  @override
+  String get diskHeadersUsed => 'Utilizat';
+
+  @override
+  String get diskHeadersSystem => 'Sistèma';
+
+  @override
+  String get diskHeadersFormat => 'Formatar';
+
+  @override
+  String get writeChangesToDisk => 'Aplicar las modificacions suls disques';
+
+  @override
+  String get writeChangesFallbackSerial => 'disc';
+
+  @override
+  String get writeChangesDescription => 'Se contunhatz, las modificacions çai-jos seràn escritas suls disques. Poiretz realizar de cambiaments mai tard a la man.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'Las taulas de particions dels periferics seguents seràn modificadas :';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'Las particions seguentas seràn formatadas :';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'particion n° $partitionNumber de $diskSerial ($diskPath) de tipe $fstype coma $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'particion n° $partitionNumber de $diskSerial ($diskPath) coma';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        particion n° de tipe $fstype coma $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Causissètz l\'aparéncia';
+
+  @override
+  String get chooseYourLookPageHeader => 'La poiretz cambiar mai tard en anant a las preferéncias d\'aparéncia.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Fosc';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Clar';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Clar e lusent';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Fosc e escur';
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -1,0 +1,429 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Portuguese (`pt`).
+class AppLocalizationsPt extends AppLocalizations {
+  AppLocalizationsPt([String locale = 'pt']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Portuguese, as used in Brazil (`pt_BR`).
+class AppLocalizationsPtBr extends AppLocalizationsPt {
+  AppLocalizationsPtBr(): super('pt_BR');
+
+  @override
+  String get appTitle => 'Instalador do Ubuntu Desktop';
+
+  @override
+  String get windowTitle => 'Instalar o Ubuntu';
+
+  @override
+  String get restartButtonText => 'Reiniciar';
+
+  @override
+  String get welcome => 'Bem-vindo';
+
+  @override
+  String get tryOrInstallPageTitle => 'Experimentar ou instalar';
+
+  @override
+  String get repairInstallation => 'Reparar instalação';
+
+  @override
+  String get repairInstallationDescription => 'A reparação reinstalará todos os softwares instalados sem alterar documentos ou configurações.';
+
+  @override
+  String get tryUbuntu => 'Experimentar o Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Você pode experimentar o Ubuntu sem fazer nenhuma alteração no seu computador.';
+
+  @override
+  String get installUbuntu => 'Instalar o Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Instalar o Ubuntu ao lado do (ou em substituição ao) seu sistema operacional atual. Isto não deve demorar muito.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Talvez você queira ler as <a href=\"$url\">notas de lançamento</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Desligue a RST';
+
+  @override
+  String get turnOffRSTDescription => 'Este computador usa Intel RST (Rapid Storage Technology). Você precisa desligar a RST no Windows antes de instalar o Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Abra esta página em um celular ou outro dispositivo para encontrar instruções: <a href=\"https://$url\">$url</a>';
+  }
+}

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -1,0 +1,441 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Russian (`ru`).
+class AppLocalizationsRu extends AppLocalizations {
+  AppLocalizationsRu([String locale = 'ru']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu Desktop Installer';
+
+  @override
+  String get windowTitle => 'Install Ubuntu';
+
+  @override
+  String get cancelButtonText => 'Cancel';
+
+  @override
+  String get changeButtonText => 'Change';
+
+  @override
+  String get okButtonText => 'OK';
+
+  @override
+  String get noButtonText => 'No';
+
+  @override
+  String get restartButtonText => 'Restart';
+
+  @override
+  String get revertButtonText => 'Revert';
+
+  @override
+  String get yesButtonText => 'Yes';
+
+  @override
+  String get welcome => 'Welcome';
+
+  @override
+  String get tryOrInstallPageTitle => 'Try or install';
+
+  @override
+  String get repairInstallation => 'Repair installation';
+
+  @override
+  String get repairInstallationDescription => 'Repairing will reinstall all installed software without touching documents or settings.';
+
+  @override
+  String get tryUbuntu => 'Try Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'You can try Ubuntu without making any changes to your computer.';
+
+  @override
+  String get installUbuntu => 'Install Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Install Ubuntu alongside (or instead of) your current operating system. This shouldn\'t take too long.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'You may wish to read the <a href=\"$url\">release notes</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Turn off RST';
+
+  @override
+  String get turnOffRSTDescription => 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing Ubuntu.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Keyboard layout';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Choose your keyboard layout:';
+
+  @override
+  String get typeToTest => 'Type here to test your keyboard';
+
+  @override
+  String get detectLayout => 'Detect Keyboard Layout';
+
+  @override
+  String get pressOneKey => 'Please press one of the following keys:';
+
+  @override
+  String get isKeyPresent => 'Is the following key present on your keyboard?';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Updates and other software';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'What apps would you like to install to start with?';
+
+  @override
+  String get normalInstallationTitle => 'Normal installation';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilities, office software, games and media players.';
+
+  @override
+  String get minimalInstallationTitle => 'Minimal installation';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser and basic utilities.';
+
+  @override
+  String get otherOptions => 'Other options';
+
+  @override
+  String get installThirdPartyTitle => 'Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats';
+
+  @override
+  String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
+
+  @override
+  String get allocateDiskSpace => 'Allocate disk space';
+
+  @override
+  String get startInstallingButtonText => 'Start Installing';
+
+  @override
+  String get diskHeadersDevice => 'Device';
+
+  @override
+  String get diskHeadersType => 'Type';
+
+  @override
+  String get diskHeadersMountPoint => 'Mount point';
+
+  @override
+  String get diskHeadersSize => 'Size';
+
+  @override
+  String get diskHeadersUsed => 'Used';
+
+  @override
+  String get diskHeadersSystem => 'System';
+
+  @override
+  String get diskHeadersFormat => 'Format';
+
+  @override
+  String get freeDiskSpace => 'free space';
+
+  @override
+  String get newPartitionTable => 'New partition table';
+
+  @override
+  String get bootLoaderDevice => 'Device for boot loader installation';
+
+  @override
+  String get partitionCreateTitle => 'Create partition';
+
+  @override
+  String get partitionEditTitle => 'Edit partition';
+
+  @override
+  String get partitionSizeLabel => 'Size:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Type for the new partition:';
+
+  @override
+  String get partitionTypePrimary => 'Primary';
+
+  @override
+  String get partitionTypeLogical => 'Logical';
+
+  @override
+  String get partitionLocationLabel => 'Location for the new partition:';
+
+  @override
+  String get partitionLocationBeginning => 'Beginning of this space';
+
+  @override
+  String get partitionLocationEnd => 'End of this space';
+
+  @override
+  String get partitionFormatLabel => 'Used as:';
+
+  @override
+  String get partitionFormatExt4 => 'Ext4 journaling file system';
+
+  @override
+  String get partitionFormatExt3 => 'Ext3 journaling file system';
+
+  @override
+  String get partitionFormatExt2 => 'Ext2 file system';
+
+  @override
+  String get partitionFormatBtrfs => 'btrfs journaling file system';
+
+  @override
+  String get partitionFormatJfs => 'JFS journaling file system';
+
+  @override
+  String get partitionFormatXfs => 'XFS journaling file system';
+
+  @override
+  String get partitionFormatFat16 => 'FAT16 file system';
+
+  @override
+  String get partitionFormatFat32 => 'FAT32 file system';
+
+  @override
+  String get partitionFormatSwap => 'swap area';
+
+  @override
+  String get partitionFormatBios => 'Reserved BIOS boot area';
+
+  @override
+  String get partitionFormatEfi => 'EFI System Partition';
+
+  @override
+  String get partitionFormatPhysical => 'physical volume for encryption';
+
+  @override
+  String get partitionFormatNone => 'do not use the partition';
+
+  @override
+  String get partitionErase => 'Format the partition';
+
+  @override
+  String get partitionMountPointLabel => 'Mount point:';
+
+  @override
+  String get whoAreYouPageTitle => 'Who are you?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Log in automatically';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Require my password to log in';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Your name';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'A name is required';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Your computer\'s name';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'The name it uses when it talks to other computers.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'A computer name is required';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Pick a username';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'A username is required';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'The username is invalid';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Choose a password';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A password is required';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirm your password';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'The passwords do not match';
+
+  @override
+  String get writeChangesToDisk => 'Write changes to disk';
+
+  @override
+  String get writeChangesFallbackSerial => 'disk';
+
+  @override
+  String get writeChangesDescription => 'If you continue, the changes listed below will be written to the disks. You will be able to make further changes manually.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'The partition tables of the following devices are changed:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+
+  @override
+  String writeChangesPartitionEntryPrimaryFull(Object partitionNumber, Object diskSerial, Object diskPath, Object fstype, Object mountPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as $fstype used for $mountPath';
+  }
+
+  @override
+  String writeChangesPartitionEntryPrimary(Object partitionNumber, Object diskSerial, Object diskPath) {
+    return 'partition #$partitionNumber of $diskSerial ($diskPath) as';
+  }
+
+  @override
+  String writeChangesPartitionEntrySecondary(Object fstype, Object mountPath) {
+    return '        partition # as $fstype used for $mountPath';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Choose your look';
+
+  @override
+  String get chooseYourLookPageHeader => 'You can always change this later in the appearance settings.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Dark';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Light';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Everything is light and bright';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Hello darkness my old friend';
+
+  @override
+  String get installationCompleteTitle => 'Installation complete';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** is installed and ready to use.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Restart into $system';
+  }
+
+  @override
+  String get shutdown => 'Shut Down';
+
+  @override
+  String get turnOffBitlockerTitle => 'Turn off BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'This computer uses Windows BitLocker encryption.\nYou need to turn off BitLocker in Windows before installing Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'For instructions, open this page on a phone or other device: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Restart Into Windows';
+}
+
+/// The translations for Russian, as used in Russian Federation (`ru_RU`).
+class AppLocalizationsRuRu extends AppLocalizationsRu {
+  AppLocalizationsRuRu(): super('ru_RU');
+
+  @override
+  String get appTitle => 'Установка Ubuntu';
+
+  @override
+  String get windowTitle => 'Установить Ubuntu';
+
+  @override
+  String get restartButtonText => 'Перезагрузить';
+
+  @override
+  String get welcome => 'Добро пожаловать';
+
+  @override
+  String get tryOrInstallPageTitle => 'Попробовать или установить';
+
+  @override
+  String get repairInstallation => 'Исправить установку';
+
+  @override
+  String get repairInstallationDescription => 'Исправление повторно устанавливает все установленные программы, не трогая документы и настройки.';
+
+  @override
+  String get tryUbuntu => 'Попробовать Ubuntu';
+
+  @override
+  String get tryUbuntuDescription => 'Вы можете попробовать Ubuntu без каких-либо изменений на вашем компьютере.';
+
+  @override
+  String get installUbuntu => 'Установить Ubuntu';
+
+  @override
+  String get installUbuntuDescription => 'Установить Ubuntu рядом (или вместо) вашей текущей операционной системы. Это не займёт много времени.';
+
+  @override
+  String releaseNotesLabel(Object url) {
+    return 'Вы также можете прочитать <a href=\"$url\">заметки о выпуске</a>.';
+  }
+
+  @override
+  String get turnOffRST => 'Выключить RST';
+
+  @override
+  String get turnOffRSTDescription => 'Двнный компьютер использует Intel RST (Rapid Storage Technology). Перед тем, как продолжить установку Ubuntu, необходимо отключить RST в Windows.';
+
+  @override
+  String instructionsForRST(Object url) {
+    return 'Для получения справки, откройте эту страницу на телефоне или другом устройстве: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Раскладка клавиатуры';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Выберите раскладку клавиатуры:';
+
+  @override
+  String get typeToTest => 'Введите здесь, чтобы проверить свою клавиатуру';
+
+  @override
+  String get detectLayout => 'Определить раскладку клавиатуры';
+}

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -42,7 +42,6 @@ dev_dependencies:
     path: ../ubuntu_test
 
 flutter:
-  generate: true
   uses-material-design: true
   assets:
     - assets/


### PR DESCRIPTION
Automatic `app_localizations*.dart` generation is frustrating to work
with, because either the generation is unreliable or IDEs have problems
resolving the files generated into `.dart_tool/flutter_gen/gen_l10n/`.
As a result, half of the IDE is very often red.

After this change, `flutter gen-l10n` (or `melos run gen-l10n`) needs
to be run manually when changing `.arb` files. Given that translations
do not change nearly as often as the source code, this makes the overall
development experience much more pleasant regardless of an extra manual
step.