### PR TITLE
Upgrade `wizard_router` and isolate the dependency into `ubuntu_wizard`

### DIFF
--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   provider: ^6.0.0
   subiquity_client:
     path: ../subiquity_client
-  wizard_router: ^0.2.0
+  wizard_router: ^0.4.0
   yaru: ^0.1.4
 
 dev_dependencies:

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:wizard_router/wizard_router.dart';
+import 'package:ubuntu_wizard/widgets.dart';
 
 import 'pages.dart';
 import 'routes.dart';

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   ubuntu_wizard:
     path: ../ubuntu_wizard
   url_launcher: ^6.0.9
-  wizard_router: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
`Wizard.next()` returns now a future that completes if/when the wizard
returns back to the awaiting page. This mechanism can be used to reset
the previously selected guided storage from within the guided storage
selection page.

Ref: #318