### PR TITLE
Turn off the public_member_api_docs linter rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,3 +13,4 @@ linter:
     constant_identifier_names: false
     lines_longer_than_80_chars: false
     prefer_const_constructors: true
+    public_member_api_docs: false


### PR DESCRIPTION
First of all, this linter rule is so noisy that it hides useful linter
issues. There are  linter issues slipping in due to `--no-fatal-infos`,
which is used in the CI to ignore `public_member_api_docs`.

Secondly, in an app project where there tend to be areas that don't need
docs, this linter rule results in not-so-useful docs that basically
repeat the same what the member name states, just to silence the linter
without adding any real value. For example:

    /// Does something.
    void doSomething() { ... }