### PR TITLE
Upgrade wizard_router for scoped route conditions

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -76,42 +76,50 @@ class _UbuntuDesktopInstallerWizardState
 
     return Wizard(
       initialRoute: widget.initialRoute ?? Routes.welcome,
-      routes: <String, WidgetBuilder>{
-        Routes.welcome: WelcomePage.create,
+      routes: <String, WizardRoute>{
+        Routes.welcome: const WizardRoute(
+          builder: WelcomePage.create,
+        ),
         // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-        // Routes.tryOrInstall: TryOrInstallPage.create,
-        if (model.hasRst) Routes.turnOffRST: TurnOffRSTPage.create,
-        Routes.keyboardLayout: KeyboardLayoutPage.create,
-        Routes.updatesOtherSoftware: UpdatesOtherSoftwarePage.create,
+        // Routes.tryOrInstall: WizardRoute(
+        //   builder: TryOrInstallPage.create,
+        //   onNext: (settings) {
+        //     switch (settings.arguments as Option?) {
+        //       case Option.repairUbuntu:
+        //         return Routes.repairUbuntu;
+        //       case Option.tryUbuntu:
+        //         return Routes.tryUbuntu;
+        //       default:
+        //         if (model.hasRst) return Routes.turnOffRST;
+        //         return Routes.keyboardLayout;
+        //     }
+        //   },
+        // ),
+        if (model.hasRst)
+          Routes.turnOffRST: const WizardRoute(
+            builder: TurnOffRSTPage.create,
+          ),
+        Routes.keyboardLayout: const WizardRoute(
+          builder: KeyboardLayoutPage.create,
+        ),
+        Routes.updatesOtherSoftware: const WizardRoute(
+          builder: UpdatesOtherSoftwarePage.create,
+        ),
         if (model.hasSecureBoot)
-          Routes.configureSecureBoot: ConfigureSecureBootPage.create,
+          Routes.configureSecureBoot: const WizardRoute(
+            builder: ConfigureSecureBootPage.create,
+          ),
         if (model.hasEncryption)
-          Routes.chooseSecurityKey: ChooseSecurityKeyPage.create,
+          Routes.chooseSecurityKey: const WizardRoute(
+            builder: ChooseSecurityKeyPage.create,
+          ),
         if (model.hasBitLocker)
-          Routes.turnOffBitlocker: TurnOffBitLockerPage.create,
-        Routes.installationType: InstallationTypePage.create,
-        Routes.selectGuidedStorage: SelectGuidedStoragePage.create,
-        Routes.allocateDiskSpace: AllocateDiskSpacePage.create,
-        Routes.writeChangesToDisk: WriteChangesToDiskPage.create,
-        Routes.whoAreYou: WhoAreYouPage.create,
-        // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-        // Routes.chooseYourLook: ChooseYourLookPage.create,
-        Routes.installationSlides: InstallationSlidesPage.create,
-        Routes.installationComplete: InstallationCompletePage.create,
-      },
-      onNext: (settings) {
-        switch (settings.name) {
-          case Routes.tryOrInstall:
-            switch (settings.arguments as Option?) {
-              case Option.repairUbuntu:
-                return Routes.repairUbuntu;
-              case Option.tryUbuntu:
-                return Routes.tryUbuntu;
-              default:
-                if (model.hasRst) return Routes.turnOffRST;
-                return Routes.keyboardLayout;
-            }
-          case Routes.installationType:
+          Routes.turnOffBitlocker: const WizardRoute(
+            builder: TurnOffBitLockerPage.create,
+          ),
+        Routes.installationType: WizardRoute(
+          builder: InstallationTypePage.create,
+          onNext: (settings) {
             if (settings.arguments == InstallationType.erase) {
               if (service.hasMultipleDisks) {
                 return Routes.selectGuidedStorage;
@@ -120,11 +128,31 @@ class _UbuntuDesktopInstallerWizardState
               }
             }
             return Routes.allocateDiskSpace;
-          case Routes.selectGuidedStorage:
-            return Routes.writeChangesToDisk;
-          default:
-            return null;
-        }
+          },
+        ),
+        Routes.selectGuidedStorage: WizardRoute(
+          builder: SelectGuidedStoragePage.create,
+          onNext: (settings) => Routes.writeChangesToDisk,
+        ),
+        Routes.allocateDiskSpace: const WizardRoute(
+          builder: AllocateDiskSpacePage.create,
+        ),
+        Routes.writeChangesToDisk: const WizardRoute(
+          builder: WriteChangesToDiskPage.create,
+        ),
+        Routes.whoAreYou: const WizardRoute(
+          builder: WhoAreYouPage.create,
+        ),
+        // https://github.com/canonical/ubuntu-desktop-installer/issues/373
+        // Routes.chooseYourLook: const WizardRoute(
+        //   builder: ChooseYourLookPage.create,
+        // ),
+        Routes.installationSlides: const WizardRoute(
+          builder: InstallationSlidesPage.create,
+        ),
+        Routes.installationComplete: const WizardRoute(
+          builder: InstallationCompletePage.create,
+        ),
       },
     );
   }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
@@ -36,7 +36,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           localizationsDelegates: localizationsDelegates,
           home: Wizard(
-            routes: {'/': (_) => AllocateDiskSpacePage()},
+            routes: {'/': WizardRoute(builder: (_) => AllocateDiskSpacePage())},
           ),
         ),
       ),
@@ -104,7 +104,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           localizationsDelegates: localizationsDelegates,
           home: Wizard(
-            routes: {'/': (_) => AllocateDiskSpacePage()},
+            routes: {'/': WizardRoute(builder: (_) => AllocateDiskSpacePage())},
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
@@ -114,8 +114,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -345,8 +349,12 @@ void main() {
           Provider<UdevService>(create: (_) => MockUdevService()),
         ],
         child: Wizard(
-          routes: {'/': AllocateDiskSpacePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: AllocateDiskSpacePage.create,
+              onNext: (settings) => '/',
+            )
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_desktop_installer/test/choose_security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key_page_test.dart
@@ -45,8 +45,8 @@ void main() {
       ],
       home: Wizard(
         routes: {
-          '/': (_) => buildPage(model),
-          '/next': (_) => const Text('Next'),
+          '/': WizardRoute(builder: (_) => buildPage(model)),
+          '/next': WizardRoute(builder: (_) => const Text('Next')),
         },
       ),
     );
@@ -121,7 +121,9 @@ void main() {
       localizationsDelegates: localizationsDelegates,
       home: Provider<SubiquityClient>.value(
         value: client,
-        child: Wizard(routes: {'/': ChooseSecurityKeyPage.create}),
+        child: Wizard(routes: {
+          '/': WizardRoute(builder: ChooseSecurityKeyPage.create),
+        }),
       ),
     ));
 

--- a/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
@@ -27,7 +27,7 @@ void main() {
           localizationsDelegates: localizationsDelegates,
           home: Wizard(
             routes: {
-              '/': ChooseYourLookPage.create,
+              '/': WizardRoute(builder: ChooseYourLookPage.create),
             },
           ),
         ),

--- a/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
@@ -20,14 +20,16 @@ void main() {
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
         routes: {
-          '/': (_) {
-            return Provider<InstallationCompleteModel>.value(
-              value: model,
-              child: InstallationCompletePage(),
-            );
-          },
+          '/': WizardRoute(
+            builder: (_) {
+              return Provider<InstallationCompleteModel>.value(
+                value: model,
+                child: InstallationCompletePage(),
+              );
+            },
+            onNext: (settings) => '/',
+          ),
         },
-        onNext: (settings) => '/',
       ),
     );
   }
@@ -62,7 +64,9 @@ void main() {
         home: Provider<SubiquityClient>(
           create: (_) => MockSubiquityClient(),
           child: Wizard(
-            routes: {'/': InstallationCompletePage.create},
+            routes: {
+              '/': WizardRoute(builder: InstallationCompletePage.create),
+            },
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
@@ -32,7 +32,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           localizationsDelegates: localizationsDelegates,
           home: Wizard(
-            routes: {'/': (_) => InstallationTypePage()},
+            routes: {'/': WizardRoute(builder: (_) => InstallationTypePage())},
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type_page_test.dart
@@ -46,8 +46,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -129,8 +133,12 @@ void main() {
           Provider(create: (_) => DiskStorageService(client)),
         ],
         child: Wizard(
-          routes: {'/': InstallationTypePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: InstallationTypePage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_page_test.dart
@@ -63,8 +63,8 @@ void main() {
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
         routes: {
-          '/': (_) => buildPage(model),
-          '/next': (_) => Text('Next page'),
+          '/': WizardRoute(builder: (_) => buildPage(model)),
+          '/next': WizardRoute(builder: (_) => Text('Next page')),
         },
       ),
     );
@@ -188,8 +188,12 @@ void main() {
             Provider<SubiquityClient>(create: (_) => MockSubiquityClient()),
           ],
           child: Wizard(
-            routes: {'/': KeyboardLayoutPage.create},
-            onNext: (settings) => '/',
+            routes: {
+              '/': WizardRoute(
+                builder: KeyboardLayoutPage.create,
+                onNext: (settings) => '/',
+              )
+            },
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -54,8 +54,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -130,8 +134,12 @@ void main() {
       home: Provider<DiskStorageService>.value(
         value: service,
         child: Wizard(
-          routes: {'/': SelectGuidedStoragePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: SelectGuidedStoragePage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
@@ -31,14 +31,9 @@ void main() {
       locale: Locale('en'),
       home: Wizard(
         routes: {
-          Routes.tryOrInstall: (_) => TryOrInstallPage(),
-          Routes.repairUbuntu: (context) => Text(Routes.repairUbuntu),
-          Routes.tryUbuntu: (context) => Text(Routes.tryUbuntu),
-          Routes.keyboardLayout: (context) => Text(Routes.keyboardLayout),
-        },
-        onNext: (settings) {
-          switch (settings.name) {
-            case Routes.tryOrInstall:
+          Routes.tryOrInstall: WizardRoute(
+            builder: (_) => TryOrInstallPage(),
+            onNext: (settings) {
               switch (model.option) {
                 case Option.repairUbuntu:
                   return Routes.repairUbuntu;
@@ -49,7 +44,17 @@ void main() {
                 default:
                   break;
               }
-          }
+            },
+          ),
+          Routes.repairUbuntu: WizardRoute(
+            builder: (context) => Text(Routes.repairUbuntu),
+          ),
+          Routes.tryUbuntu: WizardRoute(
+            builder: (context) => Text(Routes.tryUbuntu),
+          ),
+          Routes.keyboardLayout: WizardRoute(
+            builder: (context) => Text(Routes.keyboardLayout),
+          ),
         },
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
@@ -21,14 +21,16 @@ void main() {
         localizationsDelegates: localizationsDelegates,
         home: Wizard(
           routes: {
-            '/': (_) {
-              return Provider<TurnOffBitLockerModel>.value(
-                value: model,
-                child: TurnOffBitLockerPage(),
-              );
-            },
+            '/': WizardRoute(
+              builder: (_) {
+                return Provider<TurnOffBitLockerModel>.value(
+                  value: model,
+                  child: TurnOffBitLockerPage(),
+                );
+              },
+              onNext: (settings) => '/',
+            ),
           },
-          onNext: (settings) => '/',
         ),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
@@ -21,14 +21,16 @@ void main() {
         localizationsDelegates: localizationsDelegates,
         home: Wizard(
           routes: {
-            '/': (_) {
-              return Provider<TurnOffRSTModel>.value(
-                value: model,
-                child: TurnOffRSTPage(),
-              );
-            },
+            '/': WizardRoute(
+              builder: (_) {
+                return Provider<TurnOffRSTModel>.value(
+                  value: model,
+                  child: TurnOffRSTPage(),
+                );
+              },
+              onNext: (settings) => '/',
+            ),
           },
-          onNext: (settings) => '/',
         ),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
@@ -43,8 +43,8 @@ void main() {
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
         routes: {
-          '/': (_) => buildPage(model),
-          '/next': (_) => Text('Next page'),
+          '/': WizardRoute(builder: (_) => buildPage(model)),
+          '/next': WizardRoute(builder: (_) => Text('Next page')),
         },
       ),
     );
@@ -128,8 +128,12 @@ void main() {
       home: Provider<SubiquityClient>(
         create: (_) => MockSubiquityClient(),
         child: Wizard(
-          routes: {'/': UpdatesOtherSoftwarePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: UpdatesOtherSoftwarePage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -26,9 +26,10 @@ void main() {
       localizationsDelegates: localizationsDelegates,
       locale: Locale('en'),
       home: Wizard(
-        routes: <String, WidgetBuilder>{
-          Routes.welcome: (_) => WelcomePage(),
-          Routes.tryOrInstall: (context) => Text(Routes.tryOrInstall),
+        routes: <String, WizardRoute>{
+          Routes.welcome: WizardRoute(builder: (_) => WelcomePage()),
+          Routes.tryOrInstall:
+              WizardRoute(builder: (_) => Text(Routes.tryOrInstall)),
         },
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
@@ -51,8 +51,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
@@ -93,8 +93,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -141,8 +145,12 @@ void main() {
           ),
         ],
         child: Wizard(
-          routes: {'/': WriteChangesToDiskPage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: WriteChangesToDiskPage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   provider: ^6.0.0
   subiquity_client:
     path: ../subiquity_client
-  wizard_router: ^0.4.0
+  wizard_router: ^0.6.0
   yaru: ^0.1.4
 
 dev_dependencies:

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -135,7 +135,7 @@ void main() {
       MaterialApp(
         localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
         home: Wizard(routes: {
-          '/': (_) {
+          '/': WizardRoute(builder: (_) {
             return Builder(builder: (context) {
               return WizardPage(
                 actions: <WizardAction>[
@@ -144,7 +144,7 @@ void main() {
                 ],
               );
             });
-          }
+          }),
         }),
       ),
     );

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -16,22 +16,25 @@ class UbuntuWslSetupWizard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Wizard(
       initialRoute: initialRoute ?? Routes.selectLanguage,
-      routes: <String, WidgetBuilder>{
-        Routes.selectLanguage: SelectLanguagePage.create,
-        Routes.profileSetup: ProfileSetupPage.create,
-        Routes.advancedSetup: AdvancedSetupPage.create,
-        Routes.setupComplete: SetupCompletePage.create,
-      },
-      onNext: (settings) {
-        switch (settings.name) {
-          case Routes.profileSetup:
+      routes: <String, WizardRoute>{
+        Routes.selectLanguage: const WizardRoute(
+          builder: SelectLanguagePage.create,
+        ),
+        Routes.profileSetup: WizardRoute(
+          builder: ProfileSetupPage.create,
+          onNext: (settings) {
             if ((settings.arguments as bool?) == true) {
               return Routes.advancedSetup;
             }
             return Routes.setupComplete;
-          default:
-            return null;
-        }
+          },
+        ),
+        Routes.advancedSetup: const WizardRoute(
+          builder: AdvancedSetupPage.create,
+        ),
+        Routes.setupComplete: const WizardRoute(
+          builder: SetupCompletePage.create,
+        ),
       },
     );
   }
@@ -49,9 +52,13 @@ class UbuntuWslReconfigureWizard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Wizard(
       initialRoute: initialRoute ?? Routes.advancedSetup,
-      routes: <String, WidgetBuilder>{
-        Routes.advancedSetup: AdvancedSetupPage.create,
-        Routes.configurationUI: ConfigurationUIPage.create,
+      routes: <String, WizardRoute>{
+        Routes.advancedSetup: const WizardRoute(
+          builder: AdvancedSetupPage.create,
+        ),
+        Routes.configurationUI: const WizardRoute(
+          builder: ConfigurationUIPage.create,
+        ),
       },
     );
   }

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
@@ -45,8 +45,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -140,8 +144,12 @@ void main() {
       home: Provider<SubiquityClient>.value(
         value: client,
         child: Wizard(
-          routes: {'/': AdvancedSetupPage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: AdvancedSetupPage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
@@ -52,8 +52,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -169,8 +173,12 @@ void main() {
       home: Provider<SubiquityClient>.value(
         value: client,
         child: Wizard(
-          routes: {'/': ConfigurationUIPage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: ConfigurationUIPage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -54,8 +54,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -220,8 +224,12 @@ void main() {
       home: Provider<SubiquityClient>.value(
         value: client,
         child: Wizard(
-          routes: {'/': ProfileSetupPage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: ProfileSetupPage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -47,8 +47,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model, settings)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model, settings),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -104,8 +108,12 @@ void main() {
           Provider<SubiquityClient>.value(value: client),
         ],
         child: Wizard(
-          routes: {'/': SelectLanguagePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: SelectLanguagePage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
@@ -36,8 +36,12 @@ void main() {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
-        routes: {'/': (_) => buildPage(model)},
-        onNext: (settings) => '/',
+        routes: {
+          '/': WizardRoute(
+            builder: (_) => buildPage(model),
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     );
   }
@@ -77,8 +81,12 @@ void main() {
       home: Provider<SubiquityClient>.value(
         value: client,
         child: Wizard(
-          routes: {'/': SetupCompletePage.create},
-          onNext: (settings) => '/',
+          routes: {
+            '/': WizardRoute(
+              builder: SetupCompletePage.create,
+              onNext: (settings) => '/',
+            ),
+          },
         ),
       ),
     ));


### PR DESCRIPTION
The complexity of `Wizard.onNext` had increased to a point where it got
hard to follow the route conditions that were placed separately from the
list of routes.

The new version is a bit more verbose, but makes it easier to read the
conditions that are scoped together with the respective route, which is
a welcome improvement because several more conditions are coming later
(internet, secure boot, security key, active directory, ...)