### PR TITLE
Fix subiquity error in WSL Profile setup

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -83,10 +83,10 @@ class KeyboardSetup with _$KeyboardSetup {
 @freezed
 class IdentityData with _$IdentityData {
   const factory IdentityData({
-    String? realname,
-    String? username,
-    @JsonKey(name: 'crypted_password') String? cryptedPassword,
-    String? hostname,
+    @Default('') String? realname,
+    @Default('') String? username,
+    @Default('') @JsonKey(name: 'crypted_password') String? cryptedPassword,
+    @Default('') String? hostname,
   }) = _IdentityData;
 
   factory IdentityData.fromJson(Map<String, dynamic> json) =>

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -1232,10 +1232,10 @@ class _$IdentityDataTearOff {
   const _$IdentityDataTearOff();
 
   _IdentityData call(
-      {String? realname,
-      String? username,
-      @JsonKey(name: 'crypted_password') String? cryptedPassword,
-      String? hostname}) {
+      {String? realname = '',
+      String? username = '',
+      @JsonKey(name: 'crypted_password') String? cryptedPassword = '',
+      String? hostname = ''}) {
     return _IdentityData(
       realname: realname,
       username: username,
@@ -1370,21 +1370,24 @@ class __$IdentityDataCopyWithImpl<$Res> extends _$IdentityDataCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_IdentityData implements _IdentityData {
   const _$_IdentityData(
-      {this.realname,
-      this.username,
-      @JsonKey(name: 'crypted_password') this.cryptedPassword,
-      this.hostname});
+      {this.realname = '',
+      this.username = '',
+      @JsonKey(name: 'crypted_password') this.cryptedPassword = '',
+      this.hostname = ''});
 
   factory _$_IdentityData.fromJson(Map<String, dynamic> json) =>
       _$_$_IdentityDataFromJson(json);
 
+  @JsonKey(defaultValue: '')
   @override
   final String? realname;
+  @JsonKey(defaultValue: '')
   @override
   final String? username;
   @override
   @JsonKey(name: 'crypted_password')
   final String? cryptedPassword;
+  @JsonKey(defaultValue: '')
   @override
   final String? hostname;
 

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -108,10 +108,10 @@ Map<String, dynamic> _$_$_KeyboardSetupToJson(_$_KeyboardSetup instance) =>
 
 _$_IdentityData _$_$_IdentityDataFromJson(Map<String, dynamic> json) {
   return _$_IdentityData(
-    realname: json['realname'] as String?,
-    username: json['username'] as String?,
+    realname: json['realname'] as String? ?? '',
+    username: json['username'] as String? ?? '',
     cryptedPassword: json['crypted_password'] as String?,
-    hostname: json['hostname'] as String?,
+    hostname: json['hostname'] as String? ?? '',
   );
 }
 

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -176,12 +176,8 @@ void main() {
       expect(id.cryptedPassword, '');
       expect(id.hostname, 'ubuntu-desktop');
 
-      newId = IdentityData(
-        realname: '',
-        username: '',
-        cryptedPassword: '',
-        hostname: '',
-      );
+      // empty defaults for null values
+      newId = IdentityData();
 
       await _client.setIdentity(newId);
 


### PR DESCRIPTION
The WSL Profile setup UI has no hostname field, but subiquity expects that none of the `IdentityData` fields are null. Specify the same empty defaults that are used in `subiquity/common/types.py`.