### PR TITLE
subiquity_client: restore timezone test

### DIFF
--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -340,23 +340,15 @@ void main() {
     });
 
     test('timezone', () async {
-      final systemTimezone =
-          Process.runSync('timedatectl', ['show', '-p', 'Timezone', '--value'])
-              .stdout
-              .toString()
-              .trim();
+      await _client.setTimezone('Pacific/Guam');
       var tzdata = await _client.timezone();
-      expect(tzdata.timezone, systemTimezone);
+      expect(tzdata.timezone, 'Pacific/Guam');
+      expect(tzdata.fromGeoIP, isFalse);
 
-      try {
-        await _client.setTimezone('Pacific/Guam');
-        tzdata = await _client.timezone();
-        expect(tzdata.timezone, 'Pacific/Guam');
-        expect(tzdata.fromGeoIP, isFalse);
-      } finally {
-        // Restore initial timezone to leave the test system in a clean state
-        await _client.setTimezone(systemTimezone);
-      }
+      await _client.setTimezone('geoip');
+      tzdata = await _client.timezone();
+      expect(tzdata.timezone, isNotNull);
+      expect(tzdata.fromGeoIP, isTrue);
     });
 
     test('ssh', () async {

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -357,9 +357,7 @@ void main() {
         // Restore initial timezone to leave the test system in a clean state
         await _client.setTimezone(systemTimezone);
       }
-    },
-        skip:
-            'fails on headless test systems (CI) because subiquity calls `timedatectl set-timezone`, which requires sudo');
+    });
 
     test('ssh', () async {
       var newSsh = SSHData(


### PR DESCRIPTION
subiquity no longer runs `timedatectl set-timezone` in dry-run mode: https://github.com/canonical/subiquity/commit/c79aa60