### PR TITLE
Wsl setup run in snap

### DIFF
--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -74,7 +74,7 @@ abstract class SubiquityServer {
     }
 
     _serverProcess = await Process.start(
-      '/usr/bin/python3',
+      'python3',
       subiquityCmd,
       workingDirectory: subiquityPath,
       environment: _getEnvironment(subiquityPath),

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -65,6 +65,11 @@ abstract class SubiquityServer {
     ];
 
     var subiquityPath = p.join(Directory.current.path, 'subiquity');
+    String? workingDirectory;
+    // try using local subiquity
+    if (Directory(subiquityPath).existsSync()) {
+      workingDirectory = subiquityPath;
+    }
 
     // kill the existing test server if it's already running, so they don't pile
     // up on hot restarts
@@ -76,7 +81,7 @@ abstract class SubiquityServer {
     _serverProcess = await Process.start(
       'python3',
       subiquityCmd,
-      workingDirectory: subiquityPath,
+      workingDirectory: workingDirectory,
       environment: _getEnvironment(subiquityPath),
     ).then((process) {
       stdout.addStream(process.stdout);

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,7 @@ parts:
       - -lib/python*/site-packages/wheel*
       - -lib/python*/site-packages/probert
       - -bin/activate*
+      - -bin/python3*
       - -lib/python3.8/site-packages/__pycache__/six.cpython*
       - -lib/python3.8/site-packages/pip-*.dist-info/RECORD
       - -lib/python3.8/site-packages/wheel-*.dist-info/RECORD
@@ -86,6 +87,9 @@ parts:
     source-type: git
     source-commit: 2bb505172b5f97372eb1abd12ced4629e852504b
     requirements: [requirements.txt]
+    stage:
+      - "*"
+      - -bin/python3*
 
   subiquitydeps:
     plugin: nil


### PR DESCRIPTION
This is the dart part of the fixes for running WSL setup from the snap. Those are concentrated around the subprocess call for subiquity.

Note that we will need a more recent subiquity to be able to run it without dry-un, but as the variants changes will be needed as well, let’s update the submodule at this time.