### PR TITLE
Add hidden --initial-route command-line argument for integration testing

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -12,7 +12,10 @@ import 'routes.dart';
 class UbuntuDesktopInstallerApp extends StatelessWidget {
   const UbuntuDesktopInstallerApp({
     Key? key,
+    this.initialRoute,
   }) : super(key: key);
+
+  final String? initialRoute;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +32,7 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       localizationsDelegates: localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: _UbuntuDesktopInstallerWizard.create(context),
+      home: _UbuntuDesktopInstallerWizard.create(context, initialRoute),
     );
   }
 }
@@ -37,13 +40,16 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
 class _UbuntuDesktopInstallerWizard extends StatefulWidget {
   const _UbuntuDesktopInstallerWizard({
     Key? key,
+    this.initialRoute,
   }) : super(key: key);
 
-  static Widget create(BuildContext context) {
+  final String? initialRoute;
+
+  static Widget create(BuildContext context, String? initialRoute) {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => _UbuntuDesktopInstallerModel(client),
-      child: _UbuntuDesktopInstallerWizard(),
+      child: _UbuntuDesktopInstallerWizard(initialRoute: initialRoute),
     );
   }
 
@@ -67,7 +73,7 @@ class _UbuntuDesktopInstallerWizardState
     final model = Provider.of<_UbuntuDesktopInstallerModel>(context);
 
     return Wizard(
-      initialRoute: Routes.welcome,
+      initialRoute: widget.initialRoute ?? Routes.welcome,
       routes: <String, WidgetBuilder>{
         Routes.welcome: WelcomePage.create,
         Routes.tryOrInstall: TryOrInstallPage.create,

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -18,7 +18,7 @@ void main(List<String> args) {
   final subiquityServer = SubiquityServer();
 
   runWizardApp(
-    UbuntuDesktopInstallerApp(),
+    UbuntuDesktopInstallerApp(initialRoute: options['initial-route']),
     options: options,
     subiquityClient: subiquityClient,
     subiquityServer: subiquityServer,

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -85,7 +85,7 @@ class _WelcomePageState extends State<WelcomePage> {
         ),
       ),
       actions: <WizardAction>[
-        WizardAction.back(context, enabled: false),
+        WizardAction.back(context),
         WizardAction.next(
           context,
           onActivated: () {

--- a/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
@@ -31,7 +31,9 @@ void main() {
         child: MaterialApp(
           supportedLocales: AppLocalizations.supportedLocales,
           localizationsDelegates: localizationsDelegates,
-          home: InstallationTypePage(),
+          home: Wizard(
+            routes: {'/': (_) => InstallationTypePage()},
+          ),
         ),
       ),
     );

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -115,6 +115,7 @@ ArgResults? parseCommandLine(
   parser.addFlag('dry-run',
       defaultsTo: io.Platform.environment['LIVE_RUN'] != '1',
       help: 'Run Subiquity server in dry-run mode');
+  parser.addOption('initial-route', hide: true);
   parser.addOption(
     'log-file',
     valueHelp: 'path',

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -28,7 +28,7 @@ class WizardAction {
     return WizardAction(
       label: UbuntuLocalizations.of(context).backAction,
       visible: visible,
-      enabled: enabled,
+      enabled: enabled ?? Wizard.of(context).hasPrevious,
       onActivated: () {
         if (onActivated != null) {
           onActivated();

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -134,13 +134,17 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
-        home: Builder(builder: (context) {
-          return WizardPage(
-            actions: <WizardAction>[
-              WizardAction.back(context),
-              WizardAction.next(context),
-            ],
-          );
+        home: Wizard(routes: {
+          '/': (_) {
+            return Builder(builder: (context) {
+              return WizardPage(
+                actions: <WizardAction>[
+                  WizardAction.back(context),
+                  WizardAction.next(context),
+                ],
+              );
+            });
+          }
         }),
       ),
     );

--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -9,9 +9,11 @@ import 'wizard.dart';
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({
     Key? key,
+    this.initialRoute,
     this.reconfigure = false,
   }) : super(key: key);
 
+  final String? initialRoute;
   final bool reconfigure;
 
   @override
@@ -29,7 +31,9 @@ class UbuntuWslSetupApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       localizationsDelegates: localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: reconfigure ? UbuntuWslReconfigureWizard() : UbuntuWslSetupWizard(),
+      home: reconfigure
+          ? UbuntuWslReconfigureWizard(initialRoute: initialRoute)
+          : UbuntuWslSetupWizard(initialRoute: initialRoute),
     );
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -9,7 +9,10 @@ void main(List<String> args) {
     parser.addFlag('reconfigure');
   })!;
   runWizardApp(
-    UbuntuWslSetupApp(reconfigure: options['reconfigure'] == true),
+    UbuntuWslSetupApp(
+      initialRoute: options['initial-route'],
+      reconfigure: options['reconfigure'] == true,
+    ),
     options: options,
     subiquityClient: SubiquityClient(),
     subiquityServer: SubiquityServer.wsl(),

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -79,7 +79,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
         ),
       ),
       actions: [
-        WizardAction.back(context, enabled: false),
+        WizardAction.back(context),
         WizardAction.next(
           context,
           onActivated: () {

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -5,12 +5,17 @@ import 'pages.dart';
 import 'routes.dart';
 
 class UbuntuWslSetupWizard extends StatelessWidget {
-  const UbuntuWslSetupWizard({Key? key}) : super(key: key);
+  const UbuntuWslSetupWizard({
+    Key? key,
+    this.initialRoute,
+  }) : super(key: key);
+
+  final String? initialRoute;
 
   @override
   Widget build(BuildContext context) {
     return Wizard(
-      initialRoute: Routes.selectLanguage,
+      initialRoute: initialRoute ?? Routes.selectLanguage,
       routes: <String, WidgetBuilder>{
         Routes.selectLanguage: SelectLanguagePage.create,
         Routes.profileSetup: ProfileSetupPage.create,
@@ -33,12 +38,17 @@ class UbuntuWslSetupWizard extends StatelessWidget {
 }
 
 class UbuntuWslReconfigureWizard extends StatelessWidget {
-  const UbuntuWslReconfigureWizard({Key? key}) : super(key: key);
+  const UbuntuWslReconfigureWizard({
+    Key? key,
+    this.initialRoute,
+  }) : super(key: key);
+
+  final String? initialRoute;
 
   @override
   Widget build(BuildContext context) {
     return Wizard(
-      initialRoute: Routes.advancedSetup,
+      initialRoute: initialRoute ?? Routes.advancedSetup,
       routes: <String, WidgetBuilder>{
         Routes.advancedSetup: AdvancedSetupPage.create,
         Routes.configurationUI: ConfigurationUIPage.create,


### PR DESCRIPTION
This allows integration tests jump straight on a specific page.

For example, if an integration test wants to test navigation to the
"Turn off RST" or "Turn off BitLocker" pages, the test doesn't need to
navigate through half a dozen pages _and_ enter irrelevant input
values on the way to the target page. With help of --initial-route, the
test can jump straight on the page before and test that the wizard
shows the correct page when pressing "Continue".