### PR TITLE
Fix wrong assumptions in language list tests

### DIFF
--- a/packages/ubuntu_desktop_installer/test/welcome_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_model_test.dart
@@ -56,8 +56,10 @@ void main() {
     expect(model.languageCount, greaterThan(1));
     expect(model.selectedLanguageIndex, equals(0));
 
+    // falls back to the base locale (en_US)
     model.selectLocale(Locale('foo'));
-    expect(model.selectedLanguageIndex, equals(0));
+    expect(
+        model.locale(model.selectedLanguageIndex), equals(Locale('en', 'US')));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);

--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -59,24 +59,29 @@ void main() {
 
     final settings = Settings.of(tester.element(languageList), listen: false);
 
-    final listItems =
-        find.descendant(of: languageList, matching: find.byType(ListTile));
+    final listItems = find.descendant(
+        of: languageList, matching: find.byType(ListTile), skipOffstage: false);
     expect(listItems, findsWidgets);
     expect(listItems.evaluate().length, lessThan(app.supportedLocales.length));
     for (final language in ['English', 'Français', 'Italiano']) {
-      expect(find.descendant(of: languageList, matching: find.text(language)),
-          findsOneWidget);
+      final listItem = find.descendant(
+          of: languageList, matching: find.text(language), skipOffstage: false);
+      await tester.dragUntilVisible(listItem, languageList, Offset(0, -10));
+      expect(listItem, findsOneWidget);
     }
 
-    final itemEnglish = find.widgetWithText(ListTile, 'English');
+    final itemEnglish =
+        find.widgetWithText(ListTile, 'English', skipOffstage: false);
     expect(itemEnglish, findsOneWidget);
     expect((itemEnglish.evaluate().single.widget as ListTile).selected, true);
     expect(settings.locale.languageCode, 'en');
 
-    final itemFrench = find.widgetWithText(ListTile, 'Français');
+    final itemFrench =
+        find.widgetWithText(ListTile, 'Français', skipOffstage: false);
     expect(itemFrench, findsOneWidget);
     expect((itemFrench.evaluate().single.widget as ListTile).selected, false);
 
+    await tester.ensureVisible(itemFrench);
     await tester.tap(itemFrench);
     await tester.pump();
     expect((itemEnglish.evaluate().single.widget as ListTile).selected, false);


### PR DESCRIPTION
- Fix the widget test to not assume that all tested languages
  (English, French, Italian) are on the screen at the same time,
  because they won't be after the list of languages grows

- Fix the model test to not assume that en_US is the first language