### PR TITLE
arbgen: generate ARB files from languagelist and PO files

### DIFF
--- a/scripts/import-po.sh
+++ b/scripts/import-po.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $(basename $0) dir1 dir2 ..."
+    exit 1
+fi
+
+if ! dart --version >/dev/null 2>&1; then
+    echo "Dart is not installed"
+    exit 1
+fi
+
+project_dir=$(realpath $(dirname "$0")/..)
+arbgen_dir="$project_dir/tool/arbgen"
+arbgen_bin="$arbgen_dir/bin/arbgen.dart"
+
+(cd "$arbgen_dir" && dart pub get)
+
+# find dirs that contain .arb files
+arb_dirs=$(find "$project_dir" -type f -name "*.arb" -exec dirname {} \; | uniq)
+echo "Resolving ARB directories..."
+for arb_dir in $arb_dirs; do
+    # app_en.arb -> app, ubuntu_en.arb -> ubuntu
+    prefix=$(basename $(find "$arb_dir" -name "*_en.arb") "_en.arb")
+    echo "+ $(realpath $arb_dir --relative-to="$project_dir") ($prefix)"
+done
+
+for import_dir in "$@"; do
+    if [ ! -d "$import_dir" ]; then
+        echo "Error: $import_dir is not a directory"
+        exit 1
+    fi
+
+    # find dirs that contain .po files
+    po_dirs=$(find "$import_dir" -type f -name "*.po" -exec dirname {} \; | uniq)
+
+    # import all .po dirs to all .arb dirs
+    for po_dir in $po_dirs; do
+        echo "Importing $(realpath "$po_dir" --relative-to="$import_dir")..."
+        for arb_dir in $arb_dirs; do
+            # app_en.arb -> app, ubuntu_en.arb -> ubuntu
+            prefix=$(basename $(find "$arb_dir" -name "*_en.arb") "_en.arb")
+
+            dart run "$arbgen_bin" "$po_dir" --verbose --prefix $prefix \
+              --output "$(realpath $arb_dir --relative-to="$project_dir")" 
+        done
+    done
+done
+
+echo "Cleaning up ARB directories..."
+# https://github.com/flutter/flutter/issues/92818
+for arb_dir in $arb_dirs; do
+    arb_files=$(find $arb_dir -name "*.arb")
+    for arb_file in $arb_files; do
+      lang=$(cut -d '_' -f 2 <<< $(basename "$arb_file" ".arb"))
+      if [ ${#lang} -gt 2 ]; then
+        echo "D $(realpath $arb_file --relative-to="$project_dir")"
+        rm "$arb_file"
+      fi
+    done
+done

--- a/tool/arbgen/.gitignore
+++ b/tool/arbgen/.gitignore
@@ -1,0 +1,7 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+pubspec.lock
+
+# Conventional directory for build output.
+build/

--- a/tool/arbgen/README.md
+++ b/tool/arbgen/README.md
@@ -1,0 +1,35 @@
+# ARB generator
+
+Generates Flutter ARB files from `languagelist` and PO files.
+
+## Dependencies
+
+Get Dart package dependencies:
+
+```bash
+$ cd tool/arbgen
+$ dart pub get
+```
+
+## Language files
+
+Generate `ubuntu_*.arb` from a [`languagelist`](https://git.launchpad.net/ubiquity/tree/d-i/source/localechooser/languagelist) file:
+
+```bash
+$ dart run bin/arbgen.dart /path/to/languagelist \
+    --prefix ubuntu \
+    --output ../../packages/ubuntu_wizard/lib/src/l10n
+```
+
+## Translation files
+
+Generate `app_*.arb` from a directory of [PO files](https://git.launchpad.net/ubiquity/tree/debian/real-po).
+
+```bash
+$ dart run bin/arbgen.dart /path/to/po/directory \
+    --output ../../packages/ubuntu_desktop_installer/lib/l10n
+```
+
+**NOTES**:
+- The command can be repeated for multiple input directories.
+- The output directory must contain `app_en.arb` for the generator to be able to match PO and ARB translation entries.

--- a/tool/arbgen/bin/arbgen.dart
+++ b/tool/arbgen/bin/arbgen.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:arbgen/arbgen.dart';
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+
+String get appName => p.basename(Platform.script.path);
+String get appDescription =>
+    'Generates Flutter ARB files from `languagelist` and PO files.';
+
+void printUsage(String options, {String? error}) {
+  final hasError = error?.isNotEmpty == true;
+  final out = hasError ? stderr : stdout;
+  if (hasError) {
+    out.write('Error: $error\n\n');
+  }
+  out.write('Usage: $appName [options] <input>\n\n');
+  out.write('Generate Flutter ARB files from `languagelist` and PO files.\n\n');
+  out.write('Options:\n$options\n');
+  exit(hasError ? -1 : 0);
+}
+
+void main(List<String> args) {
+  final parser = ArgParser();
+  parser.addFlag('help', abbr: 'h', negatable: false, help: 'Show usage.');
+  parser.addFlag('verbose',
+      abbr: 'v', negatable: false, help: 'Verbose output.');
+  parser.addOption(
+    'output',
+    abbr: 'o',
+    valueHelp: 'dir',
+    help: 'The output directory.',
+    defaultsTo: 'l10n',
+  );
+  parser.addOption(
+    'prefix',
+    abbr: 'p',
+    valueHelp: 'name',
+    help: 'The .arb file prefix.',
+    defaultsTo: 'app',
+  );
+
+  try {
+    final options = parser.parse(args);
+    if (options['help'] == true) {
+      printUsage(parser.usage);
+    }
+    if (options.rest.length != 1) {
+      printUsage(
+        parser.usage,
+        error: 'Unknown positional arguments "${options.rest.join(' ')}"',
+      );
+    }
+
+    final input = options.rest.single;
+    final prefix = options['prefix'];
+    final output = options['output'];
+    final verbose = options['verbose'] == true;
+
+    if (p.basename(input) == 'languagelist') {
+      importLanguagelist(
+        file: File(input),
+        prefix: prefix,
+        output: output,
+        verbose: verbose,
+      );
+    } else {
+      importPoFiles(
+        dir: Directory(input),
+        prefix: prefix,
+        output: output,
+        verbose: verbose,
+      );
+    }
+  } on FormatException catch (e) {
+    printUsage(parser.usage, error: e.message);
+  } on FileSystemException catch (e) {
+    printUsage(parser.usage, error: '${e.path}: ${e.message}');
+  }
+}

--- a/tool/arbgen/lib/arbgen.dart
+++ b/tool/arbgen/lib/arbgen.dart
@@ -1,0 +1,2 @@
+export 'src/languagelist.dart';
+export 'src/po.dart';

--- a/tool/arbgen/lib/src/languagelist.dart
+++ b/tool/arbgen/lib/src/languagelist.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+void importLanguagelist({
+  required File file,
+  required String prefix,
+  required String output,
+  bool? verbose,
+}) {
+  // langcode;language (en);language (orig);supported_environments;countrycode;fallbacklocale;langlist;console-setup
+  for (var line in file.readAsLinesSync()) {
+    final parts = line.split('#').first.split(';'); // ignore comments (#)
+    if (parts.length != 8 || parts[2].isEmpty || parts[4].isEmpty) continue;
+    _writeArbFile(
+      prefix: prefix,
+      output: output,
+      languageCode: parts[0].split('_').first,
+      languageName: parts[2],
+      countryCode: parts[4],
+      verbose: verbose,
+    );
+  }
+}
+
+void _writeArbFile({
+  required String prefix,
+  required String output,
+  required String languageName,
+  required String languageCode,
+  required String countryCode,
+  bool? verbose,
+}) {
+  final path = '$output/${prefix}_$languageCode.arb';
+  final file = File(path);
+  if (!file.existsSync()) {
+    if (verbose == true) print('A ${file.path}');
+    file.createSync(recursive: true);
+    file.writeAsStringSync('''
+{
+  "@@locale": "$languageCode",
+  "countryCode": "$countryCode",
+  "languageName": "$languageName"
+}
+''');
+  }
+}

--- a/tool/arbgen/lib/src/po.dart
+++ b/tool/arbgen/lib/src/po.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:gettext_parser/gettext_parser.dart' as gettext;
+import 'package:path/path.dart' as p;
+
+void importPoFiles({
+  required Directory dir,
+  required String prefix,
+  required String output,
+  bool? verbose,
+}) {
+  final enFile = File(p.join(output, '${prefix}_en.arb'));
+  final enArb = enFile.parseArb(allowEmpty: false);
+
+  for (final poFile in dir.listSync()) {
+    if (poFile is! File || p.extension(poFile.path) != '.po') continue;
+
+    final locale = p.basenameWithoutExtension(poFile.path);
+    final arbFile = File(p.join(output, '${prefix}_$locale.arb'));
+    if (!arbFile.existsSync()) continue;
+
+    final arbJson = arbFile.readJsonSync();
+    final arbData = Map.of(arbJson);
+    final poData = poFile.parsePo();
+
+    for (final context in poData['translations'].entries) {
+      for (final msg in context.value.entries) {
+        for (final match in enArb[msg.key] ?? []) {
+          final tr = (msg.value['msgstr'] as List<String>?)?.firstOrNull;
+          if (tr != null && tr.isNotEmpty) {
+            arbData[match] ??= tr;
+          }
+        }
+      }
+    }
+
+    if (!const MapEquality().equals(arbData, arbJson)) {
+      if (verbose == true) print('M ${arbFile.path}');
+      arbFile.writeJsonSync(arbData);
+    }
+  }
+}
+
+extension JsonFile on File {
+  Map<String, dynamic> readJsonSync({bool allowEmpty = true}) {
+    try {
+      return jsonDecode(readAsStringSync()) as Map<String, dynamic>;
+    } on Exception {
+      if (allowEmpty) return {};
+      rethrow;
+    }
+  }
+
+  void writeJsonSync(Map<String, dynamic> json) {
+    final data = const JsonEncoder.withIndent('  ').convert(json);
+    writeAsStringSync(data + '\n');
+  }
+}
+
+extension ArbFile on File {
+  Map<String, List<String>> parseArb({bool allowEmpty = true}) {
+    final translations = Map<String, List<String>>();
+    final json = readJsonSync(allowEmpty: allowEmpty);
+    for (final entry in json.entries) {
+      if (entry.key.startsWith('@') || entry.value is! String) continue;
+      (translations[entry.value] ??= []).add(entry.key);
+    }
+    return translations;
+  }
+}
+
+extension PoFile on File {
+  Map<String, dynamic> parsePo() {
+    return gettext.po.parse(readAsStringSync());
+  }
+}

--- a/tool/arbgen/pubspec.yaml
+++ b/tool/arbgen/pubspec.yaml
@@ -1,0 +1,13 @@
+name: arbgen
+description: Generates stub .arb files from a languagelist file.
+publist_to: 'none'
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  args: ^2.3.0
+  collection: ^1.15.0
+  gettext_parser: ^0.2.0
+  path: ^1.8.0
+  quiver: ^3.0.1+1


### PR DESCRIPTION
Run `scripts/import-po.sh path/to/ubiquity` to import all translated strings from Ubiquity where the msgid matches any translation in `xxx_en.arb`.