### PR TITLE
udev: add support for looking up block devices

### DIFF
--- a/packages/udev/example/example.dart
+++ b/packages/udev/example/example.dart
@@ -9,13 +9,13 @@ void main() async {
 
   print('Wired devices:');
   for (final wired in client.devices.where((d) => d.wired != null)) {
-    final device = udev.device(syspath: wired.udi);
+    final device = UdevDevice.fromSyspath(udev, syspath: wired.udi);
     print('\t${device?.vendor} ${device?.model}');
   }
 
   print('Wireless devices:');
   for (final wireless in client.devices.where((d) => d.wireless != null)) {
-    final device = udev.device(syspath: wireless.udi);
+    final device = UdevDevice.fromSyspath(udev, syspath: wireless.udi);
     print('\t${device?.vendor} ${device?.model}');
   }
 

--- a/packages/udev/ffigen.yaml
+++ b/packages/udev/ffigen.yaml
@@ -6,8 +6,9 @@ headers:
   entry-points:
     - '/usr/include/libudev.h'
 llvm-path:
-  # add 12 for ubuntu 21.04 (ffigen has paths 9-11)
+  # add 12-13 for ubuntu 21.04-21.10 (ffigen has paths 9-11)
   - '/usr/lib/llvm-12'
+  - '/usr/lib/llvm-13'
 structs:
   dependency-only: opaque
   include:
@@ -18,6 +19,7 @@ functions:
     - 'udev_new'
     - 'udev_unref'
     - 'udev_device_get_property_value'
+    - 'udev_device_new_from_subsystem_sysname'
     - 'udev_device_new_from_syspath'
     - 'udev_device_unref'
 macros:

--- a/packages/udev/lib/src/bindings.g.dart
+++ b/packages/udev/lib/src/bindings.g.dart
@@ -71,6 +71,26 @@ class Libudev {
       _udev_device_new_from_syspath_ptr
           .asFunction<_dart_udev_device_new_from_syspath>();
 
+  ffi.Pointer<udev_device> udev_device_new_from_subsystem_sysname(
+    ffi.Pointer<udev> udev,
+    ffi.Pointer<ffi.Int8> subsystem,
+    ffi.Pointer<ffi.Int8> sysname,
+  ) {
+    return _udev_device_new_from_subsystem_sysname(
+      udev,
+      subsystem,
+      sysname,
+    );
+  }
+
+  late final _udev_device_new_from_subsystem_sysname_ptr =
+      _lookup<ffi.NativeFunction<_c_udev_device_new_from_subsystem_sysname>>(
+          'udev_device_new_from_subsystem_sysname');
+  late final _dart_udev_device_new_from_subsystem_sysname
+      _udev_device_new_from_subsystem_sysname =
+      _udev_device_new_from_subsystem_sysname_ptr
+          .asFunction<_dart_udev_device_new_from_subsystem_sysname>();
+
   ffi.Pointer<ffi.Int8> udev_device_get_property_value(
     ffi.Pointer<udev_device> udev_device,
     ffi.Pointer<ffi.Int8> key,
@@ -121,6 +141,20 @@ typedef _c_udev_device_new_from_syspath = ffi.Pointer<udev_device> Function(
 typedef _dart_udev_device_new_from_syspath = ffi.Pointer<udev_device> Function(
   ffi.Pointer<udev> udev,
   ffi.Pointer<ffi.Int8> syspath,
+);
+
+typedef _c_udev_device_new_from_subsystem_sysname = ffi.Pointer<udev_device>
+    Function(
+  ffi.Pointer<udev> udev,
+  ffi.Pointer<ffi.Int8> subsystem,
+  ffi.Pointer<ffi.Int8> sysname,
+);
+
+typedef _dart_udev_device_new_from_subsystem_sysname = ffi.Pointer<udev_device>
+    Function(
+  ffi.Pointer<udev> udev,
+  ffi.Pointer<ffi.Int8> subsystem,
+  ffi.Pointer<ffi.Int8> sysname,
 );
 
 typedef _c_udev_device_get_property_value = ffi.Pointer<ffi.Int8> Function(

--- a/packages/udev/lib/src/udev.dart
+++ b/packages/udev/lib/src/udev.dart
@@ -37,16 +37,6 @@ class Udev {
     lib!.udev_unref(_udev);
     instance = null;
   }
-
-  /// Looks up the device object based on information found in `/sys/`,
-  /// annotated with properties from the udev-internal device database.
-  ///
-  /// [syspath] is any subdirectory of `/sys/`, with the restriction that a
-  /// subdirectory of `/sys/devices` (or a symlink to one) represents a real
-  /// device and as such must contain a `uevent` file.
-  UdevDevice? device({required String syspath}) {
-    return _devices[syspath] ??= UdevDevice._fromSyspath(_udev, syspath);
-  }
 }
 
 /// Provides APIs to introspect a device on the local system.
@@ -55,6 +45,38 @@ class UdevDevice {
   final Pointer<udev_device> _udev_device;
 
   UdevDevice._(this._udev_device);
+
+  /// Looks up the device object based on the provided [subsystem] and [sysname].
+  static UdevDevice? fromSysname(
+    Udev udev, {
+    required String subsystem,
+    required String sysname,
+  }) {
+    return udev._devices['$subsystem:$sysname'] ??=
+        _fromSysname(udev._udev, subsystem, sysname);
+  }
+
+  static UdevDevice? _fromSysname(
+      Pointer<udev> udev, String subsystem, String sysname) {
+    final csubsystem = subsystem.toNativeUtf8();
+    final csysname = sysname.toNativeUtf8();
+    final dev = Udev.lib!.udev_device_new_from_subsystem_sysname(
+        udev, csubsystem.cast(), csysname.cast());
+    malloc.free(csubsystem);
+    malloc.free(csysname);
+    if (dev == nullptr) return null;
+    return UdevDevice._(dev);
+  }
+
+  /// Looks up the device object based on information found in `/sys/`,
+  /// annotated with properties from the udev-internal device database.
+  ///
+  /// [syspath] is any subdirectory of `/sys/`, with the restriction that a
+  /// subdirectory of `/sys/devices` (or a symlink to one) represents a real
+  /// device and as such must contain a `uevent` file.
+  static UdevDevice? fromSyspath(Udev udev, {required String syspath}) {
+    return udev._devices[syspath] ??= _fromSyspath(udev._udev, syspath);
+  }
 
   static UdevDevice? _fromSyspath(Pointer<udev> udev, String syspath) {
     final cstr = syspath.toNativeUtf8();
@@ -66,16 +88,22 @@ class UdevDevice {
 
   void _dispose() => Udev.lib!.udev_device_unref(_udev_device);
 
-  /// Model name (`ID_MODEL_FROM_DATABASE`).
-  String get model => _getPropertyValue("ID_MODEL_FROM_DATABASE");
+  /// Model name (`ID_MODEL` or `ID_MODEL_FROM_DATABASE`).
+  String get model =>
+      _getPropertyValue('ID_MODEL_FROM_DATABASE') ??
+      _getPropertyValue('ID_MODEL') ??
+      '';
 
-  /// Vendor name (`ID_VENDOR_FROM_DATABASE`).
-  String get vendor => _getPropertyValue("ID_VENDOR_FROM_DATABASE");
+  /// Vendor name (`ID_VENDOR` or `ID_VENDOR_FROM_DATABASE`).
+  String get vendor =>
+      _getPropertyValue('ID_VENDOR_FROM_DATABASE') ??
+      _getPropertyValue('ID_VENDOR') ??
+      '';
 
-  String _getPropertyValue(String key) {
+  String? _getPropertyValue(String key) {
     final ckey = key.toNativeUtf8().cast<Int8>();
     final cval = Udev.lib!.udev_device_get_property_value(_udev_device, ckey);
-    if (cval == nullptr) return '';
+    if (cval == nullptr) return null;
     malloc.free(ckey);
     return cval.cast<Utf8>().toDartString();
   }


### PR DESCRIPTION
The device partitioning pages need to show pretty disk names.

For example:

```dart
final device = UdevDevice.fromSysname(udev, subsystem: 'block', sysname: 'sda');
print(device?.vendor); // "SanDisk"
print(device?.model); // "Ultra_Fit"
```