### PR TITLE
WizardPage: fix AppBar theme

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -57,7 +57,11 @@ class WizardPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: title, automaticallyImplyLeading: false),
+      appBar: AppBar(
+        textTheme: Theme.of(context).textTheme,
+        title: title,
+        automaticallyImplyLeading: false,
+      ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[


### PR DESCRIPTION
The AppBar theme is not correctly taken from yaru.dart and is overwritten. This sets the theme correctly.

![fixed](https://user-images.githubusercontent.com/15329494/134488670-905ec070-63b6-4e82-bda6-145171392ccb.gif)

Closes #340 