### PR TITLE
Set the log level to debug in the snap environment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ apps:
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
       GIO_MODULE_DIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gio/modules
       LIVE_RUN: 1
+      LOG_LEVEL: debug
 
   probert:
     command: bin/probert


### PR DESCRIPTION
There is almost nothing logged at the moment and we will need debug information as more users try the new installer