### PR TITLE
Added pt_BR translations

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -501,7 +501,25 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get windowTitle => 'Instalar o Ubuntu';
 
   @override
+  String get cancelButtonText => 'Cancelar';
+
+  @override
+  String get changeButtonText => 'Alterar';
+
+  @override
+  String get okButtonText => 'Ok';
+
+  @override
+  String get noButtonText => 'Não';
+
+  @override
   String get restartButtonText => 'Reiniciar';
+
+  @override
+  String get revertButtonText => 'Desfazer';
+
+  @override
+  String get yesButtonText => 'Sim';
 
   @override
   String get welcome => 'Bem-vindo';
@@ -542,4 +560,419 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String instructionsForRST(Object url) {
     return 'Abra esta página em um celular ou outro dispositivo para encontrar instruções: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get keyboardLayoutPageTitle => 'Layout do teclado';
+
+  @override
+  String get chooseYourKeyboardLayout => 'Escolha o layout do seu teclado:';
+
+  @override
+  String get typeToTest => 'Digite aqui para testar seu teclado';
+
+  @override
+  String get detectLayout => 'Detectar o layout do teclado';
+
+  @override
+  String get pressOneKey => 'Por favor pressione uma das seguintes teclas:';
+
+  @override
+  String get isKeyPresent => 'A seguinte tecla está presente no seu teclado?';
+
+  @override
+  String get configureSecureBootTitle => 'Configurar Secure Boot';
+
+  @override
+  String get configureSecureBootDescription => 'Você optou por instalar drivers de terceiros. Isso requer desabilitar o Secure Boot.\nPara isso, você precisa escolher uma chave de segurança agora e entrar com ela quando o sistema reiniciar.';
+
+  @override
+  String get configureSecureBootOption => 'Configurar Secure Boot';
+
+  @override
+  String get chooseSecurityKey => 'Escolha uma chave de segurança';
+
+  @override
+  String get confirmSecurityKey => 'Confirme a chave de segurança';
+
+  @override
+  String get dontInstallDriverSoftwareNow => 'Não instalar os drivers agora';
+
+  @override
+  String get dontInstallDriverSoftwareNowDescription => 'Você pode instalar depois pelo Programas & Atualizações.';
+
+  @override
+  String get configureSecureBootSecurityKeyRequired => 'Chave de segurança é obrigatória';
+
+  @override
+  String get secureBootSecurityKeysDontMatch => 'Chaves de segurança não correspondem';
+
+  @override
+  String get updatesOtherSoftwarePageTitle => 'Atualizações e outros softwares';
+
+  @override
+  String get updatesOtherSoftwarePageDescription => 'Quais apps você gostaria de instalar para começar?';
+
+  @override
+  String get normalInstallationTitle => 'Instalação normal';
+
+  @override
+  String get normalInstallationSubtitle => 'Web browser, utilidades, pacote office, games and players de mídia.';
+
+  @override
+  String get minimalInstallationTitle => 'Instalação mínima';
+
+  @override
+  String get minimalInstallationSubtitle => 'Web browser utilidades básicas.';
+
+  @override
+  String get otherOptions => 'Outras opções';
+
+  @override
+  String get installThirdPartyTitle => 'Instalar software de terceiros para hardware gráfico e de Wi-Fi, bem como formatos de mídia adicionais';
+
+  @override
+  String get installThirdPartySubtitle => 'Este software está sujeito aos termos de licença incluídos nas suas documentações. Alguns são proprietários.';
+
+  @override
+  String get installationTypeTitle => 'Tipo de installation';
+
+  @override
+  String installationTypeOSDetected(Object os) {
+    return 'Este computador possui $os atualmente instalado. O que você deseja fazer?';
+  }
+
+  @override
+  String get installationTypeNoOSDetected => 'Este computador não possui sistemas operacionais detectados atualmente. O que você deseja fazer?';
+
+  @override
+  String get installationTypeErase => 'Apagar o disco e instalar o Ubuntu';
+
+  @override
+  String installationTypeEraseWarning(Object color) {
+    return '<font color=\"$color\">Aviso:</font> Isso vai apagar todos os seus programas, documentos, fotos, músicas, e quaisquer outrso arquivos em todos os sistemas operacionais existentes.';
+  }
+
+  @override
+  String get installationTypeAdvancedLabel => 'Recursos Avançados...';
+
+  @override
+  String get installationTypeAdvancedTitle => 'Recursos avançados';
+
+  @override
+  String get installationTypeNone => 'Nenhum';
+
+  @override
+  String get installationTypeNoneSelected => 'Nenhum selecionado';
+
+  @override
+  String get installationTypeLVM => 'Usar LVM com a nova instalação do Ubuntu';
+
+  @override
+  String get installationTypeLVMSelected => 'LVM selecionado';
+
+  @override
+  String get installationTypeEncrypt => 'Criptograsfar a nova instalação do Ubuntu para maior segurança';
+
+  @override
+  String get installationTypeEncryptInfo => 'Você deverá escolher uma chave de segurança no próximo passo.';
+
+  @override
+  String get installationTypeZFS => 'EXPERIMENTAL: Apagar o disco e usar ZFS';
+
+  @override
+  String get installationTypeZFSSelected => 'ZFS selecionado';
+
+  @override
+  String installationTypeReinstall(Object os) {
+    return 'Apagar $os e reinstalar';
+  }
+
+  @override
+  String installationTypeReinstallWarning(Object color, Object os) {
+    return '<font color=\"$color\">Aviso:</font> Isso vai apagar todos os programas do $os, documentos, fotos, músicas e quaisquer outros arquivos.';
+  }
+
+  @override
+  String installationTypeAlongside(Object product, Object os) {
+    return 'Instalar $product junto com $os';
+  }
+
+  @override
+  String get installationTypeAlongsideInfo => 'Documentos, músicas, e outros arquivos pessoais serão mantidos. Você poderá selecionar qual sistema operacional usar cada vez que o computador iniciar.';
+
+  @override
+  String get installationTypeManual => 'Opção avançada';
+
+  @override
+  String get installationTypeManualInfo => 'Você pode criar ou redimensionar partições manualmente ou escolher múltiplas partições para o Ubuntu.';
+
+  @override
+  String get selectGuidedStoragePageTitle => 'Apagar o disco e instalar o Ubuntu';
+
+  @override
+  String get selectGuidedStorageDropdownLabel => 'Selecione o disco:';
+
+  @override
+  String get selectGuidedStorageInfoLabel => 'O disco inteiro será utilizado:';
+
+  @override
+  String get selectGuidedStorageInstallNow => 'Instalar agora';
+
+  @override
+  String get allocateDiskSpace => 'Alocar espaço em disco';
+
+  @override
+  String get startInstallingButtonText => 'Iniciar instalação';
+
+  @override
+  String get diskHeadersDevice => 'Dispositivo';
+
+  @override
+  String get diskHeadersType => 'Tipo';
+
+  @override
+  String get diskHeadersMountPoint => 'Ponto de montagem';
+
+  @override
+  String get diskHeadersSize => 'Tamanho';
+
+  @override
+  String get diskHeadersUsed => 'Utilizado';
+
+  @override
+  String get diskHeadersSystem => 'Sistema';
+
+  @override
+  String get diskHeadersFormat => 'Formato';
+
+  @override
+  String get freeDiskSpace => 'espaço livre';
+
+  @override
+  String get newPartitionTable => 'Nova tabela de partições';
+
+  @override
+  String get bootLoaderDevice => 'Dispositivo para instalação do boot loader';
+
+  @override
+  String get partitionCreateTitle => 'Criar partição';
+
+  @override
+  String get partitionEditTitle => 'Editar partição';
+
+  @override
+  String get partitionSizeLabel => 'Tamanho:';
+
+  @override
+  String get partitionUnitB => 'B';
+
+  @override
+  String get partitionUnitKB => 'KB';
+
+  @override
+  String get partitionUnitMB => 'MB';
+
+  @override
+  String get partitionUnitGB => 'GB';
+
+  @override
+  String get partitionTypeLabel => 'Tipo para a nova partiçaõ:';
+
+  @override
+  String get partitionTypePrimary => 'Primária';
+
+  @override
+  String get partitionTypeLogical => 'Lógica';
+
+  @override
+  String get partitionLocationLabel => 'Localização para a nova partição:';
+
+  @override
+  String get partitionLocationBeginning => 'Início deste espaço';
+
+  @override
+  String get partitionLocationEnd => 'Final deste espaço';
+
+  @override
+  String get partitionFormatLabel => 'Utilizado como:';
+
+  @override
+  String get partitionFormatExt4 => 'Sistema de arquivos Ext4 com journaling';
+
+  @override
+  String get partitionFormatExt3 => 'Sistema de arquivos Ext3 com journaling';
+
+  @override
+  String get partitionFormatExt2 => 'Sistema de arquivos Ext2';
+
+  @override
+  String get partitionFormatBtrfs => 'Sistema de arquivos btrfs com journaling';
+
+  @override
+  String get partitionFormatJfs => 'Sistema de arquivos JFS com journaling';
+
+  @override
+  String get partitionFormatXfs => 'Sistema de arquivos XFS com journaling';
+
+  @override
+  String get partitionFormatFat => 'Sistema de arquivos FAT';
+
+  @override
+  String get partitionFormatFat12 => 'Sistema de arquivos FA12';
+
+  @override
+  String get partitionFormatFat16 => 'Sistema de arquivos FA16';
+
+  @override
+  String get partitionFormatFat32 => 'Sistema de arquivos FAT32';
+
+  @override
+  String get partitionFormatSwap => 'Swap area';
+
+  @override
+  String get partitionFormatIso9660 => 'Sistema de arquivos ISO 9660';
+
+  @override
+  String get partitionFormatVfat => 'Sistema de arquivos VFAT';
+
+  @override
+  String get partitionFormatNtfs => 'Sistema de arquivos NTFS';
+
+  @override
+  String get partitionFormatReiserFS => 'Sistema de arquivos ReiserFS';
+
+  @override
+  String get partitionFormatZfsroot => 'Sistema de arquivos raiz ZFS';
+
+  @override
+  String get partitionErase => 'Formatar a partição';
+
+  @override
+  String get partitionMountPointLabel => 'Ponto de montagem:';
+
+  @override
+  String get whoAreYouPageTitle => 'Quem é você?';
+
+  @override
+  String get whoAreYouPageAutoLogin => 'Iniciar sessão automaticamente';
+
+  @override
+  String get whoAreYouPageRequirePassword => 'Solicitar minha senha para entrar';
+
+  @override
+  String get whoAreYouPageRealNameLabel => 'Seu nome';
+
+  @override
+  String get whoAreYouPageRealNameRequired => 'O nome é obrigatório';
+
+  @override
+  String get whoAreYouPageComputerNameLabel => 'Nome do seu computador';
+
+  @override
+  String get whoAreYouPageComputerNameInfo => 'O nome usado para falar com outros computadores.';
+
+  @override
+  String get whoAreYouPageComputerNameRequired => 'O nome do computador é obrigatório';
+
+  @override
+  String get whoAreYouPageInvalidComputerName => 'The computer name is invalid';
+
+  @override
+  String get whoAreYouPageUsernameLabel => 'Escolha um nome de usuário';
+
+  @override
+  String get whoAreYouPageUsernameRequired => 'Nome de usuário é obrigatório';
+
+  @override
+  String get whoAreYouPageInvalidUsername => 'O nome de usuário informado é inválido';
+
+  @override
+  String get whoAreYouPagePasswordLabel => 'Escolha uma senha';
+
+  @override
+  String get whoAreYouPagePasswordRequired => 'A senha é obrigatória';
+
+  @override
+  String get whoAreYouPageConfirmPasswordLabel => 'Confirme sua senha';
+
+  @override
+  String get whoAreYouPagePasswordMismatch => 'As senhas não correspondem';
+
+  @override
+  String get writeChangesToDisk => 'Gravar alterações no disco';
+
+  @override
+  String get writeChangesFallbackSerial => 'disco';
+
+  @override
+  String get writeChangesDescription => 'Se você prosseguir, as mudanças listadas abaixo serão escritas nos discos. Você será capaz de realizar alterações posteriores manualmente.';
+
+  @override
+  String get writeChangesPartitionTablesHeader => 'As tabelas de partições dos seguintes dispositivos foram alteradas:';
+
+  @override
+  String writeChangesPartitionTablesEntry(Object serial, Object path) {
+    return '$serial ($path)';
+  }
+
+  @override
+  String get writeChangesPartitionsHeader => 'As seguintes partições serão formatadas:';
+
+  @override
+  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partição #$disk${partition} como $format usada para $mount';
+  }
+
+  @override
+  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
+    return 'partição #$disk${partition} como $format';
+  }
+
+  @override
+  String get chooseYourLookPageTitle => 'Escolha seu visual';
+
+  @override
+  String get chooseYourLookPageHeader => 'Você pode sempre alterar isso depois nas configurações de aparência.';
+
+  @override
+  String get chooseYourLookPageDarkSetting => 'Escuro';
+
+  @override
+  String get chooseYourLookPageLightSetting => 'Claro';
+
+  @override
+  String get chooseYourLookPageLightBodyText => 'Tudo está claro e brilhante';
+
+  @override
+  String get chooseYourLookPageDarkBodyText => 'Olá, escuridão, minha velha amiga';
+
+  @override
+  String get installationCompleteTitle => 'Instalação concluída';
+
+  @override
+  String readyToUse(Object system) {
+    return '**$system** está instalado e pronto pra uso.';
+  }
+
+  @override
+  String restartInto(Object system) {
+    return 'Reiniciar no $system';
+  }
+
+  @override
+  String get shutdown => 'Desligar';
+
+  @override
+  String get turnOffBitlockerTitle => 'Desligar BitLocker';
+
+  @override
+  String get turnOffBitlockerDescription => 'Este computador usa criptografia do Windows BitLocker. Você precisa desativar o BitLocker no Windows antes de instalar o Ubuntu.';
+
+  @override
+  String turnOffBitlockerLinkInstructions(Object url) {
+    return 'Para obter instruções, abra esta página em um telefone ou outro dispositivo: <a href=\"https://$url\">$url</a>';
+  }
+
+  @override
+  String get restartIntoWindows => 'Reiniciar no Windows';
 }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
@@ -4,7 +4,13 @@
   "appTitle": "Instalador do Ubuntu Desktop",
   "windowTitle": "Instalar o Ubuntu",
 
+  "cancelButtonText": "Cancelar",
+  "changeButtonText": "Alterar",
+  "okButtonText": "Ok",
+  "noButtonText": "Não",
   "restartButtonText": "Reiniciar",
+  "revertButtonText": "Desfazer",
+  "yesButtonText": "Sim",
 
   "welcome": "Bem-vindo",
 
@@ -16,8 +22,238 @@
   "installUbuntu": "Instalar o Ubuntu",
   "installUbuntuDescription": "Instalar o Ubuntu ao lado do (ou em substituição ao) seu sistema operacional atual. Isto não deve demorar muito.",
   "releaseNotesLabel": "Talvez você queira ler as <a href=\"{url}\">notas de lançamento</a>.",
+    "@releaseNotesLabel": {
+      "type": "text",
+      "placeholders": {
+        "url": {}
+      }
+    },
 
   "turnOffRST": "Desligue a RST",
   "turnOffRSTDescription": "Este computador usa Intel RST (Rapid Storage Technology). Você precisa desligar a RST no Windows antes de instalar o Ubuntu.",
-  "instructionsForRST": "Abra esta página em um celular ou outro dispositivo para encontrar instruções: <a href=\"https://{url}\">{url}</a>"
-}
+  "instructionsForRST": "Abra esta página em um celular ou outro dispositivo para encontrar instruções: <a href=\"https://{url}\">{url}</a>",
+    "@instructionsForRST": {
+      "type": "text",
+      "placeholders": {
+        "url": {}
+      }
+    },
+
+    "keyboardLayoutPageTitle": "Layout do teclado",
+    "chooseYourKeyboardLayout": "Escolha o layout do seu teclado:",
+    "typeToTest": "Digite aqui para testar seu teclado",
+    "detectLayout": "Detectar o layout do teclado",
+    "pressOneKey": "Por favor pressione uma das seguintes teclas:",
+    "isKeyPresent": "A seguinte tecla está presente no seu teclado?",
+  
+    "configureSecureBootTitle": "Configurar Secure Boot",
+    "configureSecureBootDescription": "Você optou por instalar drivers de terceiros. Isso requer desabilitar o Secure Boot.\nPara isso, você precisa escolher uma chave de segurança agora e entrar com ela quando o sistema reiniciar.",
+    "configureSecureBootOption": "Configurar Secure Boot",
+    "chooseSecurityKey": "Escolha uma chave de segurança",
+    "confirmSecurityKey": "Confirme a chave de segurança",
+    "dontInstallDriverSoftwareNow": "Não instalar os drivers agora",
+    "dontInstallDriverSoftwareNowDescription": "Você pode instalar depois pelo Programas & Atualizações.",
+    "configureSecureBootSecurityKeyRequired": "Chave de segurança é obrigatória",
+    "secureBootSecurityKeysDontMatch": "Chaves de segurança não correspondem",
+  
+    "updatesOtherSoftwarePageTitle": "Atualizações e outros softwares",
+    "updatesOtherSoftwarePageDescription": "Quais apps você gostaria de instalar para começar?",
+    "normalInstallationTitle": "Instalação normal",
+    "normalInstallationSubtitle": "Web browser, utilidades, pacote office, games and players de mídia.",
+    "minimalInstallationTitle": "Instalação mínima",
+    "minimalInstallationSubtitle": "Web browser utilidades básicas.",
+    "otherOptions": "Outras opções",
+    "installThirdPartyTitle": "Instalar software de terceiros para hardware gráfico e de Wi-Fi, bem como formatos de mídia adicionais",
+    "installThirdPartySubtitle": "Este software está sujeito aos termos de licença incluídos nas suas documentações. Alguns são proprietários.",
+  
+    "installationTypeTitle": "Tipo de installation",
+    "installationTypeOSDetected": "Este computador possui {os} atualmente instalado. O que você deseja fazer?",
+    "@installationTypeOSDetected": {
+      "type": "text",
+      "placeholders": {
+        "os": {}
+      }
+    },
+    "installationTypeNoOSDetected": "Este computador não possui sistemas operacionais detectados atualmente. O que você deseja fazer?",
+    "installationTypeErase": "Apagar o disco e instalar o Ubuntu",
+    "installationTypeEraseWarning": "<font color=\"{color}\">Aviso:</font> Isso vai apagar todos os seus programas, documentos, fotos, músicas, e quaisquer outrso arquivos em todos os sistemas operacionais existentes.",
+    "@installationTypeEraseWarning": {
+      "type": "text",
+      "placeholders": {
+        "color": {}
+      }
+    },
+    "installationTypeAdvancedLabel": "Recursos Avançados...",
+    "installationTypeAdvancedTitle": "Recursos avançados",
+    "installationTypeNone": "Nenhum",
+    "installationTypeNoneSelected": "Nenhum selecionado",
+    "installationTypeLVM": "Usar LVM com a nova instalação do Ubuntu",
+    "installationTypeLVMSelected": "LVM selecionado",
+    "installationTypeEncrypt": "Criptograsfar a nova instalação do Ubuntu para maior segurança",
+    "installationTypeEncryptInfo": "Você deverá escolher uma chave de segurança no próximo passo.",
+    "installationTypeZFS": "EXPERIMENTAL: Apagar o disco e usar ZFS",
+    "installationTypeZFSSelected": "ZFS selecionado",
+    "installationTypeReinstall": "Apagar {os} e reinstalar",
+    "@installationTypeReinstall": {
+      "type": "text",
+      "placeholders": {
+        "os": {}
+      }
+    },
+    "installationTypeReinstallWarning": "<font color=\"{color}\">Aviso:</font> Isso vai apagar todos os programas do {os}, documentos, fotos, músicas e quaisquer outros arquivos.",
+    "@installationTypeReinstallWarning": {
+      "type": "text",
+      "placeholders": {
+        "color": {},
+        "os": {}
+      }
+    },
+    "installationTypeAlongside": "Instalar {product} junto com {os}",
+    "@installationTypeAlongside": {
+      "type": "text",
+      "placeholders": {
+        "product": {},
+        "os": {}
+      }
+    },
+    "installationTypeAlongsideInfo": "Documentos, músicas, e outros arquivos pessoais serão mantidos. Você poderá selecionar qual sistema operacional usar cada vez que o computador iniciar.",
+    "installationTypeManual": "Opção avançada",
+    "installationTypeManualInfo": "Você pode criar ou redimensionar partições manualmente ou escolher múltiplas partições para o Ubuntu.",
+  
+    "selectGuidedStoragePageTitle": "Apagar o disco e instalar o Ubuntu",
+    "selectGuidedStorageDropdownLabel": "Selecione o disco:",
+    "selectGuidedStorageInfoLabel": "O disco inteiro será utilizado:",
+    "selectGuidedStorageInstallNow": "Instalar agora",
+  
+    "allocateDiskSpace": "Alocar espaço em disco",
+    "startInstallingButtonText": "Iniciar instalação",
+    "diskHeadersDevice": "Dispositivo",
+    "diskHeadersType": "Tipo",
+    "diskHeadersMountPoint": "Ponto de montagem",
+    "diskHeadersSize": "Tamanho",
+    "diskHeadersUsed": "Utilizado",
+    "diskHeadersSystem": "Sistema",
+    "diskHeadersFormat": "Formato",
+    "freeDiskSpace": "espaço livre",
+    "newPartitionTable": "Nova tabela de partições",
+    "bootLoaderDevice": "Dispositivo para instalação do boot loader",
+  
+    "partitionCreateTitle": "Criar partição",
+    "partitionEditTitle": "Editar partição",
+    "partitionSizeLabel": "Tamanho:",
+    "partitionUnitB": "B",
+    "partitionUnitKB": "KB",
+    "partitionUnitMB": "MB",
+    "partitionUnitGB": "GB",
+    "partitionTypeLabel": "Tipo para a nova partiçaõ:",
+    "partitionTypePrimary": "Primária",
+    "partitionTypeLogical": "Lógica",
+    "partitionLocationLabel": "Localização para a nova partição:",
+    "partitionLocationBeginning": "Início deste espaço",
+    "partitionLocationEnd": "Final deste espaço",
+    "partitionFormatLabel": "Utilizado como:",
+    "partitionFormatExt4": "Sistema de arquivos Ext4 com journaling",
+    "partitionFormatExt3": "Sistema de arquivos Ext3 com journaling",
+    "partitionFormatExt2": "Sistema de arquivos Ext2",
+    "partitionFormatBtrfs": "Sistema de arquivos btrfs com journaling",
+    "partitionFormatJfs": "Sistema de arquivos JFS com journaling",
+    "partitionFormatXfs": "Sistema de arquivos XFS com journaling",
+    "partitionFormatFat": "Sistema de arquivos FAT",
+    "partitionFormatFat12": "Sistema de arquivos FA12",
+    "partitionFormatFat16": "Sistema de arquivos FA16",
+    "partitionFormatFat32": "Sistema de arquivos FAT32",
+    "partitionFormatSwap": "Swap area",
+    "partitionFormatIso9660": "Sistema de arquivos ISO 9660",
+    "partitionFormatVfat": "Sistema de arquivos VFAT",
+    "partitionFormatNtfs": "Sistema de arquivos NTFS",
+    "partitionFormatReiserFS": "Sistema de arquivos ReiserFS",
+    "partitionFormatZfsroot": "Sistema de arquivos raiz ZFS",
+    "partitionErase": "Formatar a partição",
+    "partitionMountPointLabel": "Ponto de montagem:",
+  
+    "whoAreYouPageTitle": "Quem é você?",
+    "whoAreYouPageAutoLogin": "Iniciar sessão automaticamente",
+    "whoAreYouPageRequirePassword": "Solicitar minha senha para entrar",
+    "whoAreYouPageRealNameLabel": "Seu nome",
+    "whoAreYouPageRealNameRequired": "O nome é obrigatório",
+    "whoAreYouPageComputerNameLabel": "Nome do seu computador",
+    "whoAreYouPageComputerNameInfo": "O nome usado para falar com outros computadores.",
+    "whoAreYouPageComputerNameRequired": "O nome do computador é obrigatório",
+    "whoAreYouPageInvalidComputerName": "The computer name is invalid",
+    "whoAreYouPageUsernameLabel": "Escolha um nome de usuário",
+    "whoAreYouPageUsernameRequired": "Nome de usuário é obrigatório",
+    "whoAreYouPageInvalidUsername": "O nome de usuário informado é inválido",
+    "whoAreYouPagePasswordLabel": "Escolha uma senha",
+    "whoAreYouPagePasswordRequired": "A senha é obrigatória",
+    "whoAreYouPageConfirmPasswordLabel": "Confirme sua senha",
+    "whoAreYouPagePasswordMismatch": "As senhas não correspondem",
+  
+    "writeChangesToDisk": "Gravar alterações no disco",
+    "writeChangesFallbackSerial": "disco",
+    "@writeChangesFallbackSerial": { "description": "Nome de exibição padrão para um disco sem o serial (improvável)" },
+    "writeChangesDescription": "Se você prosseguir, as mudanças listadas abaixo serão escritas nos discos. Você será capaz de realizar alterações posteriores manualmente.",
+    "writeChangesPartitionTablesHeader": "As tabelas de partições dos seguintes dispositivos foram alteradas:",
+    "writeChangesPartitionTablesEntry": "{serial} ({path})",
+    "@writeChangesPartitionTablesEntry": {
+      "description": "Um registro para um disco cuja tabela de partição está sendo alterada",
+      "placeholders": {
+        "serial": {},
+        "path": {}
+      }
+    },
+    "writeChangesPartitionsHeader": "As seguintes partições serão formatadas:",
+    "writeChangesPartitionEntryMounted": "partição #{disk}{partition} como {format} usada para {mount}",
+    "@writeChangesPartitionEntryMounted": {
+      "description": "Um registro de partição montada",
+      "placeholders": {
+        "disk": {},
+        "partition": {},
+        "format": {},
+        "mount": {}
+      }
+    },
+    "writeChangesPartitionEntryUnmounted": "partição #{disk}{partition} como {format}",
+    "@writeChangesPartitionEntryUnmounted": {
+      "description": "Um registro de partição não montada",
+      "placeholders": {
+        "disk": {},
+        "partition": {},
+        "format": {}
+      }
+    },
+  
+    "chooseYourLookPageTitle": "Escolha seu visual",
+    "chooseYourLookPageHeader": "Você pode sempre alterar isso depois nas configurações de aparência.",
+    "chooseYourLookPageDarkSetting": "Escuro",
+    "chooseYourLookPageLightSetting": "Claro",
+    "chooseYourLookPageLightBodyText": "Tudo está claro e brilhante",
+    "chooseYourLookPageDarkBodyText": "Olá, escuridão, minha velha amiga",
+  
+    "installationCompleteTitle": "Instalação concluída",
+    "readyToUse": "**{system}** está instalado e pronto pra uso.",
+    "@readyToUse": {
+      "type": "text",
+      "placeholders": {
+        "system": {}
+      }
+    },
+    "restartInto": "Reiniciar no {system}",
+    "@restartInto": {
+      "type": "text",
+      "placeholders": {
+          "system": {}
+      }
+    },
+    "shutdown": "Desligar",
+  
+    "turnOffBitlockerTitle": "Desligar BitLocker",
+    "turnOffBitlockerDescription": "Este computador usa criptografia do Windows BitLocker. Você precisa desativar o BitLocker no Windows antes de instalar o Ubuntu.",
+    "turnOffBitlockerLinkInstructions": "Para obter instruções, abra esta página em um telefone ou outro dispositivo: <a href=\"https://{url}\">{url}</a>",
+    "@turnOffBitlockerLinkInstructions": {
+      "type": "text",
+      "placeholders": {
+        "url": {}
+      }
+    },
+    "restartIntoWindows": "Reiniciar no Windows"
+  }

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pt.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pt.dart
@@ -38,4 +38,13 @@ class UbuntuLocalizationsPtBr extends UbuntuLocalizationsPt {
 
   @override
   String get continueAction => 'Continuar';
+
+  @override
+  String get strongPassword => 'Senha forte';
+
+  @override
+  String get moderatePassword => 'Senha média';
+
+  @override
+  String get weakPassword => 'Senha fraca';
 }

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_pt_BR.arb
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_pt_BR.arb
@@ -2,7 +2,14 @@
   "@@locale": "pt_BR",
 
   "languageName": "Português do Brasil",
+  "@languageName": {
+    "description": "Português do Brasil"
+  },
 
   "backAction": "Voltar",
-  "continueAction": "Continuar"
+  "continueAction": "Continuar",
+  
+  "strongPassword": "Senha forte",
+  "moderatePassword": "Senha média",
+  "weakPassword": "Senha fraca"
 }

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart' as intl;
 import 'app_localizations_en.dart';
 import 'app_localizations_fi.dart';
 import 'app_localizations_fr.dart';
+import 'app_localizations_pt.dart';
 
 /// Callers can lookup localized strings with an instance of AppLocalizations returned
 /// by `AppLocalizations.of(context)`.
@@ -96,7 +97,9 @@ abstract class AppLocalizations {
     Locale('fi'),
     Locale('fi', 'FI'),
     Locale('fr'),
-    Locale('fr', 'FR')
+    Locale('fr', 'FR'),
+    Locale('pt'),
+    Locale('pt', 'BR')
   ];
 
   /// No description provided for @appTitle.
@@ -433,7 +436,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'fi', 'fr'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'fi', 'fr', 'pt'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -461,6 +464,12 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
    }
   break;
    }
+    case 'pt': {
+  switch (locale.countryCode) {
+    case 'BR': return AppLocalizationsPtBr();
+   }
+  break;
+   }
   }
 
   // Lookup logic when only language code is specified.
@@ -468,6 +477,7 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
     case 'en': return AppLocalizationsEn();
     case 'fi': return AppLocalizationsFi();
     case 'fr': return AppLocalizationsFr();
+    case 'pt': return AppLocalizationsPt();
   }
 
   throw FlutterError(

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
@@ -1,0 +1,342 @@
+
+
+
+import 'app_localizations.dart';
+
+/// The translations for Portuguese (`pt`).
+class AppLocalizationsPt extends AppLocalizations {
+  AppLocalizationsPt([String locale = 'pt']) : super(locale);
+
+  @override
+  String get appTitle => 'Ubuntu WSL';
+
+  @override
+  String get windowTitle => 'Ubuntu WSL';
+
+  @override
+  String get exitButton => 'Sair';
+
+  @override
+  String get finishButton => 'Concluir';
+
+  @override
+  String get saveButton => 'Salvar';
+
+  @override
+  String get setupButton => 'Configurar';
+
+  @override
+  String get selectLanguageTitle => 'Selecione seu idioma';
+
+  @override
+  String get profileSetupTitle => 'Configurar perfil';
+
+  @override
+  String get profileSetupHeader => 'Por favor crie a sua conta UNIX padrão. Para mais informações visite: <a href=\"https://aka.ms/wslusers\">https://aka.ms/wslusers</a>';
+
+  @override
+  String get profileSetupRealnameLabel => 'Seu nome';
+
+  @override
+  String get profileSetupRealnameRequired => 'Um nome é necessário';
+
+  @override
+  String get profileSetupUsernameHint => 'Escolha um nome de usuário';
+
+  @override
+  String get profileSetupUsernameHelper => 'O nome de usuário não precisa ser igual ao Windows.';
+
+  @override
+  String get profileSetupPasswordHint => 'Escolha uma senha';
+
+  @override
+  String get profileSetupConfirmPasswordHint => 'Confirme a senha';
+
+  @override
+  String get profileSetupShowAdvancedOptions => 'Mostrar opções avançadas na próxima página';
+
+  @override
+  String get profileSetupPasswordMismatch => 'As senhas não correspondem';
+
+  @override
+  String get profileSetupUsernameRequired => 'Nome de usuário é obrigatório';
+
+  @override
+  String get profileSetupUsernameInvalid => 'O nome de usuário é inválido';
+
+  @override
+  String get profileSetupPasswordRequired => 'Senha é obrigatória';
+
+  @override
+  String get advancedSetupTitle => 'Configurações avançadas';
+
+  @override
+  String get advancedSetupHeader => 'Nessa página você pode ajustar o Ubuntu WSL de acordo com suas necessidades.';
+
+  @override
+  String get advancedSetupMountLocationHint => 'Ponto de montagem';
+
+  @override
+  String get advancedSetupMountLocationHelper => 'Local para montagem automática';
+
+  @override
+  String get advancedSetupMountLocationInvalid => 'O local informado é inválido';
+
+  @override
+  String get advancedSetupMountOptionHint => 'Opções de montagem';
+
+  @override
+  String get advancedSetupMountOptionHelper => 'Opções passadas para a montagem automática';
+
+  @override
+  String get advancedSetupHostGenerationTitle => 'Habilitar geração de host';
+
+  @override
+  String get advancedSetupHostGenerationSubtitle => 'Selecione para habilitar re-criação do arquivo /etc/hosts a cada reinicialização do sistema.';
+
+  @override
+  String get advancedSetupResolvConfGenerationTitle => 'Habilitar geração do arquivo resolv.conf';
+
+  @override
+  String get advancedSetupResolvConfGenerationSubtitle => 'Selecione para habilitar re-criação do arquivo /etc/resolv.conf a cada reinicialização do sistema.';
+
+  @override
+  String get advancedSetupGUIIntegrationTitle => 'Intergração gráfica';
+
+  @override
+  String get advancedSetupGUIIntegrationSubtitle => 'Selecione para habilitar configuração automática do DISPLAY. É necessário X server de terceiros.';
+
+  @override
+  String get configurationUITitle => 'UI de Configuração do Ubuntu WSL (experimental)';
+
+  @override
+  String get configurationUIInteroperabilityHeader => 'Interoperabilidade';
+
+  @override
+  String get configurationUILegacyGUIIntegrationTitle => 'Integration Gráfica Legada';
+
+  @override
+  String get configurationUILegacyGUIIntegrationSubtitle => 'Esta opção habilita a integração gráfica legada no Windows 10. Requer X server de terceiros.';
+
+  @override
+  String get configurationUILegacyAudioIntegrationTitle => 'Integração de Áudio Legada';
+
+  @override
+  String get configurationUILegacyAudioIntegrationSubtitle => 'Esta opção habilita a integração de áudio legada no Windows 10. Requer PulseAudio para Windows instalado.';
+
+  @override
+  String get configurationUIAdvancedIPDetectionTitle => 'Detecção Avançada de IP';
+
+  @override
+  String get configurationUIAdvancedIPDetectionSubtitle => 'Esta opção habilita detecção avançada de IP pelo endereço IPv4 do Windows que é mais confiável para uso com WSL2.\nRequer Interoperabilidade com WSL habilitada.';
+
+  @override
+  String get configurationUIMessageOfTheDayHeader => 'Mensagem do Dia (MOTD)';
+
+  @override
+  String get configurationUIWSLNewsTitle => 'WSL News';
+
+  @override
+  String get configurationUIWSLNewsSubtitle => 'Esta opção permite ao usuário controlar seu MOTD News. Selecione para habilitar a exibição do MOTD.';
+
+  @override
+  String get configurationUIAutoMountHeader => 'Montagem Automática';
+
+  @override
+  String get configurationUIAutoMountTitle => 'Habiltar';
+
+  @override
+  String get configurationUIAutoMountSubtitle => 'Habilitar o recurso de montagem automática. Esse recurso permite a montagem automática dos drives do Windows no WSL.';
+
+  @override
+  String get configurationUIMountFstabTitle => 'Montar /etc/fstab';
+
+  @override
+  String get configurationUIMountFstabSubtitle => 'Habilita a montagem do arquivo /etc/fstab. O arquivo de configuração /etc/fstab contém ???';
+
+  @override
+  String get setupCompleteTitle => 'Configuração concluída';
+
+  @override
+  String setupCompleteHeader(Object user) {
+    return 'Olá $user,\nVocê concluiu a configuração com sucesso.';
+  }
+
+  @override
+  String get setupCompleteUpdate => 'Recomendamos rodar os seguintes commandos para atualizar o Ubuntu para a última versão:';
+
+  @override
+  String get setupCompleteManage => 'Você pode usar o comando ubuntuwsl para gerenciar suas configurações do WSL:';
+
+  @override
+  String get setupCompleteRestart => '* Todas as configurações serão aplicadas após reiniciar o Ubuntu.';
+}
+
+/// The translations for Portuguese, as used in Brazil (`pt_BR`).
+class AppLocalizationsPtBr extends AppLocalizationsPt {
+  AppLocalizationsPtBr(): super('pt_BR');
+
+  @override
+  String get appTitle => 'Ubuntu WSL';
+
+  @override
+  String get windowTitle => 'Ubuntu WSL';
+
+  @override
+  String get exitButton => 'Sair';
+
+  @override
+  String get finishButton => 'Concluir';
+
+  @override
+  String get saveButton => 'Salvar';
+
+  @override
+  String get setupButton => 'Configurar';
+
+  @override
+  String get selectLanguageTitle => 'Selecione seu idioma';
+
+  @override
+  String get profileSetupTitle => 'Configurar perfil';
+
+  @override
+  String get profileSetupHeader => 'Por favor crie a sua conta UNIX padrão. Para mais informações visite: <a href=\"https://aka.ms/wslusers\">https://aka.ms/wslusers</a>';
+
+  @override
+  String get profileSetupRealnameLabel => 'Seu nome';
+
+  @override
+  String get profileSetupRealnameRequired => 'Um nome é necessário';
+
+  @override
+  String get profileSetupUsernameHint => 'Escolha um nome de usuário';
+
+  @override
+  String get profileSetupUsernameHelper => 'O nome de usuário não precisa ser igual ao Windows.';
+
+  @override
+  String get profileSetupPasswordHint => 'Escolha uma senha';
+
+  @override
+  String get profileSetupConfirmPasswordHint => 'Confirme a senha';
+
+  @override
+  String get profileSetupShowAdvancedOptions => 'Mostrar opções avançadas na próxima página';
+
+  @override
+  String get profileSetupPasswordMismatch => 'As senhas não correspondem';
+
+  @override
+  String get profileSetupUsernameRequired => 'Nome de usuário é obrigatório';
+
+  @override
+  String get profileSetupUsernameInvalid => 'O nome de usuário é inválido';
+
+  @override
+  String get profileSetupPasswordRequired => 'Senha é obrigatória';
+
+  @override
+  String get advancedSetupTitle => 'Configurações avançadas';
+
+  @override
+  String get advancedSetupHeader => 'Nessa página você pode ajustar o Ubuntu WSL de acordo com suas necessidades.';
+
+  @override
+  String get advancedSetupMountLocationHint => 'Ponto de montagem';
+
+  @override
+  String get advancedSetupMountLocationHelper => 'Local para montagem automática';
+
+  @override
+  String get advancedSetupMountLocationInvalid => 'O local informado é inválido';
+
+  @override
+  String get advancedSetupMountOptionHint => 'Opções de montagem';
+
+  @override
+  String get advancedSetupMountOptionHelper => 'Opções passadas para a montagem automática';
+
+  @override
+  String get advancedSetupHostGenerationTitle => 'Habilitar geração de host';
+
+  @override
+  String get advancedSetupHostGenerationSubtitle => 'Selecione para habilitar re-criação do arquivo /etc/hosts a cada reinicialização do sistema.';
+
+  @override
+  String get advancedSetupResolvConfGenerationTitle => 'Habilitar geração do arquivo resolv.conf';
+
+  @override
+  String get advancedSetupResolvConfGenerationSubtitle => 'Selecione para habilitar re-criação do arquivo /etc/resolv.conf a cada reinicialização do sistema.';
+
+  @override
+  String get advancedSetupGUIIntegrationTitle => 'Intergração gráfica';
+
+  @override
+  String get advancedSetupGUIIntegrationSubtitle => 'Selecione para habilitar configuração automática do DISPLAY. É necessário X server de terceiros.';
+
+  @override
+  String get configurationUITitle => 'UI de Configuração do Ubuntu WSL (experimental)';
+
+  @override
+  String get configurationUIInteroperabilityHeader => 'Interoperabilidade';
+
+  @override
+  String get configurationUILegacyGUIIntegrationTitle => 'Integration Gráfica Legada';
+
+  @override
+  String get configurationUILegacyGUIIntegrationSubtitle => 'Esta opção habilita a integração gráfica legada no Windows 10. Requer X server de terceiros.';
+
+  @override
+  String get configurationUILegacyAudioIntegrationTitle => 'Integração de Áudio Legada';
+
+  @override
+  String get configurationUILegacyAudioIntegrationSubtitle => 'Esta opção habilita a integração de áudio legada no Windows 10. Requer PulseAudio para Windows instalado.';
+
+  @override
+  String get configurationUIAdvancedIPDetectionTitle => 'Detecção Avançada de IP';
+
+  @override
+  String get configurationUIAdvancedIPDetectionSubtitle => 'Esta opção habilita detecção avançada de IP pelo endereço IPv4 do Windows que é mais confiável para uso com WSL2.\nRequer Interoperabilidade com WSL habilitada.';
+
+  @override
+  String get configurationUIMessageOfTheDayHeader => 'Mensagem do Dia (MOTD)';
+
+  @override
+  String get configurationUIWSLNewsTitle => 'WSL News';
+
+  @override
+  String get configurationUIWSLNewsSubtitle => 'Esta opção permite ao usuário controlar seu MOTD News. Selecione para habilitar a exibição do MOTD.';
+
+  @override
+  String get configurationUIAutoMountHeader => 'Montagem Automática';
+
+  @override
+  String get configurationUIAutoMountTitle => 'Habiltar';
+
+  @override
+  String get configurationUIAutoMountSubtitle => 'Habilitar o recurso de montagem automática. Esse recurso permite a montagem automática dos drives do Windows no WSL.';
+
+  @override
+  String get configurationUIMountFstabTitle => 'Montar /etc/fstab';
+
+  @override
+  String get configurationUIMountFstabSubtitle => 'Habilita a montagem do arquivo /etc/fstab. O arquivo de configuração /etc/fstab contém ???';
+
+  @override
+  String get setupCompleteTitle => 'Configuração concluída';
+
+  @override
+  String setupCompleteHeader(Object user) {
+    return 'Olá $user,\nVocê concluiu a configuração com sucesso.';
+  }
+
+  @override
+  String get setupCompleteUpdate => 'Recomendamos rodar os seguintes commandos para atualizar o Ubuntu para a última versão:';
+
+  @override
+  String get setupCompleteManage => 'Você pode usar o comando ubuntuwsl para gerenciar suas configurações do WSL:';
+
+  @override
+  String get setupCompleteRestart => '* Todas as configurações serão aplicadas após reiniciar o Ubuntu.';
+}

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_pt.arb
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_pt.arb
@@ -1,0 +1,70 @@
+{
+  "@@locale": "pt",
+
+  "appTitle": "Ubuntu WSL",
+  "windowTitle": "Ubuntu WSL",
+
+  "exitButton": "Sair",
+  "finishButton": "Concluir",
+  "saveButton": "Salvar",
+  "setupButton": "Configurar",
+
+  "selectLanguageTitle": "Selecione seu idioma",
+
+  "profileSetupTitle": "Configurar perfil",
+  "profileSetupHeader": "Por favor crie a sua conta UNIX padrão. Para mais informações visite: <a href=\"https://aka.ms/wslusers\">https://aka.ms/wslusers</a>",
+  "profileSetupRealnameLabel": "Seu nome",
+  "profileSetupRealnameRequired": "Um nome é necessário",
+  "profileSetupUsernameHint": "Escolha um nome de usuário",
+  "profileSetupUsernameHelper": "O nome de usuário não precisa ser igual ao Windows.",
+  "profileSetupPasswordHint": "Escolha uma senha",
+  "profileSetupConfirmPasswordHint": "Confirme a senha",
+  "profileSetupShowAdvancedOptions": "Mostrar opções avançadas na próxima página",
+  "profileSetupPasswordMismatch": "As senhas não correspondem",
+  "profileSetupUsernameRequired": "Nome de usuário é obrigatório",
+  "profileSetupUsernameInvalid": "O nome de usuário é inválido",
+  "profileSetupPasswordRequired": "Senha é obrigatória",
+
+  "advancedSetupTitle": "Configurações avançadas",
+  "advancedSetupHeader": "Nessa página você pode ajustar o Ubuntu WSL de acordo com suas necessidades.",
+  "advancedSetupMountLocationHint": "Ponto de montagem",
+  "advancedSetupMountLocationHelper": "Local para montagem automática",
+  "advancedSetupMountLocationInvalid": "O local informado é inválido",
+  "advancedSetupMountOptionHint": "Opções de montagem",
+  "advancedSetupMountOptionHelper": "Opções passadas para a montagem automática",
+  "advancedSetupHostGenerationTitle": "Habilitar geração de host",
+  "advancedSetupHostGenerationSubtitle": "Selecione para habilitar re-criação do arquivo /etc/hosts a cada reinicialização do sistema.",
+  "advancedSetupResolvConfGenerationTitle": "Habilitar geração do arquivo resolv.conf",
+  "advancedSetupResolvConfGenerationSubtitle": "Selecione para habilitar re-criação do arquivo /etc/resolv.conf a cada reinicialização do sistema.",
+  "advancedSetupGUIIntegrationTitle": "Intergração gráfica",
+  "advancedSetupGUIIntegrationSubtitle": "Selecione para habilitar configuração automática do DISPLAY. É necessário X server de terceiros.",
+
+  "configurationUITitle": "UI de Configuração do Ubuntu WSL (experimental)",
+  "configurationUIInteroperabilityHeader": "Interoperabilidade",
+  "configurationUILegacyGUIIntegrationTitle": "Integration Gráfica Legada",
+  "configurationUILegacyGUIIntegrationSubtitle": "Esta opção habilita a integração gráfica legada no Windows 10. Requer X server de terceiros.",
+  "configurationUILegacyAudioIntegrationTitle": "Integração de Áudio Legada",
+  "configurationUILegacyAudioIntegrationSubtitle": "Esta opção habilita a integração de áudio legada no Windows 10. Requer PulseAudio para Windows instalado.",
+  "configurationUIAdvancedIPDetectionTitle": "Detecção Avançada de IP",
+  "configurationUIAdvancedIPDetectionSubtitle": "Esta opção habilita detecção avançada de IP pelo endereço IPv4 do Windows que é mais confiável para uso com WSL2.\nRequer Interoperabilidade com WSL habilitada.",
+  "configurationUIMessageOfTheDayHeader": "Mensagem do Dia (MOTD)",
+  "configurationUIWSLNewsTitle": "WSL News",
+  "configurationUIWSLNewsSubtitle": "Esta opção permite ao usuário controlar seu MOTD News. Selecione para habilitar a exibição do MOTD.",
+  "configurationUIAutoMountHeader": "Montagem Automática",
+  "configurationUIAutoMountTitle": "Habiltar",
+  "configurationUIAutoMountSubtitle": "Habilitar o recurso de montagem automática. Esse recurso permite a montagem automática dos drives do Windows no WSL.",
+  "configurationUIMountFstabTitle": "Montar /etc/fstab",
+  "configurationUIMountFstabSubtitle": "Habilita a montagem do arquivo /etc/fstab. O arquivo de configuração /etc/fstab contém ???",
+
+  "setupCompleteTitle": "Configuração concluída",
+  "setupCompleteHeader": "Olá {user},\nVocê concluiu a configuração com sucesso.",
+  "@setupCompleteHeader": {
+    "type": "text",
+    "placeholders": {
+      "user": {}
+    }
+  },
+  "setupCompleteUpdate": "Recomendamos rodar os seguintes commandos para atualizar o Ubuntu para a última versão:",
+  "setupCompleteManage": "Você pode usar o comando ubuntuwsl para gerenciar suas configurações do WSL:",
+  "setupCompleteRestart": "* Todas as configurações serão aplicadas após reiniciar o Ubuntu."
+}

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_pt_BR.arb
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_pt_BR.arb
@@ -1,0 +1,70 @@
+{
+  "@@locale": "pt_BR",
+
+  "appTitle": "Ubuntu WSL",
+  "windowTitle": "Ubuntu WSL",
+
+  "exitButton": "Sair",
+  "finishButton": "Concluir",
+  "saveButton": "Salvar",
+  "setupButton": "Configurar",
+
+  "selectLanguageTitle": "Selecione seu idioma",
+
+  "profileSetupTitle": "Configurar perfil",
+  "profileSetupHeader": "Por favor crie a sua conta UNIX padrão. Para mais informações visite: <a href=\"https://aka.ms/wslusers\">https://aka.ms/wslusers</a>",
+  "profileSetupRealnameLabel": "Seu nome",
+  "profileSetupRealnameRequired": "Um nome é necessário",
+  "profileSetupUsernameHint": "Escolha um nome de usuário",
+  "profileSetupUsernameHelper": "O nome de usuário não precisa ser igual ao Windows.",
+  "profileSetupPasswordHint": "Escolha uma senha",
+  "profileSetupConfirmPasswordHint": "Confirme a senha",
+  "profileSetupShowAdvancedOptions": "Mostrar opções avançadas na próxima página",
+  "profileSetupPasswordMismatch": "As senhas não correspondem",
+  "profileSetupUsernameRequired": "Nome de usuário é obrigatório",
+  "profileSetupUsernameInvalid": "O nome de usuário é inválido",
+  "profileSetupPasswordRequired": "Senha é obrigatória",
+
+  "advancedSetupTitle": "Configurações avançadas",
+  "advancedSetupHeader": "Nessa página você pode ajustar o Ubuntu WSL de acordo com suas necessidades.",
+  "advancedSetupMountLocationHint": "Ponto de montagem",
+  "advancedSetupMountLocationHelper": "Local para montagem automática",
+  "advancedSetupMountLocationInvalid": "O local informado é inválido",
+  "advancedSetupMountOptionHint": "Opções de montagem",
+  "advancedSetupMountOptionHelper": "Opções passadas para a montagem automática",
+  "advancedSetupHostGenerationTitle": "Habilitar geração de host",
+  "advancedSetupHostGenerationSubtitle": "Selecione para habilitar re-criação do arquivo /etc/hosts a cada reinicialização do sistema.",
+  "advancedSetupResolvConfGenerationTitle": "Habilitar geração do arquivo resolv.conf",
+  "advancedSetupResolvConfGenerationSubtitle": "Selecione para habilitar re-criação do arquivo /etc/resolv.conf a cada reinicialização do sistema.",
+  "advancedSetupGUIIntegrationTitle": "Intergração gráfica",
+  "advancedSetupGUIIntegrationSubtitle": "Selecione para habilitar configuração automática do DISPLAY. É necessário X server de terceiros.",
+
+  "configurationUITitle": "UI de Configuração do Ubuntu WSL (experimental)",
+  "configurationUIInteroperabilityHeader": "Interoperabilidade",
+  "configurationUILegacyGUIIntegrationTitle": "Integration Gráfica Legada",
+  "configurationUILegacyGUIIntegrationSubtitle": "Esta opção habilita a integração gráfica legada no Windows 10. Requer X server de terceiros.",
+  "configurationUILegacyAudioIntegrationTitle": "Integração de Áudio Legada",
+  "configurationUILegacyAudioIntegrationSubtitle": "Esta opção habilita a integração de áudio legada no Windows 10. Requer PulseAudio para Windows instalado.",
+  "configurationUIAdvancedIPDetectionTitle": "Detecção Avançada de IP",
+  "configurationUIAdvancedIPDetectionSubtitle": "Esta opção habilita detecção avançada de IP pelo endereço IPv4 do Windows que é mais confiável para uso com WSL2.\nRequer Interoperabilidade com WSL habilitada.",
+  "configurationUIMessageOfTheDayHeader": "Mensagem do Dia (MOTD)",
+  "configurationUIWSLNewsTitle": "WSL News",
+  "configurationUIWSLNewsSubtitle": "Esta opção permite ao usuário controlar seu MOTD News. Selecione para habilitar a exibição do MOTD.",
+  "configurationUIAutoMountHeader": "Montagem Automática",
+  "configurationUIAutoMountTitle": "Habiltar",
+  "configurationUIAutoMountSubtitle": "Habilitar o recurso de montagem automática. Esse recurso permite a montagem automática dos drives do Windows no WSL.",
+  "configurationUIMountFstabTitle": "Montar /etc/fstab",
+  "configurationUIMountFstabSubtitle": "Habilita a montagem do arquivo /etc/fstab. O arquivo de configuração /etc/fstab contém ???",
+
+  "setupCompleteTitle": "Configuração concluída",
+  "setupCompleteHeader": "Olá {user},\nVocê concluiu a configuração com sucesso.",
+  "@setupCompleteHeader": {
+    "type": "text",
+    "placeholders": {
+      "user": {}
+    }
+  },
+  "setupCompleteUpdate": "Recomendamos rodar os seguintes commandos para atualizar o Ubuntu para a última versão:",
+  "setupCompleteManage": "Você pode usar o comando ubuntuwsl para gerenciar suas configurações do WSL:",
+  "setupCompleteRestart": "* Todas as configurações serão aplicadas após reiniciar o Ubuntu."
+}


### PR DESCRIPTION
Hi @jpnurmi !

As part of the 'prefill' feature, during my work with the server side code, I felt the need for more translations so I completed translation files required to enable pt_BR locale. I tested WSL, even though I touched translation files in ubuntu_wizard and ubuntu_desktop_installer packages. Feel free to find a translation specialist to review those translations and make use of them.

- pt.arb file was merely created due `melos` complains. I'm not keen to the terms used in Portugal.
- pt_BR.arb files are pretty complete. I'd consider them useful. Dedicated review by professional translators won't hurt, though.

I'll be submitting another PR in a couple of minutes with code I changed for WSL Locale page and view model related to that feature and with more details about what's been done.