### PR TITLE
SubiquityServer: pass server environment from the outside

### DIFF
--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -19,7 +19,7 @@ void main() {
     setUpAll(() async {
       _testServer = SubiquityServer();
       _client = SubiquityClient();
-      _socketPath = await _testServer.start(ServerMode.DRY_RUN, [
+      _socketPath = await _testServer.start(ServerMode.DRY_RUN, args: [
         '--machine-config',
         'examples/simple.json',
         '--source-catalog',

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -32,6 +32,13 @@ void main(List<String> args) {
         options['machine-config'],
       ],
     ],
+    serverEnvironment: {
+      // so subiquity doesn't think it's the installer or flutter snap...
+      'SNAP': '.',
+      'SNAP_NAME': 'subiquity',
+      'SNAP_REVISION': '',
+      'SNAP_VERSION': '',
+    },
     providers: [
       Provider(create: (_) => DiskStorageService(subiquityClient)),
       Provider(create: (_) => HostnameService()),

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -377,8 +377,11 @@ class MockSubiquityServer extends _i1.Mock implements _i7.SubiquityServer {
   }
 
   @override
-  _i5.Future<String> start(_i7.ServerMode? serverMode, [List<String>? args]) =>
-      (super.noSuchMethod(Invocation.method(#start, [serverMode, args]),
+  _i5.Future<String> start(_i7.ServerMode? serverMode,
+          {List<String>? args, Map<String, String>? environment}) =>
+      (super.noSuchMethod(
+          Invocation.method(
+              #start, [serverMode], {#args: args, #environment: environment}),
           returnValue: Future<String>.value('')) as _i5.Future<String>);
   @override
   _i5.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -38,6 +38,7 @@ Future<void> runWizardApp(
   required SubiquityServer subiquityServer,
   SubiquityInitCallback? onInitSubiquity,
   List<String>? serverArgs,
+  Map<String, String>? serverEnvironment,
   List<SingleChildWidget>? providers,
 }) async {
   final interfaceSettings = GSettings('org.gnome.desktop.interface');
@@ -52,7 +53,7 @@ Future<void> runWizardApp(
   final serverMode = isLiveRun(options) ? ServerMode.LIVE : ServerMode.DRY_RUN;
 
   await subiquityServer
-      .start(serverMode, serverArgs)
+      .start(serverMode, args: serverArgs, environment: serverEnvironment)
       .then(subiquityClient.open);
 
   onInitSubiquity?.call(subiquityClient);

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -17,23 +17,29 @@ void main() {
   testWidgets('initializes subiquity', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
-    when(server.start(any, any)).thenAnswer((_) async => 'socket path');
+    when(server.start(any,
+            args: anyNamed('args'), environment: anyNamed('environment')))
+        .thenAnswer((_) async => 'socket path');
 
     await runWizardApp(
       Container(),
       subiquityClient: client,
       subiquityServer: server,
       serverArgs: ['--foo', 'bar'],
+      serverEnvironment: {'baz': 'qux'},
       onInitSubiquity: (client) => client.setVariant(Variant.DESKTOP),
     );
-    verify(server.start(ServerMode.DRY_RUN, ['--foo', 'bar'])).called(1);
+    verify(server.start(ServerMode.DRY_RUN,
+        args: ['--foo', 'bar'], environment: {'baz': 'qux'})).called(1);
     verify(client.open('socket path')).called(1);
     verify(client.setVariant(Variant.DESKTOP)).called(1);
   });
 
   testWidgets('provides the client', (tester) async {
     final server = MockSubiquityServer();
-    when(server.start(any, any)).thenAnswer((_) async => '');
+    when(server.start(any,
+            args: anyNamed('args'), environment: anyNamed('environment')))
+        .thenAnswer((_) async => '');
 
     await runWizardApp(
       Container(key: ValueKey('app')),


### PR DESCRIPTION
In WSL, DRYRUN_RECONF environment variable can be used to control
whether a dry-run instance of Subiquity runs in reconfiguration mode.

Allow WSL OOBE to pass a suitable environment from the main entry-point
where the necessary arguments are available.