### PR TITLE
Remove extra space in Burmese language name

### DIFF
--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_my.dart
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_localizations_my.dart
@@ -11,7 +11,7 @@ class UbuntuLocalizationsMy extends UbuntuLocalizations {
   String get countryCode => 'MM';
 
   @override
-  String get languageName => ' ﻿မြန်မာစာ';
+  String get languageName => '﻿မြန်မာစာ';
 
   @override
   String get backAction => 'Go Back';

--- a/packages/ubuntu_wizard/lib/src/l10n/ubuntu_my.arb
+++ b/packages/ubuntu_wizard/lib/src/l10n/ubuntu_my.arb
@@ -1,5 +1,5 @@
 {
   "@@locale": "my",
   "countryCode": "MM",
-  "languageName": " ﻿မြန်မာစာ"
+  "languageName": "﻿မြန်မာစာ"
 }


### PR DESCRIPTION
Removing the extra space fixes the sorting order of the language names.
According to Ubiquity, Burmese is not expected to be the first language
but somewhere at the bottom.

There is an extra 0x20 in Ubiquity's languagelist where the language
name was imported from:

https://git.launchpad.net/ubiquity/tree/d-i/source/localechooser/languagelist#n75