### PR TITLE
Enable the prefer_const_constructors linter rule and fix findings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,8 +6,10 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.mocks.dart"
     - "**/l10n/*.dart"
+    - "**/test/**.dart"
 
 linter:
   rules:
     constant_identifier_names: false
     lines_longer_than_80_chars: false
+    prefer_const_constructors: true

--- a/packages/logger/lib/logger.dart
+++ b/packages/logger/lib/logger.dart
@@ -49,7 +49,8 @@ class Logger {
     }
 
     // console output
-    final console = PrintAppender(formatter: _LogFormatter(verbose: false));
+    final console =
+        PrintAppender(formatter: const _LogFormatter(verbose: false));
     console.attachToLogger(log.Logger.root);
 
     // log file
@@ -60,7 +61,7 @@ class Logger {
 
         final file = RotatingFileAppender(
           baseFilePath: '$path.$pid',
-          formatter: _LogFormatter(verbose: true),
+          formatter: const _LogFormatter(verbose: true),
         );
         file.attachToLogger(log.Logger.root);
 

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -111,7 +111,7 @@ abstract class SubiquityServer {
         await client.send(request);
         break;
       } on Exception catch (_) {
-        await Future.delayed(Duration(seconds: 1));
+        await Future.delayed(const Duration(seconds: 1));
       }
     }
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -20,7 +20,7 @@ class AllocateDiskSpacePage extends StatefulWidget {
     final service = Provider.of<DiskStorageService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => AllocateDiskSpaceModel(service),
-      child: AllocateDiskSpacePage(),
+      child: const AllocateDiskSpacePage(),
     );
   }
 
@@ -74,13 +74,13 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
         children: <Widget>[
           PartitionBar(),
           const SizedBox(height: kContentSpacing / 2),
-          PartitionLegend(),
+          const PartitionLegend(),
           const SizedBox(height: kContentSpacing / 2),
           Expanded(child: PartitionTable(controller: _scrollController)),
           const SizedBox(height: kContentSpacing / 2),
-          PartitionButtonRow(),
+          const PartitionButtonRow(),
           const SizedBox(height: kContentSpacing),
-          BootDiskSelector(),
+          const BootDiskSelector(),
         ],
       ),
       actions: <WizardAction>[

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -18,7 +18,7 @@ class PartitionBar extends StatelessWidget {
     final model = Provider.of<AllocateDiskSpaceModel>(context);
     return RoundedContainer(
       child: CustomPaint(
-        size: Size(double.infinity, 24),
+        size: const Size(double.infinity, 24),
         painter: _PartitionPainter(model),
       ),
     );
@@ -87,9 +87,9 @@ class PartitionLegend extends StatelessWidget {
       child: ListView.separated(
         shrinkWrap: true,
         scrollDirection: Axis.horizontal,
-        padding: EdgeInsets.symmetric(vertical: 8),
+        padding: const EdgeInsets.symmetric(vertical: 8),
         itemCount: partitionCount + 1,
-        separatorBuilder: (context, index) => SizedBox(width: 40),
+        separatorBuilder: (context, index) => const SizedBox(width: 40),
         itemBuilder: (context, index) {
           if (index >= partitionCount) {
             return _PartitionLabel(
@@ -193,11 +193,11 @@ class PartitionTable extends StatelessWidget {
               ),
             ),
           ),
-          DataCell(SizedBox.shrink()),
-          DataCell(SizedBox.shrink()),
+          const DataCell(SizedBox.shrink()),
+          const DataCell(SizedBox.shrink()),
           DataCell(Text(disk.prettySize)),
           DataCell(Text(disk.ptable ?? '')),
-          DataCell(SizedBox.shrink()),
+          const DataCell(SizedBox.shrink()),
         ],
       ),
       for (var partitionIndex = 0;
@@ -220,7 +220,7 @@ class PartitionTable extends StatelessWidget {
                   index: hashList([diskIndex, partitionIndex]),
                   key: ValueKey(hashList([diskIndex, partitionIndex])),
                   child: Padding(
-                    padding: EdgeInsets.only(left: 40),
+                    padding: const EdgeInsets.only(left: 40),
                     child: Row(
                       children: [
                         const Icon(YaruIcons.drive_harddisk),
@@ -317,31 +317,31 @@ class PartitionButtonRow extends StatelessWidget {
                   child: const Icon(Icons.add),
                   style: OutlinedButton.styleFrom(
                     side: BorderSide.none,
-                    shape: RoundedRectangleBorder(),
+                    shape: const RoundedRectangleBorder(),
                   ),
                   onPressed: model.canAddPartition
                       ? () => showCreatePartitionDialog(
                           context, model.selectedDisk!)
                       : null,
                 ),
-                VerticalDivider(width: 1),
+                const VerticalDivider(width: 1),
                 OutlinedButton(
                   child: const Icon(Icons.remove),
                   style: OutlinedButton.styleFrom(
                     side: BorderSide.none,
-                    shape: RoundedRectangleBorder(),
+                    shape: const RoundedRectangleBorder(),
                   ),
                   onPressed: model.canRemovePartition
                       ? () => model.deletePartition(
                           model.selectedDisk!, model.selectedPartition!)
                       : null,
                 ),
-                VerticalDivider(width: 1),
+                const VerticalDivider(width: 1),
                 OutlinedButton(
                   child: Text(lang.changeButtonText),
                   style: OutlinedButton.styleFrom(
                     side: BorderSide.none,
-                    shape: RoundedRectangleBorder(),
+                    shape: const RoundedRectangleBorder(),
                   ),
                   onPressed: model.canEditPartition
                       ? () => showEditPartitionDialog(context,

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -28,7 +28,7 @@ class ChooseSecurityKeyPage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => ChooseSecurityKeyModel(client),
-      child: ChooseSecurityKeyPage(),
+      child: const ChooseSecurityKeyPage(),
     );
   }
 
@@ -69,7 +69,7 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
                 child: Html(
                   data: lang.chooseSecurityKeyWarning(
                       Theme.of(context).errorColor.toHex()),
-                  style: {'body': Style(margin: EdgeInsets.all(0))},
+                  style: {'body': Style(margin: EdgeInsets.zero)},
                 ),
               ),
             ),

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_widgets.dart
@@ -18,7 +18,7 @@ class _SecurityKeyFormField extends StatelessWidget {
       fieldWidth: fieldWidth,
       labelText: lang.chooseSecurityKeyHint,
       obscureText: true,
-      successWidget: securityKey.isNotEmpty ? SuccessIcon() : null,
+      successWidget: securityKey.isNotEmpty ? const SuccessIcon() : null,
       initialValue: securityKey,
       validator: RequiredValidator(
         errorText: lang.chooseSecurityKeyRequired,
@@ -52,7 +52,8 @@ class _ConfirmSecurityKeyFormField extends StatelessWidget {
       fieldWidth: fieldWidth,
       labelText: lang.chooseSecurityKeyConfirmHint,
       obscureText: true,
-      successWidget: confirmedSecurityKey.isNotEmpty ? SuccessIcon() : null,
+      successWidget:
+          confirmedSecurityKey.isNotEmpty ? const SuccessIcon() : null,
       initialValue: confirmedSecurityKey,
       autovalidateMode: AutovalidateMode.always,
       validator: EqualValidator(

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -7,7 +7,7 @@ import '../../l10n.dart';
 class ChooseYourLookPage extends StatelessWidget {
   const ChooseYourLookPage({Key? key}) : super(key: key);
 
-  static Widget create(BuildContext context) => ChooseYourLookPage();
+  static Widget create(BuildContext context) => const ChooseYourLookPage();
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +19,7 @@ class ChooseYourLookPage extends StatelessWidget {
         WizardAction.next(context),
       ],
       title: Text(lang.chooseYourLookPageTitle),
-      contentPadding: EdgeInsets.fromLTRB(20, 50, 20, 150),
+      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 150),
       content: Center(
         child: ListView(
             shrinkWrap: true,

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -17,7 +17,7 @@ class InstallationCompletePage extends StatelessWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return Provider(
       create: (_) => InstallationCompleteModel(client),
-      child: InstallationCompletePage(),
+      child: const InstallationCompletePage(),
     );
   }
 
@@ -38,7 +38,7 @@ class InstallationCompletePage extends StatelessWidget {
                   width: 8,
                 ),
               ),
-              child: CircleAvatar(
+              child: const CircleAvatar(
                 radius: 80,
                 backgroundImage: AssetImage(
                   'assets/version.png',

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -21,7 +21,7 @@ class InstallationSlidesPage extends StatefulWidget {
     final journal = Provider.of<JournalService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => InstallationSlidesModel(client, journal),
-      child: InstallationSlidesPage(),
+      child: const InstallationSlidesPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -24,7 +24,7 @@ class InstallationTypePage extends StatefulWidget {
     final service = Provider.of<DiskStorageService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (context) => InstallationTypeModel(client, service),
-      child: InstallationTypePage(),
+      child: const InstallationTypePage(),
     );
   }
 
@@ -61,7 +61,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
               subtitle: Html(
                 data: lang.installationTypeReinstallWarning(
                     Theme.of(context).errorColor.toHex(), model.existingOS!),
-                style: {'body': Style(margin: EdgeInsets.all(0))},
+                style: {'body': Style(margin: EdgeInsets.zero)},
               ),
               value: InstallationType.reinstall,
               groupValue: model.installationType,
@@ -83,7 +83,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
             subtitle: Html(
               data: lang.installationTypeEraseWarning(
                   Theme.of(context).errorColor.toHex()),
-              style: {'body': Style(margin: EdgeInsets.all(0))},
+              style: {'body': Style(margin: EdgeInsets.zero)},
             ),
             value: InstallationType.erase,
             groupValue: model.installationType,

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -23,7 +23,7 @@ class KeyboardLayoutPage extends StatefulWidget {
         client: Provider.of<SubiquityClient>(context, listen: false),
         keyboardService: Provider.of<KeyboardService>(context, listen: false),
       ),
-      child: KeyboardLayoutPage(),
+      child: const KeyboardLayoutPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -20,7 +20,7 @@ class SelectGuidedStoragePage extends StatefulWidget {
     final service = Provider.of<DiskStorageService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (context) => SelectGuidedStorageModel(service),
-      child: SelectGuidedStoragePage(),
+      child: const SelectGuidedStoragePage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -18,7 +18,7 @@ class TryOrInstallPage extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => TryOrInstallModel(),
-      child: TryOrInstallPage(),
+      child: const TryOrInstallPage(),
     );
   }
 
@@ -33,7 +33,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: Text(lang.tryOrInstallPageTitle),
-      contentPadding: EdgeInsets.fromLTRB(20, 50, 20, 150),
+      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 150),
       content: Row(
         children: [
           Expanded(

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -32,7 +32,7 @@ class TurnOffBitLockerPage extends StatelessWidget {
                 .turnOffBitlockerLinkInstructions('help.ubuntu.com/bitlocker'),
             style: {
               'body': Style(
-                margin: EdgeInsets.all(0),
+                margin: EdgeInsets.zero,
               ),
             },
             onLinkTap: (url, _, __, ___) => launch(url!),

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -20,7 +20,7 @@ class TurnOffRSTPage extends StatelessWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return Provider(
       create: (_) => TurnOffRSTModel(client),
-      child: TurnOffRSTPage(),
+      child: const TurnOffRSTPage(),
     );
   }
 
@@ -38,7 +38,7 @@ class TurnOffRSTPage extends StatelessWidget {
               data: lang.instructionsForRST('help.ubuntu.com/rst'),
               style: {
                 'body': Style(
-                  margin: EdgeInsets.all(0),
+                  margin: EdgeInsets.zero,
                 ),
               },
               onLinkTap: (url, _, __, ___) => launch(url!),

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -20,7 +20,7 @@ class WelcomePage extends StatefulWidget {
         client: Provider.of<SubiquityClient>(context, listen: false),
         keyboardService: Provider.of<KeyboardService>(context, listen: false),
       ),
-      child: WelcomePage(),
+      child: const WelcomePage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -28,7 +28,7 @@ class WhoAreYouPage extends StatefulWidget {
     final service = Provider.of<HostnameService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => WhoAreYouModel(client: client, service: service),
-      child: WhoAreYouPage(),
+      child: const WhoAreYouPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -22,7 +22,7 @@ class WriteChangesToDiskPage extends StatefulWidget {
     final service = Provider.of<DiskStorageService>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => WriteChangesToDiskModel(client, service),
-      child: WriteChangesToDiskPage(),
+      child: const WriteChangesToDiskPage(),
     );
   }
 
@@ -68,7 +68,7 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
                 alignment: Alignment.centerLeft,
                 child: Text(
                   prettyFormatDisk(disk),
-                  style: TextStyle(fontWeight: FontWeight.bold),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                   key: ValueKey(disk),
                 ),
               ),

--- a/packages/ubuntu_wizard/lib/settings.dart
+++ b/packages/ubuntu_wizard/lib/settings.dart
@@ -30,11 +30,11 @@ class Settings extends ChangeNotifier {
     switch (brightness) {
       case Brightness.dark:
         _theme = ThemeMode.dark;
-        _gsettings.set('gtk-theme', DBusString('Yaru-dark'));
+        _gsettings.set('gtk-theme', const DBusString('Yaru-dark'));
         break;
       case Brightness.light:
         _theme = ThemeMode.light;
-        _gsettings.set('gtk-theme', DBusString('Yaru'));
+        _gsettings.set('gtk-theme', const DBusString('Yaru'));
         break;
     }
     notifyListeners();

--- a/packages/ubuntu_wizard/lib/src/utils/window.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/window.dart
@@ -7,8 +7,8 @@ import 'package:logger/logger.dart';
 /// @internal
 final log = Logger('window');
 
-final _methodChannel = MethodChannel('ubuntu_wizard');
-final _eventChannel = EventChannel('ubuntu_wizard/events');
+const _methodChannel = MethodChannel('ubuntu_wizard');
+const _eventChannel = EventChannel('ubuntu_wizard/events');
 
 void _listenEvent(String event, VoidCallback callback) {
   _eventChannel.receiveBroadcastStream().listen((ev) {

--- a/packages/ubuntu_wizard/lib/src/widgets/dropdown_builder.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/dropdown_builder.dart
@@ -54,7 +54,7 @@ class DropdownBuilder<T> extends StatelessWidget {
       alignedDropdown: true,
       child: DropdownButtonHideUnderline(
         child: InputDecorator(
-          decoration: InputDecoration(contentPadding: EdgeInsets.zero)
+          decoration: const InputDecoration(contentPadding: EdgeInsets.zero)
               .applyDefaults(Theme.of(context).inputDecorationTheme),
           child: DropdownButton<T>(
             value: selected,

--- a/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
@@ -97,7 +97,7 @@ class OptionCardState extends State<OptionCard> {
               alignment: Alignment.centerLeft,
               child: Text(
                 widget.titleText ?? '',
-                style: TextStyle(
+                style: const TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 19,
                 ),

--- a/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
@@ -32,7 +32,7 @@ class PasswordStrengthLabel extends StatelessWidget {
           style: TextStyle(color: Theme.of(context).successColor),
         );
       default:
-        return SizedBox.shrink();
+        return const SizedBox.shrink();
     }
   }
 }

--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -140,7 +140,7 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
               padding: EdgeInsets.only(left: widget.spacing ?? 0.0),
               child: widget.successWidget == null ||
                       !widget.validator.isValid(value.text)
-                  ? SizedBox.shrink()
+                  ? const SizedBox.shrink()
                   : _alignBaseline(widget.successWidget),
             );
           },

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
@@ -10,7 +10,7 @@ class AdvancedSetupModel extends ChangeNotifier {
   }
 
   final SubiquityClient _client;
-  final _conf = ValueNotifier(WSLConfigurationBase());
+  final _conf = ValueNotifier(const WSLConfigurationBase());
 
   /// Location for the automount.
   String get mountLocation => _conf.value.automountRoot ?? '';

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -27,7 +27,7 @@ class AdvancedSetupPage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => AdvancedSetupModel(client),
-      child: AdvancedSetupPage(),
+      child: const AdvancedSetupPage(),
     );
   }
 
@@ -68,9 +68,9 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
               child: _MountOptionFormField(fieldWidth: fieldWidth),
             ),
             const SizedBox(height: kContentSpacing * 2),
-            _HostGenerationCheckButton(),
+            const _HostGenerationCheckButton(),
             const SizedBox(height: kContentSpacing),
-            _ResolvConfGenerationCheckButton(),
+            const _ResolvConfGenerationCheckButton(),
           ],
         );
       }),

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
@@ -13,7 +13,7 @@ class ConfigurationUIModel extends ChangeNotifier {
   }
 
   final SubiquityClient _client;
-  final _conf = ValueNotifier(WSLConfigurationAdvanced());
+  final _conf = ValueNotifier(const WSLConfigurationAdvanced());
 
   /// Whether legacy GUI integration is enabled.
   bool get interopGuiintegration => _conf.value.interopGuiintegration ?? false;

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -20,7 +20,7 @@ class ConfigurationUIPage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => ConfigurationUIModel(client),
-      child: ConfigurationUIPage(),
+      child: const ConfigurationUIPage(),
     );
   }
 

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -27,7 +27,7 @@ class ProfileSetupPage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => ProfileSetupModel(client),
-      child: ProfileSetupPage(),
+      child: const ProfileSetupPage(),
     );
   }
 
@@ -53,7 +53,7 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
       title: Text(lang.profileSetupTitle),
       header: Html(
         data: lang.profileSetupHeader,
-        style: {'body': Style(margin: EdgeInsets.all(0))},
+        style: {'body': Style(margin: EdgeInsets.zero)},
         onLinkTap: (url, _, __, ___) => launch(url!),
       ),
       content: LayoutBuilder(builder: (context, constraints) {

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -17,7 +17,7 @@ class SelectLanguagePage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => SelectLanguageModel(client),
-      child: SelectLanguagePage(),
+      child: const SelectLanguagePage(),
     );
   }
 

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
@@ -12,7 +12,7 @@ class SetupCompleteModel extends ChangeNotifier with SystemShutdown {
   @override
   final SubiquityClient client;
 
-  final _identity = ValueNotifier(IdentityData());
+  final _identity = ValueNotifier(const IdentityData());
 
   /// The username for the profile.
   String get username => _identity.value.username ?? '';

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -25,7 +25,7 @@ class SetupCompletePage extends StatefulWidget {
     final client = Provider.of<SubiquityClient>(context, listen: false);
     return ChangeNotifierProvider(
       create: (_) => SetupCompleteModel(client),
-      child: SetupCompletePage(),
+      child: const SetupCompletePage(),
     );
   }
 


### PR DESCRIPTION
This is a useful linter rule that makes sure we take advantage of Dart's compile-time constants where possible.