### PR TITLE
Unblock loading the UI while waiting for subiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -17,6 +17,8 @@ export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
 
 const _kSystemdUnit = 'snap.ubuntu-desktop-installer.subiquity-server.service';
 
+enum AppStatus { loading, ready }
+
 void runInstallerApp(List<String> args, {FlavorData? flavor}) {
   final options = parseCommandLine(args, onPopulateOptions: (parser) {
     parser.addOption('machine-config',
@@ -30,10 +32,18 @@ void runInstallerApp(List<String> args, {FlavorData? flavor}) {
 
   final journalUnit = isLiveRun(options) ? _kSystemdUnit : null;
 
+  final appStatus = ValueNotifier(AppStatus.loading);
+
   runWizardApp(
-    UbuntuDesktopInstallerApp(
-      flavor: flavor,
-      initialRoute: options['initial-route'],
+    ValueListenableBuilder<AppStatus>(
+      valueListenable: appStatus,
+      builder: (context, value, child) {
+        return UbuntuDesktopInstallerApp(
+          appStatus: value,
+          flavor: flavor,
+          initialRoute: options['initial-route'],
+        );
+      },
     ),
     options: options,
     subiquityClient: subiquityClient,
@@ -58,6 +68,7 @@ void runInstallerApp(List<String> args, {FlavorData? flavor}) {
       Provider(create: (_) => UdevService()),
     ],
     onInitSubiquity: (client) {
+      appStatus.value = AppStatus.ready;
       client.setVariant(Variant.DESKTOP);
       client.setTimezone('geoip');
     },
@@ -69,11 +80,13 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
     Key? key,
     this.initialRoute,
     FlavorData? flavor,
+    this.appStatus = AppStatus.ready,
   })  : flavor = flavor ?? defaultFlavor,
         super(key: key);
 
   final String? initialRoute;
   final FlavorData flavor;
+  final AppStatus appStatus;
 
   static FlavorData get defaultFlavor {
     return FlavorData(
@@ -100,8 +113,36 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         localizationsDelegates: localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: _UbuntuDesktopInstallerWizard.create(context, initialRoute),
+        home: buildApp(context),
       ),
+    );
+  }
+
+  Widget buildApp(BuildContext context) {
+    switch (appStatus) {
+      case AppStatus.loading:
+        return _UbuntuDesktopInstallerLoadingPage();
+      case AppStatus.ready:
+        return _UbuntuDesktopInstallerWizard.create(context, initialRoute);
+    }
+  }
+}
+
+class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
+  const _UbuntuDesktopInstallerLoadingPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return WizardPage(
+      title: Text(AppLocalizations.of(context).welcome),
+      content: FractionallySizedBox(
+        widthFactor: 0.5,
+        child: RoundedContainer(),
+      ),
+      actions: <WizardAction>[
+        WizardAction.back(context, enabled: false),
+        WizardAction.next(context, enabled: false),
+      ],
     );
   }
 }

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -52,21 +52,23 @@ Future<void> runWizardApp(
 
   final serverMode = isLiveRun(options) ? ServerMode.LIVE : ServerMode.DRY_RUN;
 
-  await subiquityServer
+  subiquityServer
       .start(serverMode, args: serverArgs, environment: serverEnvironment)
-      .then(subiquityClient.open);
+      .then((socketPath) {
+    subiquityClient.open(socketPath);
 
-  onInitSubiquity?.call(subiquityClient);
+    onInitSubiquity?.call(subiquityClient);
 
-  // Use the default values for a number of endpoints
-  // for which a UI page isn't implemented yet.
-  subiquityClient.markConfigured([
-    'mirror',
-    'proxy',
-    'network',
-    'ssh',
-    'snaplist',
-  ]);
+    // Use the default values for a number of endpoints
+    // for which a UI page isn't implemented yet.
+    subiquityClient.markConfigured([
+      'mirror',
+      'proxy',
+      'network',
+      'ssh',
+      'snaplist',
+    ]);
+  });
 
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();


### PR DESCRIPTION
Instead of showing an empty window until subiquity is up and running, allow the UI to be loaded in disabled state for better UX. Under normal circumstances, this should not take more than a second.