### PR TITLE
WSL Advanced setup: allow mount location end with slash

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
@@ -39,7 +39,7 @@ class AdvancedSetupModel extends ChangeNotifier {
   /// Returns `true` if the mount location is valid.
   static bool isValidMountLocation(String? path) {
     if (path == null || path.isEmpty) return true;
-    return p.isAbsolute(path) && !path.endsWith(p.separator);
+    return p.isAbsolute(path);
   }
 
   /// Whether the current input is valid.

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_model_test.dart
@@ -86,8 +86,8 @@ void main() {
     }
 
     testValid('', isTrue);
-    testValid('/', isFalse);
-    testValid('/absolute/dir/', isFalse);
+    testValid('/', isTrue);
+    testValid('/absolute/dir/', isTrue);
     testValid('/absolute/file', isTrue);
     testValid('relative/dir/', isFalse);
     testValid('relative/file', isFalse);


### PR DESCRIPTION
Even the default value of the mount location is `/mnt/`.