### PR TITLE
Force clean build_runner cache

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -37,7 +37,9 @@ scripts:
   # run build_runner to generate code in all packages
   generate: >
     melos exec -c 1 --fail-fast --depends-on="build_runner" -- \
-      dart run build_runner build --delete-conflicting-outputs
+      flutter pub run build_runner clean &&
+    melos exec -c 1 --fail-fast --depends-on="build_runner" -- \
+      flutter pub run build_runner build --delete-conflicting-outputs
 
   # run gen-l10n to generate localizations in all packages
   gen-l10n:

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
@@ -6,9 +6,9 @@ import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart'
     as _i2;
+import 'package:ubuntu_desktop_installer/services.dart' as _i3;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters


### PR DESCRIPTION
This makes the generation step slower, but should ensure deterministic output.