### PR TITLE
Don't limit the list of architecture for the snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,9 +8,6 @@ grade: stable
 confinement: classic
 base: core20
 
-architectures:
-  - build-on: amd64
-
 apps:
   subiquity-server:
     command: bin/subiquity-server


### PR DESCRIPTION
The selection should be done on the builder instead