### PR TITLE
Revert "Pin test_api to 0.4.3 due to Flutter's incompatibility with 0…

### DIFF
--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -24,7 +24,3 @@ dev_dependencies:
   freezed: ^0.14.1
   json_serializable: ^4.1.1
   test: ^1.17.0
-
-# https://github.com/dart-lang/test/issues/1591
-dependency_overrides:
-  test_api: 0.4.3

--- a/packages/udev/pubspec.yaml
+++ b/packages/udev/pubspec.yaml
@@ -13,7 +13,3 @@ dev_dependencies:
   effective_dart: ^1.3.1
   ffigen: ^2.4.2
   test: ^1.17.7
-
-# https://github.com/dart-lang/test/issues/1591
-dependency_overrides:
-  test_api: 0.4.3


### PR DESCRIPTION
….4.4 (#379)"

This reverts commit a02f1479038c29a7aa6fa827c5900cb6adf8eb71. The issue
has been fixed: https://github.com/dart-lang/test/pull/1592.