### PR TITLE
Improve keyboard layout tab navigation

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -87,21 +87,24 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
             child: Row(
               children: <Widget>[
                 Expanded(
-                  child: RoundedListView.builder(
-                    controller: _layoutListScrollController,
-                    itemCount: model.layoutCount,
-                    itemBuilder: (context, index) {
-                      return AutoScrollTag(
-                        index: index,
-                        key: ValueKey(index),
-                        controller: _layoutListScrollController,
-                        child: ListTile(
-                          title: Text(model.layoutName(index)),
-                          selected: index == model.selectedLayoutIndex,
-                          onTap: () => model.selectLayout(index),
-                        ),
-                      );
-                    },
+                  child: FocusTraversalGroup(
+                    policy: WidgetOrderTraversalPolicy(),
+                    child: RoundedListView.builder(
+                      controller: _layoutListScrollController,
+                      itemCount: model.layoutCount,
+                      itemBuilder: (context, index) {
+                        return AutoScrollTag(
+                          index: index,
+                          key: ValueKey(index),
+                          controller: _layoutListScrollController,
+                          child: ListTile(
+                            title: Text(model.layoutName(index)),
+                            selected: index == model.selectedLayoutIndex,
+                            onTap: () => model.selectLayout(index),
+                          ),
+                        );
+                      },
+                    ),
                   ),
                 ),
                 const SizedBox(width: 20),


### PR DESCRIPTION
Traverse lists from top-to-bottom instead of jumping between lists. The
real fix would be to make the lists act like a singular focus node, but
that's hard to fix outside of Flutter. This fix makes the navigation a
bit less embarrassing, meanwhile. :)

Ref: #453