### PR TITLE
Fix an exception on app close in live-run

### DIFF
--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -13,7 +13,7 @@ enum ServerMode { LIVE, DRY_RUN }
 final log = Logger('subiquity_server');
 
 abstract class SubiquityServer {
-  late Process _serverProcess;
+  Process? _serverProcess;
 
   SubiquityServer._();
 
@@ -94,9 +94,9 @@ abstract class SubiquityServer {
       stderr.addStream(process.stderr);
       return process;
     });
-    log.info('Starting server (PID: ${_serverProcess.pid})');
+    log.info('Starting server (PID: ${_serverProcess!.pid})');
 
-    await _writePidFile(_serverProcess.pid);
+    await _writePidFile(_serverProcess!.pid);
   }
 
   static Future<void> _waitSubiquity(String socketPath) async {
@@ -142,8 +142,8 @@ abstract class SubiquityServer {
     try {
       await _pidFile().delete();
     } on FileSystemException catch (_) {}
-    _serverProcess.kill();
-    await _serverProcess.exitCode;
+    _serverProcess?.kill();
+    await _serverProcess?.exitCode;
   }
 }
 


### PR DESCRIPTION
In live-run mode, the server is not started by `SubiquityServer`.
=> Don't assume that a server process exists when the app is closed.

    flutter: INFO ubuntu_desktop_installer: Logging to /var/log/installer/ubuntu_desktop_installer.log
    flutter: INFO subiquity_client: Opening socket /run/subiquity/socket
    ...
    flutter: INFO subiquity_client: Closing socket /run/subiquity/socket
    [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: LateInitializationError: Field '_serverProcess@1178512876' has not been initialized.
    #0      SubiquityServer.stop (package:subiquity_client/subiquity_server.dart)
    <asynchronous suspension>
    #1      runWizardApp.<anonymous closure> (package:ubuntu_wizard/app.dart:70)
    <asynchronous suspension>