### PR TITLE
Sync password strength levels with Ubiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/test/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you_model_test.dart
@@ -102,8 +102,9 @@ void main() {
     }
 
     testPasswordStrength('password', equals(PasswordStrength.weak));
-    testPasswordStrength('P4ssword', equals(PasswordStrength.moderate));
-    testPasswordStrength('P@ssw0rd123', equals(PasswordStrength.strong));
+    testPasswordStrength('P4ssword', equals(PasswordStrength.fair));
+    testPasswordStrength('P@555w0rD', equals(PasswordStrength.good));
+    testPasswordStrength('321Dr0w55@P', equals(PasswordStrength.strong));
   });
 
   test('notify changes', () {

--- a/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
@@ -117,7 +117,8 @@ void main() {
     final lang = UbuntuLocalizations.of(context);
 
     expect(find.text(lang.weakPassword), findsNothing);
-    expect(find.text(lang.moderatePassword), findsNothing);
+    expect(find.text(lang.fairPassword), findsNothing);
+    expect(find.text(lang.goodPassword), findsNothing);
     expect(find.text(lang.strongPassword), findsNothing);
   });
 
@@ -134,17 +135,30 @@ void main() {
     expect(find.text(lang.weakPassword), findsOneWidget);
   });
 
-  testWidgets('moderate password', (tester) async {
+  testWidgets('fair password', (tester) async {
     final model = buildModel(
       password: 'not empty',
-      passwordStrength: PasswordStrength.moderate,
+      passwordStrength: PasswordStrength.fair,
     );
     await tester.pumpWidget(buildApp(tester, model));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.moderatePassword), findsOneWidget);
+    expect(find.text(lang.fairPassword), findsOneWidget);
+  });
+
+  testWidgets('good password', (tester) async {
+    final model = buildModel(
+      password: 'not empty',
+      passwordStrength: PasswordStrength.good,
+    );
+    await tester.pumpWidget(buildApp(tester, model));
+
+    final context = tester.element(find.byType(WhoAreYouPage));
+    final lang = UbuntuLocalizations.of(context);
+
+    expect(find.text(lang.goodPassword), findsOneWidget);
   });
 
   testWidgets('strong password', (tester) async {

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_en.arb
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_en.arb
@@ -11,6 +11,7 @@
   "continueAction": "Continue",
 
   "strongPassword": "Strong password",
-  "moderatePassword": "Moderate password",
+  "fairPassword": "Fair password",
+  "goodPassword": "Good password",
   "weakPassword": "Weak password"
 }

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations.dart
@@ -267,11 +267,17 @@ abstract class UbuntuLocalizations {
   /// **'Strong password'**
   String get strongPassword;
 
-  /// No description provided for @moderatePassword.
+  /// No description provided for @fairPassword.
   ///
   /// In en, this message translates to:
-  /// **'Moderate password'**
-  String get moderatePassword;
+  /// **'Fair password'**
+  String get fairPassword;
+
+  /// No description provided for @goodPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Good password'**
+  String get goodPassword;
 
   /// No description provided for @weakPassword.
   ///

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_am.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_am.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsAm extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ar.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ar.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsAr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_be.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_be.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsBe extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bg.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bg.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsBg extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bn.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bn.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsBn extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bo.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bo.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsBo extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bs.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_bs.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsBs extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ca.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ca.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsCa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_cs.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_cs.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsCs extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_cy.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_cy.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsCy extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_da.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_da.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsDa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_de.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_de.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsDe extends UbuntuLocalizations {
   String get strongPassword => 'Starkes Passwort';
 
   @override
-  String get moderatePassword => 'Mittelmäßiges Passwort';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Schwaches Passwort';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_dz.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_dz.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsDz extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_el.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_el.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_en.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_en.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEn extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_eo.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_eo.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEo extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_es.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_es.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEs extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_et.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_et.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEt extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_eu.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_eu.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsEu extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fa.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fa.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsFa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fi.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fi.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsFi extends UbuntuLocalizations {
   String get strongPassword => 'Vahva salasana';
 
   @override
-  String get moderatePassword => 'Kohtalainen salasana';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Heikko salasana';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fr.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_fr.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsFr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ga.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ga.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsGa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_gl.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_gl.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsGl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_gu.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_gu.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsGu extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_he.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_he.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsHe extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hi.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hi.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsHi extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hr.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hr.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsHr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hu.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_hu.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsHu extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_id.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_id.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsId extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_is.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_is.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsIs extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_it.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_it.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsIt extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ja.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ja.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsJa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ka.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ka.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_kk.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_kk.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKk extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_km.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_km.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKm extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_kn.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_kn.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKn extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ko.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ko.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKo extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ku.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ku.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsKu extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lo.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lo.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsLo extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lt.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lt.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsLt extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lv.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_lv.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsLv extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_mk.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_mk.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsMk extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ml.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ml.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsMl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_mr.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_mr.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsMr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_my.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_my.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsMy extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nb.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nb.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsNb extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ne.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ne.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsNe extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nl.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nl.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsNl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nn.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_nn.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsNn extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_oc.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_oc.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsOc extends UbuntuLocalizations {
   String get strongPassword => 'Senhal fòrt';
 
   @override
-  String get moderatePassword => 'Senhal moderat';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Senhal feble';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pa.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pa.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsPa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pl.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pl.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsPl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pt.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_pt.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsPt extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';
@@ -47,9 +50,6 @@ class UbuntuLocalizationsPtBr extends UbuntuLocalizationsPt {
 
   @override
   String get strongPassword => 'Senha forte';
-
-  @override
-  String get moderatePassword => 'Senha média';
 
   @override
   String get weakPassword => 'Senha fraca';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ro.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ro.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsRo extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ru.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ru.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsRu extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_se.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_se.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSe extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_si.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_si.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSi extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sk.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sk.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSk extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sl.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sl.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sq.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sq.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSq extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sr.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sr.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sv.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_sv.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsSv extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ta.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ta.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTa extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_te.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_te.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTe extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tg.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tg.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTg extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_th.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_th.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTh extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tl.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tl.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTl extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tr.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_tr.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsTr extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ug.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_ug.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsUg extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_uk.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_uk.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsUk extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_vi.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_vi.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsVi extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_zh.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_zh.dart
@@ -23,7 +23,10 @@ class UbuntuLocalizationsZh extends UbuntuLocalizations {
   String get strongPassword => 'Strong password';
 
   @override
-  String get moderatePassword => 'Moderate password';
+  String get fairPassword => 'Fair password';
+
+  @override
+  String get goodPassword => 'Good password';
 
   @override
   String get weakPassword => 'Weak password';

--- a/packages/ubuntu_wizard/lib/src/utils/password.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/password.dart
@@ -6,8 +6,11 @@ enum PasswordStrength {
   /// A weak password.
   weak,
 
-  /// A moderate strength password.
-  moderate,
+  /// A fair password.
+  fair,
+
+  /// A good password.
+  good,
 
   /// A strong password.
   strong,
@@ -16,10 +19,12 @@ enum PasswordStrength {
 /// Estimates the strength of the given [password].
 PasswordStrength estimatePasswordStrength(String password) {
   final strength = pws.estimatePasswordStrength(password);
-  if (strength < 0.3) {
+  if (strength < 0.5) {
     return PasswordStrength.weak;
-  } else if (strength < 0.7) {
-    return PasswordStrength.moderate;
+  } else if (strength < 0.75) {
+    return PasswordStrength.fair;
+  } else if (strength < 0.9) {
+    return PasswordStrength.good;
   } else {
     return PasswordStrength.strong;
   }

--- a/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
@@ -24,8 +24,10 @@ class PasswordStrengthLabel extends StatelessWidget {
           lang.weakPassword,
           style: TextStyle(color: Theme.of(context).errorColor),
         );
-      case PasswordStrength.moderate:
-        return Text(lang.moderatePassword);
+      case PasswordStrength.fair:
+        return Text(lang.fairPassword);
+      case PasswordStrength.good:
+        return Text(lang.goodPassword);
       case PasswordStrength.strong:
         return Text(
           lang.strongPassword,

--- a/packages/ubuntu_wizard/test/password_strength_label_test.dart
+++ b/packages/ubuntu_wizard/test/password_strength_label_test.dart
@@ -24,16 +24,32 @@ void main() {
     expect(widget.style!.color, equals(Theme.of(context).errorColor));
   });
 
-  testWidgets('moderate password', (tester) async {
+  testWidgets('fair password', (tester) async {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       home: Builder(builder: (context) {
-        return PasswordStrengthLabel(strength: PasswordStrength.moderate);
+        return PasswordStrengthLabel(strength: PasswordStrength.fair);
       }),
     ));
 
     final context = tester.element(find.byType(PasswordStrengthLabel));
-    final text = UbuntuLocalizations.of(context).moderatePassword;
+    final text = UbuntuLocalizations.of(context).fairPassword;
+    expect(find.text(text), findsOneWidget);
+
+    final widget = tester.widget<Text>(find.text(text));
+    expect(widget.style?.color, isNull);
+  });
+
+  testWidgets('good password', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
+      home: Builder(builder: (context) {
+        return PasswordStrengthLabel(strength: PasswordStrength.good);
+      }),
+    ));
+
+    final context = tester.element(find.byType(PasswordStrengthLabel));
+    final text = UbuntuLocalizations.of(context).goodPassword;
     expect(find.text(text), findsOneWidget);
 
     final widget = tester.widget<Text>(find.text(text));

--- a/packages/ubuntu_wizard/test/password_test.dart
+++ b/packages/ubuntu_wizard/test/password_test.dart
@@ -2,7 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 const Matcher isWeak = PasswordStrengthMatcher(PasswordStrength.weak);
-const Matcher isModerate = PasswordStrengthMatcher(PasswordStrength.moderate);
+const Matcher isFair = PasswordStrengthMatcher(PasswordStrength.fair);
+const Matcher isGood = PasswordStrengthMatcher(PasswordStrength.good);
 const Matcher isStrong = PasswordStrengthMatcher(PasswordStrength.strong);
 
 void main() {
@@ -18,24 +19,29 @@ void main() {
     // 6
     expect(estimatePasswordStrength('passwd'), isWeak);
     expect(estimatePasswordStrength('p4sswd'), isWeak);
-    expect(estimatePasswordStrength('p@sswd'), isModerate);
+    expect(estimatePasswordStrength('p@sswd'), isWeak);
 
     // 8
     expect(estimatePasswordStrength('password'), isWeak);
     expect(estimatePasswordStrength('Password'), isWeak);
-    expect(estimatePasswordStrength('p4ssword'), isModerate);
-    expect(estimatePasswordStrength('P4ssword'), isModerate);
-    expect(estimatePasswordStrength('p@ssw0rd'), isModerate);
-    expect(estimatePasswordStrength('P@ssw0rd'), isModerate);
+    expect(estimatePasswordStrength('p4ssword'), isWeak);
+    expect(estimatePasswordStrength('P4ssword'), isFair);
+    expect(estimatePasswordStrength('p@ssw0rd'), isFair);
+    expect(estimatePasswordStrength('P@ssw0rd'), isFair);
+    expect(estimatePasswordStrength('P@ssw0rD'), isFair);
 
     // 9
     expect(estimatePasswordStrength('passsword'), isWeak);
-    expect(estimatePasswordStrength('p4sssword'), isModerate);
-    expect(estimatePasswordStrength('P4sssword'), isModerate);
-    expect(estimatePasswordStrength('p@sssword'), isStrong);
-    expect(estimatePasswordStrength('P@sssword'), isStrong);
-    expect(estimatePasswordStrength('p@sssw0rd'), isStrong);
-    expect(estimatePasswordStrength('P@sssw0rd'), isStrong);
+    expect(estimatePasswordStrength('p4sssword'), isWeak);
+    expect(estimatePasswordStrength('P4sssword'), isFair);
+    expect(estimatePasswordStrength('p@sssword'), isGood);
+    expect(estimatePasswordStrength('P@sssword'), isGood);
+    expect(estimatePasswordStrength('p@sssw0rd'), isGood);
+    expect(estimatePasswordStrength('P@sssw0rd'), isGood);
+    expect(estimatePasswordStrength('P@555w0rD'), isGood);
+
+    expect(estimatePasswordStrength('321Dr0w55@P'), isStrong);
+    expect(estimatePasswordStrength('y42JU%#agK%kj64'), isStrong);
   });
 
   test('encrypt password', () {

--- a/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
@@ -55,8 +55,9 @@ void main() {
     }
 
     testPasswordStrength('password', equals(PasswordStrength.weak));
-    testPasswordStrength('P4ssword', equals(PasswordStrength.moderate));
-    testPasswordStrength('P@ssw0rd123', equals(PasswordStrength.strong));
+    testPasswordStrength('P4ssword', equals(PasswordStrength.fair));
+    testPasswordStrength('P@555w0rD', equals(PasswordStrength.good));
+    testPasswordStrength('321Dr0w55@P', equals(PasswordStrength.strong));
   });
 
   test('notify changes', () {

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -107,7 +107,8 @@ void main() {
     await tester.pumpWidget(buildApp(tester, model));
 
     expect(find.text(tester.ulang.weakPassword), findsNothing);
-    expect(find.text(tester.ulang.moderatePassword), findsNothing);
+    expect(find.text(tester.ulang.fairPassword), findsNothing);
+    expect(find.text(tester.ulang.goodPassword), findsNothing);
     expect(find.text(tester.ulang.strongPassword), findsNothing);
   });
 
@@ -121,14 +122,24 @@ void main() {
     expect(find.text(tester.ulang.weakPassword), findsOneWidget);
   });
 
-  testWidgets('moderate password', (tester) async {
+  testWidgets('fair password', (tester) async {
     final model = buildModel(
       password: 'not empty',
-      passwordStrength: PasswordStrength.moderate,
+      passwordStrength: PasswordStrength.fair,
     );
     await tester.pumpWidget(buildApp(tester, model));
 
-    expect(find.text(tester.ulang.moderatePassword), findsOneWidget);
+    expect(find.text(tester.ulang.fairPassword), findsOneWidget);
+  });
+
+  testWidgets('good password', (tester) async {
+    final model = buildModel(
+      password: 'not empty',
+      passwordStrength: PasswordStrength.good,
+    );
+    await tester.pumpWidget(buildApp(tester, model));
+
+    expect(find.text(tester.ulang.goodPassword), findsOneWidget);
   });
 
   testWidgets('strong password', (tester) async {


### PR DESCRIPTION
Before: weak, moderate, strong
After: weak, fair, good, strong

The thresholds in UDI vs. Ubiquity are fairly close but not identical
due to different strength level detection algorithms.

This change allows us to import the respective translations from
Ubiquity, as is.