### PR TITLE
Write changes to disk: parse storage config only once

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
@@ -130,10 +130,7 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
     super.initState();
     final model = Provider.of<DiskStorageService>(context, listen: false);
     _storageConfig = model.storageConfig;
-  }
 
-  @override
-  Widget build(BuildContext context) {
     log.debug(
         'Storage config: ${JsonEncoder.withIndent('  ').convert(_storageConfig)}');
     for (var entry in _storageConfig!) {
@@ -203,7 +200,10 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
         }
       }
     }
+  }
 
+  @override
+  Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: Text(lang.writeChangesToDisk),


### PR DESCRIPTION
Previously, the list of disks and partitions was parsed and collected to an internal list every time `build()` was called. This caused the respective UI elements to accumulate when navigating back and forth, for example. Moving the parsing code to `initState()` ensures that the list is initialized once.