### PR TITLE
Skip the "Try or install" page

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -78,7 +78,8 @@ class _UbuntuDesktopInstallerWizardState
       initialRoute: widget.initialRoute ?? Routes.welcome,
       routes: <String, WidgetBuilder>{
         Routes.welcome: WelcomePage.create,
-        Routes.tryOrInstall: TryOrInstallPage.create,
+        // https://github.com/canonical/ubuntu-desktop-installer/issues/373
+        // Routes.tryOrInstall: TryOrInstallPage.create,
         if (model.hasRst) Routes.turnOffRST: TurnOffRSTPage.create,
         Routes.keyboardLayout: KeyboardLayoutPage.create,
         Routes.updatesOtherSoftware: UpdatesOtherSoftwarePage.create,


### PR DESCRIPTION
"Repair Ubuntu" is not supported, and "Try Ubuntu" is pointless in the live session.

Ref: #373