### PR TITLE
UdevService: prepare for network devices

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -382,7 +382,7 @@ class BootDiskSelector extends StatelessWidget {
     final lang = AppLocalizations.of(context);
 
     String prettyFormatDisk(Disk disk) {
-      return '${disk.path} ${udev.fullName(sysname: disk.sysname)} (${disk.prettySize})';
+      return '${disk.path} ${udev.bySysname(disk.sysname).fullName} (${disk.prettySize})';
     }
 
     return Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -382,7 +382,7 @@ class BootDiskSelector extends StatelessWidget {
     final lang = AppLocalizations.of(context);
 
     String prettyFormatDisk(Disk disk) {
-      return '${disk.path} ${udev.fullName(disk.sysname)} (${disk.prettySize})';
+      return '${disk.path} ${udev.fullName(sysname: disk.sysname)} (${disk.prettySize})';
     }
 
     return Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -46,8 +46,8 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
   String prettyFormatStorage(Disk disk) {
     final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.modelName(disk.sysname),
-      udev.vendorName(disk.sysname)
+      udev.modelName(sysname: disk.sysname),
+      udev.vendorName(sysname: disk.sysname)
     ].where((p) => p?.isNotEmpty == true).join(' ');
 
     final size = filesize(disk.size);

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -46,8 +46,8 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
   String prettyFormatStorage(Disk disk) {
     final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.modelName(sysname: disk.sysname),
-      udev.vendorName(sysname: disk.sysname)
+      udev.bySysname(disk.sysname).modelName,
+      udev.bySysname(disk.sysname).vendorName,
     ].where((p) => p?.isNotEmpty == true).join(' ');
 
     final size = filesize(disk.size);

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -42,8 +42,8 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
   String prettyFormatDisk(Disk disk) {
     final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.modelName(disk.sysname),
-      udev.vendorName(disk.sysname)
+      udev.modelName(sysname: disk.sysname),
+      udev.vendorName(sysname: disk.sysname)
     ].where((p) => p?.isNotEmpty == true).join(' ');
     return '$fullName (${disk.sysname})';
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -42,8 +42,8 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
   String prettyFormatDisk(Disk disk) {
     final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.modelName(sysname: disk.sysname),
-      udev.vendorName(sysname: disk.sysname)
+      udev.bySysname(disk.sysname).modelName,
+      udev.bySysname(disk.sysname).vendorName,
     ].where((p) => p?.isNotEmpty == true).join(' ');
     return '$fullName (${disk.sysname})';
   }

--- a/packages/ubuntu_desktop_installer/lib/services/udev_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/udev_service.dart
@@ -12,20 +12,30 @@ class UdevService {
   void dispose() => _udev.dispose();
 
   /// The combined model and vendor name of the device.
-  String fullName(String sysname) {
+  String fullName({String? sysname, String? syspath}) {
     return <String?>[
-      modelName(sysname),
-      vendorName(sysname),
+      modelName(sysname: sysname, syspath: syspath),
+      vendorName(sysname: sysname, syspath: syspath),
     ].where((p) => p?.isNotEmpty == true).join(' ');
   }
 
   /// The model of the specified device (e.g. 'sda' -> 'UltraFit').
-  String? modelName(String sysname) => _getDevice(sysname)?.model;
+  String? modelName({String? sysname, String? syspath}) {
+    return _getDevice(sysname: sysname, syspath: syspath)?.model;
+  }
 
   /// The vendor of the specified device (e.g. 'sda' -> 'SanDisk').
-  String? vendorName(String sysname) => _getDevice(sysname)?.vendor;
+  String? vendorName({String? sysname, String? syspath}) {
+    return _getDevice(sysname: sysname, syspath: syspath)?.vendor;
+  }
 
-  UdevDevice? _getDevice(String sysname) {
-    return UdevDevice.fromSysname(_udev, subsystem: 'block', sysname: sysname);
+  UdevDevice? _getDevice({String? sysname, String? syspath}) {
+    assert(sysname != null || syspath != null);
+    if (sysname != null) {
+      return UdevDevice.fromSysname(_udev,
+          subsystem: 'block', sysname: sysname);
+    } else {
+      return UdevDevice.fromSyspath(_udev, syspath: syspath!);
+    }
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/services/udev_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/udev_service.dart
@@ -11,31 +11,56 @@ class UdevService {
   /// Releases the resources used by udev.
   void dispose() => _udev.dispose();
 
+  /// Returns [UdevDeviceInfo] for a device specified by its [sysname].
+  UdevDeviceInfo bySysname(String sysname) =>
+      _UdevSysnameDeviceInfo(_udev, sysname);
+
+  /// Returns [UdevDeviceInfo] for a device specified by its [syspath].
+  UdevDeviceInfo bySyspath(String syspath) =>
+      _UdevSyspathDeviceInfo(_udev, syspath);
+}
+
+/// Provides pretty disk names (e.g. 'sda' -> 'SanDisk UltraFit').
+abstract class UdevDeviceInfo {
+  UdevDeviceInfo._(this._sysinfo);
+
+  UdevDevice? _getDevice(String sysinfo);
+
+  final String _sysinfo;
+
   /// The combined model and vendor name of the device.
-  String fullName({String? sysname, String? syspath}) {
+  String get fullName {
     return <String?>[
-      modelName(sysname: sysname, syspath: syspath),
-      vendorName(sysname: sysname, syspath: syspath),
+      modelName,
+      vendorName,
     ].where((p) => p?.isNotEmpty == true).join(' ');
   }
 
   /// The model of the specified device (e.g. 'sda' -> 'UltraFit').
-  String? modelName({String? sysname, String? syspath}) {
-    return _getDevice(sysname: sysname, syspath: syspath)?.model;
-  }
+  String? get modelName => _getDevice(_sysinfo)?.model;
 
   /// The vendor of the specified device (e.g. 'sda' -> 'SanDisk').
-  String? vendorName({String? sysname, String? syspath}) {
-    return _getDevice(sysname: sysname, syspath: syspath)?.vendor;
-  }
+  String? get vendorName => _getDevice(_sysinfo)?.vendor;
+}
 
-  UdevDevice? _getDevice({String? sysname, String? syspath}) {
-    assert(sysname != null || syspath != null);
-    if (sysname != null) {
-      return UdevDevice.fromSysname(_udev,
-          subsystem: 'block', sysname: sysname);
-    } else {
-      return UdevDevice.fromSyspath(_udev, syspath: syspath!);
-    }
+class _UdevSyspathDeviceInfo extends UdevDeviceInfo {
+  _UdevSyspathDeviceInfo(this._udev, String syspath) : super._(syspath);
+
+  final Udev _udev;
+
+  @override
+  UdevDevice? _getDevice(String sysinfo) {
+    return UdevDevice.fromSyspath(_udev, syspath: sysinfo);
+  }
+}
+
+class _UdevSysnameDeviceInfo extends UdevDeviceInfo {
+  _UdevSysnameDeviceInfo(this._udev, String sysname) : super._(sysname);
+
+  final Udev _udev;
+
+  @override
+  UdevDevice? _getDevice(String sysinfo) {
+    return UdevDevice.fromSysname(_udev, subsystem: 'block', sysname: sysinfo);
   }
 }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
@@ -92,12 +92,16 @@ AllocateDiskSpaceModel buildModel({
   return model;
 }
 
-@GenerateMocks([AllocateDiskSpaceModel, UdevService])
+@GenerateMocks([AllocateDiskSpaceModel, UdevDeviceInfo, UdevService])
 void main() {
   Widget buildPage(AllocateDiskSpaceModel model) {
     final udev = MockUdevService();
-    when(udev.fullName(sysname: 'sda')).thenReturn('SDA');
-    when(udev.fullName(sysname: 'sdb')).thenReturn('SDB');
+    final sda = MockUdevDeviceInfo();
+    when(sda.fullName).thenReturn('SDA');
+    when(udev.bySysname('sda')).thenReturn(sda);
+    final sdb = MockUdevDeviceInfo();
+    when(sdb.fullName).thenReturn('SDB');
+    when(udev.bySysname('sdb')).thenReturn(sdb);
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
@@ -96,8 +96,8 @@ AllocateDiskSpaceModel buildModel({
 void main() {
   Widget buildPage(AllocateDiskSpaceModel model) {
     final udev = MockUdevService();
-    when(udev.fullName('sda')).thenReturn('SDA');
-    when(udev.fullName('sdb')).thenReturn('SDB');
+    when(udev.fullName(sysname: 'sda')).thenReturn('SDA');
+    when(udev.fullName(sysname: 'sdb')).thenReturn('SDB');
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.mocks.dart
@@ -155,16 +155,9 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#fullName, [sysname]),
-          returnValue: '') as String);
-  @override
-  String? modelName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#modelName, [sysname])) as String?);
-  @override
-  String? vendorName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#vendorName, [sysname]))
-          as String?);
+  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
+      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
+      returnValue: '') as String);
   @override
   String toString() => super.toString();
 }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.mocks.dart
@@ -2,14 +2,14 @@
 // in ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
-import 'dart:ui' as _i5;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i6;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_model.dart'
-    as _i2;
-import 'package:ubuntu_desktop_installer/services.dart' as _i6;
+    as _i3;
+import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -19,11 +19,13 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i6;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeUdevDeviceInfo_0 extends _i1.Fake implements _i2.UdevDeviceInfo {}
+
 /// A class which mocks [AllocateDiskSpaceModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockAllocateDiskSpaceModel extends _i1.Mock
-    implements _i2.AllocateDiskSpaceModel {
+    implements _i3.AllocateDiskSpaceModel {
   MockAllocateDiskSpaceModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -33,9 +35,9 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
-  List<_i3.Disk> get disks =>
-      (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i3.Disk>[])
-          as List<_i3.Disk>);
+  List<_i4.Disk> get disks =>
+      (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i4.Disk>[])
+          as List<_i4.Disk>);
   @override
   int get selectedDiskIndex =>
       (super.noSuchMethod(Invocation.getter(#selectedDiskIndex), returnValue: 0)
@@ -45,9 +47,9 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#selectedPartitionIndex),
           returnValue: 0) as int);
   @override
-  _i4.Stream<dynamic> get onSelectionChanged =>
+  _i5.Stream<dynamic> get onSelectionChanged =>
       (super.noSuchMethod(Invocation.getter(#onSelectionChanged),
-          returnValue: Stream<dynamic>.empty()) as _i4.Stream<dynamic>);
+          returnValue: Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
   @override
   bool get canAddPartition => (super
           .noSuchMethod(Invocation.getter(#canAddPartition), returnValue: false)
@@ -74,27 +76,27 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
           Invocation.method(#isStorageSelected, [diskIndex, partitionIndex]),
           returnValue: false) as bool);
   @override
-  _i4.Future<void> addPartition(_i3.Disk? disk,
-          {int? size, _i2.PartitionFormat? format, String? mount}) =>
+  _i5.Future<void> addPartition(_i4.Disk? disk,
+          {int? size, _i3.PartitionFormat? format, String? mount}) =>
       (super.noSuchMethod(
           Invocation.method(#addPartition, [disk],
               {#size: size, #format: format, #mount: mount}),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> editPartition(_i3.Disk? disk, _i3.Partition? partition,
-          {_i2.PartitionFormat? format, bool? wipe, String? mount}) =>
+  _i5.Future<void> editPartition(_i4.Disk? disk, _i4.Partition? partition,
+          {_i3.PartitionFormat? format, bool? wipe, String? mount}) =>
       (super.noSuchMethod(
           Invocation.method(#editPartition, [disk, partition],
               {#format: format, #wipe: wipe, #mount: mount}),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> deletePartition(_i3.Disk? disk, _i3.Partition? partition) =>
+  _i5.Future<void> deletePartition(_i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(
           Invocation.method(#deletePartition, [disk, partition]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
   void selectStorage(int? diskIndex, [int? partitionIndex = -1]) =>
       super.noSuchMethod(
@@ -105,34 +107,34 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#selectBootDisk, [diskIndex]),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> getStorage() =>
+  _i5.Future<void> getStorage() =>
       (super.noSuchMethod(Invocation.method(#getStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> setStorage() =>
+  _i5.Future<void> setStorage() =>
       (super.noSuchMethod(Invocation.method(#setStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> resetStorage() =>
+  _i5.Future<void> resetStorage() =>
       (super.noSuchMethod(Invocation.method(#resetStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> reformatDisk(_i3.Disk? disk) =>
+  _i5.Future<void> reformatDisk(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  void addListener(_i5.VoidCallback? listener) =>
+  void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
+  void removeListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override
@@ -143,10 +145,26 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
   String toString() => super.toString();
 }
 
+/// A class which mocks [UdevDeviceInfo].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
+  MockUdevDeviceInfo() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get fullName =>
+      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
+          as String);
+  @override
+  String toString() => super.toString();
+}
+
 /// A class which mocks [UdevService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUdevService extends _i1.Mock implements _i6.UdevService {
+class MockUdevService extends _i1.Mock implements _i2.UdevService {
   MockUdevService() {
     _i1.throwOnMissingStub(this);
   }
@@ -155,9 +173,13 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
-      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
-      returnValue: '') as String);
+  _i2.UdevDeviceInfo bySysname(String? sysname) =>
+      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
+  @override
+  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
+      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
   @override
   String toString() => super.toString();
 }

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -15,7 +15,7 @@ import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
 
-@GenerateMocks([SelectGuidedStorageModel, UdevService])
+@GenerateMocks([SelectGuidedStorageModel, UdevDeviceInfo, UdevService])
 void main() {
   const testStorages = <Disk>[
     Disk(path: '/dev/sda', size: 12),
@@ -36,10 +36,14 @@ void main() {
 
   Widget buildPage(SelectGuidedStorageModel model) {
     final udev = MockUdevService();
-    when(udev.modelName(sysname: 'sda')).thenReturn('SDA');
-    when(udev.modelName(sysname: 'sdb')).thenReturn('SDB');
-    when(udev.vendorName(sysname: 'sda')).thenReturn('ATA');
-    when(udev.vendorName(sysname: 'sdb')).thenReturn('ATA');
+    final sda = MockUdevDeviceInfo();
+    when(sda.modelName).thenReturn('SDA');
+    when(sda.vendorName).thenReturn('ATA');
+    when(udev.bySysname('sda')).thenReturn(sda);
+    final sdb = MockUdevDeviceInfo();
+    when(sdb.modelName).thenReturn('SDB');
+    when(sdb.vendorName).thenReturn('ATA');
+    when(udev.bySysname('sdb')).thenReturn(sdb);
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -36,10 +36,10 @@ void main() {
 
   Widget buildPage(SelectGuidedStorageModel model) {
     final udev = MockUdevService();
-    when(udev.modelName('sda')).thenReturn('SDA');
-    when(udev.modelName('sdb')).thenReturn('SDB');
-    when(udev.vendorName('sda')).thenReturn('ATA');
-    when(udev.vendorName('sdb')).thenReturn('ATA');
+    when(udev.modelName(sysname: 'sda')).thenReturn('SDA');
+    when(udev.modelName(sysname: 'sdb')).thenReturn('SDB');
+    when(udev.vendorName(sysname: 'sda')).thenReturn('ATA');
+    when(udev.vendorName(sysname: 'sdb')).thenReturn('ATA');
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
@@ -2,14 +2,14 @@
 // in ubuntu_desktop_installer/test/select_guided_storage_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
-import 'dart:ui' as _i5;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i6;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart'
-    as _i2;
-import 'package:ubuntu_desktop_installer/services.dart' as _i6;
+    as _i3;
+import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -19,19 +19,21 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i6;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeUdevDeviceInfo_0 extends _i1.Fake implements _i2.UdevDeviceInfo {}
+
 /// A class which mocks [SelectGuidedStorageModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSelectGuidedStorageModel extends _i1.Mock
-    implements _i2.SelectGuidedStorageModel {
+    implements _i3.SelectGuidedStorageModel {
   MockSelectGuidedStorageModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  List<_i3.Disk> get storages => (super
-          .noSuchMethod(Invocation.getter(#storages), returnValue: <_i3.Disk>[])
-      as List<_i3.Disk>);
+  List<_i4.Disk> get storages => (super
+          .noSuchMethod(Invocation.getter(#storages), returnValue: <_i4.Disk>[])
+      as List<_i4.Disk>);
   @override
   int get selectedIndex =>
       (super.noSuchMethod(Invocation.getter(#selectedIndex), returnValue: 0)
@@ -45,26 +47,26 @@ class MockSelectGuidedStorageModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#selectStorage, [index]),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> loadGuidedStorage() =>
+  _i5.Future<void> loadGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#loadGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> saveGuidedStorage() =>
+  _i5.Future<void> saveGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#saveGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i4.Future<void> resetGuidedStorage() =>
+  _i5.Future<void> resetGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  void addListener(_i5.VoidCallback? listener) =>
+  void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
+  void removeListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override
@@ -78,10 +80,26 @@ class MockSelectGuidedStorageModel extends _i1.Mock
   String toString() => super.toString();
 }
 
+/// A class which mocks [UdevDeviceInfo].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
+  MockUdevDeviceInfo() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get fullName =>
+      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
+          as String);
+  @override
+  String toString() => super.toString();
+}
+
 /// A class which mocks [UdevService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUdevService extends _i1.Mock implements _i6.UdevService {
+class MockUdevService extends _i1.Mock implements _i2.UdevService {
   MockUdevService() {
     _i1.throwOnMissingStub(this);
   }
@@ -90,9 +108,13 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
-      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
-      returnValue: '') as String);
+  _i2.UdevDeviceInfo bySysname(String? sysname) =>
+      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
+  @override
+  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
+      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
   @override
   String toString() => super.toString();
 }

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
@@ -90,16 +90,9 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#fullName, [sysname]),
-          returnValue: '') as String);
-  @override
-  String? modelName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#modelName, [sysname])) as String?);
-  @override
-  String? vendorName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#vendorName, [sysname]))
-          as String?);
+  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
+      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
+      returnValue: '') as String);
   @override
   String toString() => super.toString();
 }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
@@ -69,14 +69,18 @@ WriteChangesToDiskModel buildModel({List<Disk>? disks}) {
   return model;
 }
 
-@GenerateMocks([UdevService, WriteChangesToDiskModel])
+@GenerateMocks([UdevDeviceInfo, UdevService, WriteChangesToDiskModel])
 void main() {
   Widget buildPage(WriteChangesToDiskModel model) {
     final udev = MockUdevService();
-    when(udev.modelName(sysname: 'sda')).thenReturn('SDA');
-    when(udev.modelName(sysname: 'sdb')).thenReturn('SDB');
-    when(udev.vendorName(sysname: 'sda')).thenReturn('ATA');
-    when(udev.vendorName(sysname: 'sdb')).thenReturn('ATA');
+    final sda = MockUdevDeviceInfo();
+    when(sda.modelName).thenReturn('SDA');
+    when(sda.vendorName).thenReturn('ATA');
+    when(udev.bySysname('sda')).thenReturn(sda);
+    final sdb = MockUdevDeviceInfo();
+    when(sdb.modelName).thenReturn('SDB');
+    when(sdb.vendorName).thenReturn('ATA');
+    when(udev.bySysname('sdb')).thenReturn(sdb);
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
@@ -73,10 +73,10 @@ WriteChangesToDiskModel buildModel({List<Disk>? disks}) {
 void main() {
   Widget buildPage(WriteChangesToDiskModel model) {
     final udev = MockUdevService();
-    when(udev.modelName('sda')).thenReturn('SDA');
-    when(udev.modelName('sdb')).thenReturn('SDB');
-    when(udev.vendorName('sda')).thenReturn('ATA');
-    when(udev.vendorName('sdb')).thenReturn('ATA');
+    when(udev.modelName(sysname: 'sda')).thenReturn('SDA');
+    when(udev.modelName(sysname: 'sdb')).thenReturn('SDB');
+    when(udev.vendorName(sysname: 'sda')).thenReturn('ATA');
+    when(udev.vendorName(sysname: 'sdb')).thenReturn('ATA');
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.mocks.dart
@@ -19,6 +19,24 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeUdevDeviceInfo_0 extends _i1.Fake implements _i2.UdevDeviceInfo {}
+
+/// A class which mocks [UdevDeviceInfo].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
+  MockUdevDeviceInfo() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get fullName =>
+      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
+          as String);
+  @override
+  String toString() => super.toString();
+}
+
 /// A class which mocks [UdevService].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -31,9 +49,13 @@ class MockUdevService extends _i1.Mock implements _i2.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
-      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
-      returnValue: '') as String);
+  _i2.UdevDeviceInfo bySysname(String? sysname) =>
+      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
+  @override
+  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
+      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
+          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
   @override
   String toString() => super.toString();
 }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.mocks.dart
@@ -31,16 +31,9 @@ class MockUdevService extends _i1.Mock implements _i2.UdevService {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  String fullName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#fullName, [sysname]),
-          returnValue: '') as String);
-  @override
-  String? modelName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#modelName, [sysname])) as String?);
-  @override
-  String? vendorName(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#vendorName, [sysname]))
-          as String?);
+  String fullName({String? sysname, String? syspath}) => (super.noSuchMethod(
+      Invocation.method(#fullName, [], {#sysname: sysname, #syspath: syspath}),
+      returnValue: '') as String);
   @override
   String toString() => super.toString();
 }


### PR DESCRIPTION
While storage devices are looked up using sysnames, network devices are
instead looked up using syspaths provided by Network Manager. This
commit makes it possible to specify whether it's a sysname or syspath
when querying model and vendor names.

Extracted from https://github.com/canonical/ubuntu-desktop-installer/pull/77.