### PR TITLE
WSL: disable the back button on the Select your language -page

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -84,7 +84,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
         ),
       ),
       actions: [
-        WizardAction.back(context),
+        WizardAction.back(context, enabled: false),
         WizardAction.next(
           context,
           onActivated: () {


### PR DESCRIPTION
This is supposed to be automatically taken care of by `wizard_router`,
but it doesn't trigger a rebuild as it should when navigating back, so
the back button is left enabled. It might not be easy to fix, so this
change explicitly disables the back button to make sure the user can't
attempt to navigate backwards to a page that doesn't exist.

Fixes: #469