### PR TITLE
Prevent closing the window during installation

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -52,6 +52,7 @@ class InstallationSlidesModel extends ChangeNotifier with SystemShutdown {
   void _updateStatus(ApplicationStatus? status) {
     if (state == status?.state) return;
     _status = status;
+    setWindowClosable(isDone || hasError);
     notifyListeners();
   }
 

--- a/packages/ubuntu_wizard/lib/src/utils/window.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/window.dart
@@ -36,3 +36,9 @@ Future<void> onWindowClosed() {
 Future<void> setWindowTitle(String title) {
   return _methodChannel.invokeMethod('setWindowTitle', [title]);
 }
+
+/// Sets whether the window can be closed.
+// ignore: avoid_positional_boolean_parameters
+Future<void> setWindowClosable(bool closable) {
+  return _methodChannel.invokeMethod('setWindowClosable', [closable]);
+}

--- a/packages/ubuntu_wizard/linux/ubuntu_wizard_plugin.cc
+++ b/packages/ubuntu_wizard/linux/ubuntu_wizard_plugin.cc
@@ -35,6 +35,12 @@ static void ubuntu_wizard_plugin_handle_method_call(
   } else if (strcmp(fl_method_call_get_name(method_call), "closeWindow") == 0) {
     gtk_window_close(GTK_WINDOW(window));
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+  } else if (strcmp(method, "setWindowClosable") == 0) {
+    FlValue* args = fl_method_call_get_args(method_call);
+    bool closable = fl_value_get_bool(fl_value_get_list_value(args, 0));
+    GtkWidget* titlebar = gtk_window_get_titlebar(GTK_WINDOW(window));
+    gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(titlebar), closable);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
@@ -58,8 +64,13 @@ static void on_method_call(FlMethodChannel* channel, FlMethodCall* method_call,
   ubuntu_wizard_plugin_handle_method_call(registrar, method_call);
 }
 
-static gboolean on_delete_event(GtkWidget* /*window*/, GdkEvent* /*event*/,
+static gboolean on_delete_event(GtkWidget* window, GdkEvent* /*event*/,
                                 gpointer user_data) {
+  GtkWidget* titlebar = gtk_window_get_titlebar(GTK_WINDOW(window));
+  if (!gtk_header_bar_get_show_close_button(GTK_HEADER_BAR(titlebar))) {
+    return TRUE;
+  }
+
   g_autoptr(GError) error = nullptr;
   g_autoptr(FlValue) event = fl_value_new_string("deleteEvent");
   FlEventChannel* event_channel = FL_EVENT_CHANNEL(user_data);


### PR DESCRIPTION
Hide the close button and ignore the delete-event unless the status is
"done" or "error".

Fixes #455