### PR TITLE
Resolve non-deterministic code generation issue

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/foundation.dart';
+import 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 import 'package:ubuntu_wizard/utils.dart';
 
 import '../../services.dart';
+
+export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 
 /// Models a disk.
 class DiskModel extends ChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -4,6 +4,8 @@ import 'package:ubuntu_wizard/utils.dart';
 
 import '../../services.dart';
 
+export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
+
 /// View model for [SelectGuidedStoragePage].
 class SelectGuidedStorageModel extends ChangeNotifier {
   /// Creates a new model with the given service.

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -1,8 +1,6 @@
 import 'package:logger/logger.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
-export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
-
 /// @internal
 final log = Logger('disk_storage');
 

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
@@ -6,9 +6,9 @@ import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart'
     as _i2;
-import 'package:ubuntu_desktop_installer/services.dart' as _i3;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters


### PR DESCRIPTION
It appears that exporting subiquity_client's Disk & Partition types from
view models instead of the disk storage service stabilizes the generated
output from build_runner.

It could be because the disk storage service has to be imported to both
the view and its model. When generating a mock model mock for testing,
the same data class types are visible via multiple import dependencies.