### PR TITLE
Pin test_api to 0.4.3 due to Flutter's incompatibility with 0.4.4

### DIFF
--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -24,3 +24,7 @@ dev_dependencies:
   freezed: ^0.14.1
   json_serializable: ^4.1.1
   test: ^1.17.0
+
+# https://github.com/dart-lang/test/issues/1591
+dependency_overrides:
+  test_api: 0.4.3

--- a/packages/udev/pubspec.yaml
+++ b/packages/udev/pubspec.yaml
@@ -13,3 +13,7 @@ dev_dependencies:
   effective_dart: ^1.3.1
   ffigen: ^2.4.2
   test: ^1.17.7
+
+# https://github.com/dart-lang/test/issues/1591
+dependency_overrides:
+  test_api: 0.4.3


### PR DESCRIPTION
With the latest `test_api` 0.4.4, `flutter test` fails to run for pure Dart packages. For example:
```
$ flutter test
00:01 +0 -1: loading /path/to/ubuntu-desktop-installer/packages/subiquity_client/test/types_test.dart [E]                                                           
  Failed to load "/path/to/ubuntu-desktop-installer/packages/subiquity_client/test/types_test.dart": type 'Null' is not a subtype of type 'bool' in type cast
  package:test_api  RemoteListener.start.<fn>.<fn>
  
00:01 +0 -2: loading /path/to/ubuntu-desktop-installer/packages/subiquity_client/test/subiquity_client_test.dart [E]                                                
  Failed to load "/path/to/ubuntu-desktop-installer/packages/subiquity_client/test/subiquity_client_test.dart": type 'Null' is not a subtype of type 'bool' in type cast
  package:test_api  RemoteListener.start.<fn>.<fn>
  
00:01 +0 -2: Some tests failed.                           
```

https://github.com/dart-lang/test/issues/1591