### PR TITLE
subiquity: revert to fix install failures

### DIFF
--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -260,15 +260,13 @@ class SubiquityClient {
   }
 
   /// Get guided disk options.
-  Future<GuidedStorageResponse> getGuidedStorage(int minSize, bool wait) async {
+  Future<GuidedStorageResponse> getGuidedStorage(bool wait) async {
     final request = Request(
-        'GET',
-        Uri.http('localhost', 'storage/guided',
-            {'min_size': '$minSize', 'wait': '$wait'}));
+        'GET', Uri.http('localhost', 'storage/guided', {'wait': '$wait'}));
     final response = await _send(request);
 
     final responseJson =
-        await _receiveJson("getGuidedStorage('$minSize', '$wait')", response);
+        await _receiveJson("getGuidedStorage('$wait')", response);
     return GuidedStorageResponse.fromJson(responseJson);
   }
 

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -25,8 +25,8 @@ void main() {
       _socketPath = await _testServer.start(ServerMode.DRY_RUN, [
         '--machine-config',
         'examples/simple.json',
-        '--source-catalog',
-        '../test/install-sources.yaml'
+        // '--source-catalog',
+        // '../test/install-sources.yaml'
       ]);
       _client.open(_socketPath);
     });
@@ -42,6 +42,7 @@ void main() {
       await _client.setVariant(Variant.DESKTOP);
     });
 
+    /*
     test('source', () async {
       final expected = SourceSelectionAndSetting(sources: <SourceSelection>[
         SourceSelection(
@@ -77,6 +78,7 @@ void main() {
       actual = await _client.source();
       expect(actual.currentId, 'synthesized');
     });
+     */
 
     test('locale', () async {
       await _client.setLocale('en_US.UTF-8');

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -112,7 +112,7 @@ void main() {
     });
 
     test('guided storage', () async {
-      var gs = await _client.getGuidedStorage(0, true);
+      var gs = await _client.getGuidedStorage(true);
       expect(gs.disks, isNotEmpty);
       expect(gs.disks?[0].size, isNot(0));
 

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -73,7 +73,7 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
         WizardAction.next(
           context,
           onActivated: () async {
-            await model.selectInstallationSource();
+            // await model.selectInstallationSource();
             Wizard.of(context).next();
           },
         ),

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -17,7 +17,7 @@ class DiskStorageService {
   List<dynamic>? get storageConfig => _storageResponse?.config;
 
   Future<List<Disk>> getGuidedStorage() {
-    return _client.getGuidedStorage(0, true).then((r) {
+    return _client.getGuidedStorage(true).then((r) {
       log.debug(r.disks);
       _response = r;
       return r.disks ?? <Disk>[];

--- a/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
@@ -117,7 +117,7 @@ void main() {
     await tester.tap(continueButton);
     await tester.pumpAndSettle();
 
-    verify(model.selectInstallationSource()).called(1);
+    // verify(model.selectInstallationSource()).called(1);
     expect(find.text('Next page'), findsOneWidget);
   });
 


### PR DESCRIPTION
For yet unknown reasons, running the install from current master
(snap 0+git.d623e92 2021-09-23 (106)) will fail in curtin.
This revert allows install success again while we figure out what happened.