### PR TITLE
Fix Subiquity initialization in WSL

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -33,6 +33,9 @@ void main(List<String> args) {
       Provider(create: (_) => HostnameService()),
       Provider(create: (_) => KeyboardService()),
     ],
-    variant: Variant.DESKTOP,
+    onInitSubiquity: (client) {
+      client.setVariant(Variant.DESKTOP);
+      client.setTimezone('geoip');
+    },
   );
 }

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -19,6 +19,10 @@ import 'utils.dart';
 /// @internal
 final log = Logger(_appName);
 
+/// The signature of a callback for initializing the Subiquity [client], which
+/// is called when the server connection has been established.
+typedef SubiquityInitCallback = void Function(SubiquityClient client);
+
 /// Initializes and runs the given [app].
 ///
 /// Optionally, the Subiquity client] and server may be overridden for building
@@ -27,8 +31,8 @@ Future<void> runWizardApp(
   Widget app, {
   ArgResults? options,
   required SubiquityClient subiquityClient,
-  required Variant variant,
   required SubiquityServer subiquityServer,
+  SubiquityInitCallback? onInitSubiquity,
   List<String>? serverArgs,
   List<SingleChildWidget>? providers,
 }) async {
@@ -49,7 +53,7 @@ Future<void> runWizardApp(
       .start(serverMode, serverArgs)
       .then(subiquityClient.open);
 
-  subiquityClient.setVariant(variant);
+  onInitSubiquity?.call(subiquityClient);
 
   // Use the default values for a number of endpoints
   // for which a UI page isn't implemented yet.
@@ -60,7 +64,6 @@ Future<void> runWizardApp(
     'ssh',
     'snaplist',
   ]);
-  subiquityClient.setTimezone('geoip');
 
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -24,7 +24,7 @@ void main() {
       subiquityClient: client,
       subiquityServer: server,
       serverArgs: ['--foo', 'bar'],
-      variant: Variant.DESKTOP,
+      onInitSubiquity: (client) => client.setVariant(Variant.DESKTOP),
     );
     verify(server.start(ServerMode.DRY_RUN, ['--foo', 'bar'])).called(1);
     verify(client.open('socket path')).called(1);
@@ -39,7 +39,6 @@ void main() {
       Container(key: ValueKey('app')),
       subiquityClient: MockSubiquityClient(),
       subiquityServer: server,
-      variant: Variant.DESKTOP,
     );
 
     final app = find.byKey(ValueKey('app'));

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -20,6 +20,6 @@ void main(List<String> args) {
     options: options,
     subiquityClient: SubiquityClient(),
     subiquityServer: SubiquityServer.wsl(),
-    variant: variant,
+    onInitSubiquity: (client) => client.setVariant(variant),
   );
 }


### PR DESCRIPTION
In commit 04c3d4e9, the desktop installer was changed to request geo-IP
detection for the timezone. The problem is that such endpoint doesn't
exist in the WSL system setup, so an exception is thrown on startup:

    Unhandled Exception: setTimezone("geoip") returned error 404

This commit adds a callback for subiquity initialization routines to
make it straight-forward to make any variant-specific initialization
calls on startup, as soon as the connection has been established.