### PR TITLE
WSL: remove "Show advanced options" checkbox for the time being

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
@@ -46,7 +46,16 @@ class ProfileSetupModel extends ChangeNotifier {
   PasswordStrength get passwordStrength => estimatePasswordStrength(password);
 
   /// Whether to show the advanced options.
-  bool get showAdvancedOptions => _showAdvanced.value;
+  ///
+  /// NOTE: The advanced options cannot be skipped for now. This ensures that
+  /// the UI posts a `/wslconfbase` request. That way, the respective controller
+  /// in Subiquity is always marked as configured and the `wsl.conf` file is
+  /// forced to be written.
+  ///
+  /// More details:
+  /// https://github.com/canonical/ubuntu-desktop-installer/issues/431
+  ///
+  bool get showAdvancedOptions => true; // _showAdvanced.value;
   final _showAdvanced = ValueNotifier<bool>(false);
   set showAdvancedOptions(bool value) => _showAdvanced.value = value;
 

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -81,8 +81,11 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
               padding: fieldPadding,
               child: _ConfirmPasswordFormField(fieldWidth: fieldWidth),
             ),
-            const SizedBox(height: kContentSpacing),
-            const _ShowAdvancedOptionsCheckButton(),
+            // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
+            //       See [ProfileSetupModel.showAdvancedOptions] for more details.
+            //
+            // const SizedBox(height: kContentSpacing),
+            // const _ShowAdvancedOptionsCheckButton(),
           ],
         );
       }),

--- a/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
@@ -85,10 +85,13 @@ void main() {
     model.confirmedPassword = 'password';
     expect(wasNotified, isTrue);
 
-    wasNotified = false;
-    expect(model.showAdvancedOptions, isFalse);
-    model.showAdvancedOptions = true;
-    expect(wasNotified, isTrue);
+    // NOTE: The advanced options cannot be skipped for now (#431).
+    //       See [ProfileSetupModel.showAdvancedOptions] for more details.
+    //
+    // wasNotified = false;
+    // expect(model.showAdvancedOptions, isFalse);
+    // model.showAdvancedOptions = true;
+    // expect(wasNotified, isTrue);
   });
 
   test('validation', () {

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -161,21 +161,24 @@ void main() {
     expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
   });
 
-  testWidgets('advanced options', (tester) async {
-    final model = buildModel(showAdvancedOptions: true);
-    await tester.pumpWidget(buildApp(tester, model));
+  // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
+  //       See [ProfileSetupModel.showAdvancedOptions] for more details.
+  //
+  // testWidgets('advanced options', (tester) async {
+  //   final model = buildModel(showAdvancedOptions: true);
+  //   await tester.pumpWidget(buildApp(tester, model));
 
-    final checkbox = find.widgetWithText(
-        CheckButton, tester.lang.profileSetupShowAdvancedOptions);
-    expect(checkbox, findsOneWidget);
-    expect(tester.widget<CheckButton>(checkbox).value, isTrue);
+  //   final checkbox = find.widgetWithText(
+  //       CheckButton, tester.lang.profileSetupShowAdvancedOptions);
+  //   expect(checkbox, findsOneWidget);
+  //   expect(tester.widget<CheckButton>(checkbox).value, isTrue);
 
-    when(model.showAdvancedOptions).thenReturn(true);
+  //   when(model.showAdvancedOptions).thenReturn(true);
 
-    await tester.tap(checkbox);
-    verify(model.showAdvancedOptions = false).called(1);
-    expect(tester.widget<CheckButton>(checkbox).value, isTrue);
-  });
+  //   await tester.tap(checkbox);
+  //   verify(model.showAdvancedOptions = false).called(1);
+  //   expect(tester.widget<CheckButton>(checkbox).value, isTrue);
+  // });
 
   testWidgets('load and save profile setup', (tester) async {
     final model = buildModel(isValid: true);


### PR DESCRIPTION
This ensures that the UI posts a `/wslconfbase` request. That way, the
respective controller in Subiquity is always marked as configured and
the `wsl.conf` file is forced to be written.

Close: #431