### PR TITLE
CI: move code generation out of the analysis step

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -107,8 +107,12 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         if [ -n "$(git status --porcelain)" ]; then
-          echo "::warning ::Generated files may be outdated or untracked"
-          git status --porcelain
+          for f in $(git ls-files --modified); do
+            echo "::warning ::$f may be outdated"
+          done
+          for f in $(git ls-files --others --exclude-standard); do
+            echo "::warning ::$f may be untracked"
+          done
           git diff
           exit 1
         fi


### PR DESCRIPTION
Outdated generated files are detected in the "generate" job instead of the "analyze" job which is important to pass. A warning from the "generate" job is a good hint, but can be ignored.

a) The "analyze" job checks the formatting & runs the analyzer. No more code generation in this job.
b) For pull requests, the "generate" job warns about outdated files.
c) The "generate" workflow can be manually run to let the bot regenerate files (it's no longer automatic to avoid ping pong changes).