### PR TITLE
Upgrade stage package for libLLVM from 10 to 12.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,7 +191,7 @@ parts:
       - libglapi-mesa
       - libgraphite2-3
       - libxshmfence1
-      - libllvm10
+      - libllvm12
       - libpciaccess0
       - libvulkan1
       - shared-mime-info
@@ -218,7 +218,7 @@ parts:
       - usr/lib/*/libglapi*.so.*
       - usr/lib/*/libgraphite2*.so.*
       - usr/lib/*/libxshmfence*.so.*
-      - usr/lib/*/libLLVM-10.so.*
+      - usr/lib/*/libLLVM-12.so.*
       - usr/lib/*/libpciaccess*.so.*
       - usr/lib/*/libsensors*.so.*
       - usr/lib/*/libvulkan*.so.*


### PR DESCRIPTION
Version 10 was unused in the snap, and 12 is required anyway.
This saves 17MB on the final (xz-compressed) snap size.

Ref: #376.