### PR TITLE
Remove outdated TODO-comment

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -264,7 +264,6 @@ class WSLConfigurationBase with _$WSLConfigurationBase {
       _$WSLConfigurationBaseFromJson(json);
 }
 
-// TODO: remove all common attributes with WSLConfigurationBase
 @freezed
 class WSLConfigurationAdvanced with _$WSLConfigurationAdvanced {
   const factory WSLConfigurationAdvanced({


### PR DESCRIPTION
Duplicate properties in WSLConfigurationBase vs. WSLConfigurationAdvanced
were eventually removed but the TODO-comment was left behind...