### PR TITLE
Add SubiquityClient.isOpen

### DIFF
--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -1,5 +1,6 @@
 library subiquity_client;
 
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart';
 import 'package:logger/logger.dart';
@@ -23,9 +24,13 @@ String _formatResponseLog(String method, String response) {
 
 class SubiquityClient {
   late HttpUnixClient _client;
+  final _completer = Completer<bool>();
+
+  Future<bool> get isOpen => _completer.future;
 
   void open(String socketPath) {
     log.info('Opening socket $socketPath');
+    _completer.complete(true);
     _client = HttpUnixClient(socketPath);
   }
 

--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -24,14 +24,14 @@ String _formatResponseLog(String method, String response) {
 
 class SubiquityClient {
   late HttpUnixClient _client;
-  final _completer = Completer<bool>();
+  final _isOpen = Completer<bool>();
 
-  Future<bool> get isOpen => _completer.future;
+  Future<bool> get isOpen => _isOpen.future;
 
   void open(String socketPath) {
     log.info('Opening socket $socketPath');
-    _completer.complete(true);
     _client = HttpUnixClient(socketPath);
+    _isOpen.complete(true);
   }
 
   Future<void> close() {

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -10,6 +10,14 @@ void main() {
   late SubiquityClient _client;
   var _socketPath;
 
+  test('initialization', () async {
+    final client = SubiquityClient();
+    final isOpen = client.isOpen;
+    Future.delayed(Duration(milliseconds: 1)).then((_) => client.open(''));
+    await expectLater(isOpen, completes);
+    expect(await isOpen, isTrue);
+  });
+
   group('subiquity', () {
     setUpAll(() async {
       _testServer = SubiquityServer();

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -112,6 +112,9 @@ class MockSubiquityClient extends _i1.Mock implements _i6.SubiquityClient {
   }
 
   @override
+  _i5.Future<bool> get isOpen => (super.noSuchMethod(Invocation.getter(#isOpen),
+      returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+  @override
   void open(String? socketPath) =>
       super.noSuchMethod(Invocation.method(#open, [socketPath]),
           returnValueForMissingStub: null);


### PR DESCRIPTION
To let the UI know when subiquity is ready in a way that the UI is able
to visualize the waiting state without blocking the whole UI from
starting up.

Ref: #319