### PR TITLE
Write changes to disk: reset the storage when going back

### DIFF
--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -272,6 +272,14 @@ class SubiquityClient {
     await _receive("setStorage(${jsonEncode(config)})", response);
   }
 
+  Future<StorageResponse> resetStorage() async {
+    final request = Request('POST', Uri.http('localhost', 'storage/reset'));
+    final response = await _send(request);
+
+    final responseJson = await _receiveJson("resetStorage()", response);
+    return StorageResponse.fromJson(responseJson);
+  }
+
   Future<void> reboot({bool immediate = false}) async {
     final request = Request(
         'POST',

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -95,6 +95,12 @@ void main() {
       await _client.setStorage(sr.config!);
     });
 
+    test('reset storage', () async {
+      final response = await _client.resetStorage();
+      expect(response.status, ProbeStatus.DONE);
+      expect(response.origConfig, isNotNull);
+    });
+
     test('proxy', () async {
       // TODO: Re-enable once we figure out why _client.setProxy() sometimes hangs
       // await _client.setProxy('test');

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk_page.dart
@@ -270,7 +270,14 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
         }),
       ]),
       actions: <WizardAction>[
-        WizardAction.back(context),
+        WizardAction.back(
+          context,
+          onActivated: () async {
+            final client = Provider.of<SubiquityClient>(context, listen: false);
+            await client.resetStorage();
+            Wizard.of(context).back();
+          },
+        ),
         WizardAction.next(
           context,
           onActivated: () async {

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -234,6 +234,12 @@ class MockSubiquityClient extends _i1.Mock implements _i6.SubiquityClient {
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
+  _i5.Future<_i3.StorageResponse> resetStorage() =>
+      (super.noSuchMethod(Invocation.method(#resetStorage, []),
+              returnValue:
+                  Future<_i3.StorageResponse>.value(_FakeStorageResponse_7()))
+          as _i5.Future<_i3.StorageResponse>);
+  @override
   _i5.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),


### PR DESCRIPTION
This avoids that multiple disks get configured for guided partitioning when navigating back from the "Write changes to disk" page, and selecting another disk for guided partitioning.