### PR TITLE
Revert snap config changes for single application instance activation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,8 +22,6 @@ apps:
 
   ubuntu-desktop-installer:
     command: bin/ubuntu_desktop_installer
-    slots: [dbus-ubuntu-desktop-installer]
-    common-id: com.canonical.ubuntu_desktop_installer
     desktop: bin/data/flutter_assets/assets/ubuntu-desktop-installer.desktop
     environment:
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
@@ -241,9 +239,3 @@ parts:
     stage:
       - usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
       - usr/share/drirc.d
-
-slots:
-  dbus-ubuntu-desktop-installer:
-    interface: dbus
-    bus: session
-    name: com.canonical.ubuntu_desktop_installer


### PR DESCRIPTION
This is a partial revert of 124c84abf6b757071a3f0b53f1e9a73a1b4df997 because the store rejects the snap with ' confinement 'classic' not allowed with plugs/slots '.

Original issue: #368