### PR TITLE
subiquity_client: log responses

### DIFF
--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -11,6 +11,16 @@ export 'src/types.dart';
 /// @internal
 final log = Logger('subiquity_client');
 
+const _kMaxResponseLogLength = 120;
+
+String _formatResponseLog(String method, String response) {
+  var formatted = response;
+  if (response.length > _kMaxResponseLogLength) {
+    formatted = '${response.substring(0, _kMaxResponseLogLength)}...';
+  }
+  return '==> $method $formatted';
+}
+
 class SubiquityClient {
   late HttpUnixClient _client;
 
@@ -29,6 +39,7 @@ class SubiquityClient {
     if (response.statusCode != 200) {
       throw ("$method returned error ${response.statusCode}\n$responseStr");
     }
+    log.debug(() => _formatResponseLog(method, responseStr));
     return responseStr;
   }
 

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -6,11 +6,10 @@ import 'dart:async' as _i5;
 
 import 'package:dbus/dbus.dart' as _i2;
 import 'package:gsettings/src/gsettings.dart' as _i4;
-import 'package:http/http.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/src/types.dart' as _i3;
 import 'package:subiquity_client/subiquity_client.dart' as _i6;
-import 'package:subiquity_client/subiquity_server.dart' as _i8;
+import 'package:subiquity_client/subiquity_server.dart' as _i7;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -120,12 +119,6 @@ class MockSubiquityClient extends _i1.Mock implements _i6.SubiquityClient {
   _i5.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
-  @override
-  _i5.Future<void> checkStatus(
-          String? method, _i7.StreamedResponse? response) =>
-      (super.noSuchMethod(Invocation.method(#checkStatus, [method, response]),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
   _i5.Future<String> locale() =>
       (super.noSuchMethod(Invocation.method(#locale, []),
@@ -282,13 +275,13 @@ class MockSubiquityClient extends _i1.Mock implements _i6.SubiquityClient {
 /// A class which mocks [SubiquityServer].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
+class MockSubiquityServer extends _i1.Mock implements _i7.SubiquityServer {
   MockSubiquityServer() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<String> start(_i8.ServerMode? serverMode, [List<String>? args]) =>
+  _i5.Future<String> start(_i7.ServerMode? serverMode, [List<String>? args]) =>
       (super.noSuchMethod(Invocation.method(#start, [serverMode, args]),
           returnValue: Future<String>.value('')) as _i5.Future<String>);
   @override


### PR DESCRIPTION
Responses are truncated to max 120 chars because they can be large, such as the list of keyboard layouts and variants, which is requested on startup.

Example:
```
flutter: DEBUG subiquity_client: POST http://localhost/meta/mark_configured?endpoint_names=%5B%22mirror%22%2C%22proxy%22%2C%22network%22%2C%22ssh%22%2C%22snaplist%22%2C%22timezone%22%5D
flutter: DEBUG subiquity_client: GET http://localhost/storage/has_rst
flutter: DEBUG subiquity_client: GET http://localhost/storage/has_bitlocker
flutter: DEBUG subiquity_client: GET http://localhost/keyboard
flutter: DEBUG subiquity_client: RCV markConfigured(["mirror","proxy","network","ssh","snaplist","timezone"]) null
flutter: DEBUG subiquity_client: RCV hasRst() false
flutter: DEBUG subiquity_client: RCV hasBitLocker() []
flutter: DEBUG subiquity_client: RCV keyboard() {"setting": {"layout": "fi", "variant": "", "toggle": null}, "layouts": [{"code": "af", "name": "Afghani", "variants": [...
flutter: DEBUG subiquity_client: POST http://localhost/locale
flutter: DEBUG subiquity_client: RCV setLocale("en_US.UTF-8") null
```