### PR TITLE
Replace hard-coded Ubuntu strings with the flavor's name

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -91,7 +91,7 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         locale: Settings.of(context).locale,
         onGenerateTitle: (context) {
           final lang = AppLocalizations.of(context);
-          setWindowTitle(lang.windowTitle('Ubuntu'));
+          setWindowTitle(lang.windowTitle(flavor.name));
           return lang.appTitle;
         },
         theme: flavor.theme,

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -48,11 +48,12 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
+    final flavor = Flavor.of(context);
     return WizardPage(
       title: Text(lang.chooseSecurityKeyTitle),
       header: FractionallySizedBox(
         widthFactor: kContentWidthFraction,
-        child: Text(lang.chooseSecurityKeyHeader('Ubuntu')),
+        child: Text(lang.chooseSecurityKeyHeader(flavor.name)),
       ),
       content: LayoutBuilder(builder: (context, constraints) {
         final fieldWidth = constraints.maxWidth * kContentWidthFraction;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
@@ -15,6 +15,7 @@ Future<void> showAdvancedFeaturesDialog(
     context: context,
     builder: (context) {
       final lang = AppLocalizations.of(context);
+      final flavor = Flavor.of(context);
 
       return AlertDialog(
         title: Text(lang.installationTypeAdvancedTitle),
@@ -37,7 +38,7 @@ Future<void> showAdvancedFeaturesDialog(
                 ),
                 const SizedBox(height: kContentSpacing),
                 RadioButton<AdvancedFeature>(
-                  title: Text(lang.installationTypeLVM('Ubuntu')),
+                  title: Text(lang.installationTypeLVM(flavor.name)),
                   value: AdvancedFeature.lvm,
                   groupValue: advancedFeature.value,
                   onChanged: (v) => advancedFeature.value = v!,
@@ -45,7 +46,7 @@ Future<void> showAdvancedFeaturesDialog(
                 RadioIconTile(
                   contentPadding: EdgeInsets.zero,
                   title: CheckButton(
-                    title: Text(lang.installationTypeEncrypt('Ubuntu')),
+                    title: Text(lang.installationTypeEncrypt(flavor.name)),
                     subtitle: Text(lang.installationTypeEncryptInfo),
                     value: encryption.value,
                     onChanged: model.advancedFeature == AdvancedFeature.lvm

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -45,6 +45,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
   Widget build(BuildContext context) {
     final model = Provider.of<InstallationTypeModel>(context);
     final lang = AppLocalizations.of(context);
+    final flavor = Flavor.of(context);
     return WizardPage(
       title: Text(lang.installationTypeTitle),
       header: Text(
@@ -79,7 +80,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
             ),
           if (model.existingOS != null) const SizedBox(height: kContentSpacing),
           RadioButton<InstallationType>(
-            title: Text(lang.installationTypeErase('Ubuntu')),
+            title: Text(lang.installationTypeErase(flavor.name)),
             subtitle: Html(
               data: lang.installationTypeEraseWarning(
                   Theme.of(context).errorColor.toHex()),
@@ -112,7 +113,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
           // const SizedBox(height: kContentSpacing),
           RadioButton<InstallationType>(
             title: Text(lang.installationTypeManual),
-            subtitle: Text(lang.installationTypeManualInfo('Ubuntu')),
+            subtitle: Text(lang.installationTypeManualInfo(flavor.name)),
             value: InstallationType.manual,
             groupValue: model.installationType,
             onChanged: (v) => model.installationType = v!,

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -58,8 +58,9 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
   Widget build(BuildContext context) {
     final model = Provider.of<SelectGuidedStorageModel>(context);
     final lang = AppLocalizations.of(context);
+    final flavor = Flavor.of(context);
     return WizardPage(
-      title: Text(lang.selectGuidedStoragePageTitle('Ubuntu')),
+      title: Text(lang.selectGuidedStoragePageTitle(flavor.name)),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -99,7 +100,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
                   ),
                   const SizedBox(height: kContentSpacing / 2),
                   Text(
-                    'Ubuntu',
+                    flavor.name,
                     style: Theme.of(context).textTheme.headline6,
                   ),
                   const SizedBox(height: kContentSpacing / 2),

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -31,6 +31,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
   Widget build(BuildContext context) {
     final model = Provider.of<TryOrInstallModel>(context);
     final lang = AppLocalizations.of(context);
+    final flavor = Flavor.of(context);
     return WizardPage(
       title: Text(lang.tryOrInstallPageTitle),
       contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 150),
@@ -50,8 +51,8 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
             child: OptionCard(
               selected: model.option == Option.tryUbuntu,
               imageAsset: 'assets/steering-wheel.png',
-              titleText: lang.tryUbuntu('Ubuntu'),
-              bodyText: lang.tryUbuntuDescription('Ubuntu'),
+              titleText: lang.tryUbuntu(flavor.name),
+              bodyText: lang.tryUbuntuDescription(flavor.name),
               onSelected: () => model.selectOption(Option.tryUbuntu),
             ),
           ),
@@ -60,8 +61,8 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
             child: OptionCard(
               selected: model.option == Option.installUbuntu,
               imageAsset: 'assets/hard-drive.png',
-              titleText: lang.installUbuntu('Ubuntu'),
-              bodyText: lang.installUbuntuDescription('Ubuntu'),
+              titleText: lang.installUbuntu(flavor.name),
+              bodyText: lang.installUbuntuDescription(flavor.name),
               onSelected: () => model.selectOption(Option.installUbuntu),
             ),
           ),

--- a/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install_page_test.dart
@@ -29,33 +29,36 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: localizationsDelegates,
       locale: Locale('en'),
-      home: Wizard(
-        routes: {
-          Routes.tryOrInstall: WizardRoute(
-            builder: (_) => TryOrInstallPage(),
-            onNext: (settings) {
-              switch (model.option) {
-                case Option.repairUbuntu:
-                  return Routes.repairUbuntu;
-                case Option.tryUbuntu:
-                  return Routes.tryUbuntu;
-                case Option.installUbuntu:
-                  return Routes.keyboardLayout;
-                default:
-                  break;
-              }
-            },
-          ),
-          Routes.repairUbuntu: WizardRoute(
-            builder: (context) => Text(Routes.repairUbuntu),
-          ),
-          Routes.tryUbuntu: WizardRoute(
-            builder: (context) => Text(Routes.tryUbuntu),
-          ),
-          Routes.keyboardLayout: WizardRoute(
-            builder: (context) => Text(Routes.keyboardLayout),
-          ),
-        },
+      home: Flavor(
+        data: const FlavorData(name: 'Ubuntu'),
+        child: Wizard(
+          routes: {
+            Routes.tryOrInstall: WizardRoute(
+              builder: (_) => TryOrInstallPage(),
+              onNext: (settings) {
+                switch (model.option) {
+                  case Option.repairUbuntu:
+                    return Routes.repairUbuntu;
+                  case Option.tryUbuntu:
+                    return Routes.tryUbuntu;
+                  case Option.installUbuntu:
+                    return Routes.keyboardLayout;
+                  default:
+                    break;
+                }
+              },
+            ),
+            Routes.repairUbuntu: WizardRoute(
+              builder: (context) => Text(Routes.repairUbuntu),
+            ),
+            Routes.tryUbuntu: WizardRoute(
+              builder: (context) => Text(Routes.tryUbuntu),
+            ),
+            Routes.keyboardLayout: WizardRoute(
+              builder: (context) => Text(Routes.keyboardLayout),
+            ),
+          },
+        ),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -25,12 +25,15 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: localizationsDelegates,
       locale: Locale('en'),
-      home: Wizard(
-        routes: <String, WizardRoute>{
-          Routes.welcome: WizardRoute(builder: (_) => WelcomePage()),
-          Routes.tryOrInstall:
-              WizardRoute(builder: (_) => Text(Routes.tryOrInstall)),
-        },
+      home: Flavor(
+        data: const FlavorData(name: 'Ubuntu'),
+        child: Wizard(
+          routes: <String, WizardRoute>{
+            Routes.welcome: WizardRoute(builder: (_) => WelcomePage()),
+            Routes.tryOrInstall:
+                WizardRoute(builder: (_) => Text(Routes.tryOrInstall)),
+          },
+        ),
       ),
     );
     final client = MockSubiquityClient();

--- a/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
@@ -50,18 +50,21 @@ extension UbuntuTester on WidgetTester {
   Widget buildApp(WidgetBuilder builder) {
     binding.window.devicePixelRatioTestValue = 1;
     binding.window.physicalSizeTestValue = const Size(960, 680);
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: builder,
-            onNext: (settings) => '/next',
-          ),
-          '/next': WizardRoute(
-            builder: (_) => const Text('Next page'),
-          ),
-        },
+    return Flavor(
+      data: const FlavorData(name: 'Ubuntu'),
+      child: MaterialApp(
+        localizationsDelegates: localizationsDelegates,
+        home: Wizard(
+          routes: {
+            '/': WizardRoute(
+              builder: builder,
+              onNext: (settings) => '/next',
+            ),
+            '/next': WizardRoute(
+              builder: (_) => const Text('Next page'),
+            ),
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
An imaginary "Ubuntu X" flavor built according to the instructions in #478:

| Default | "Ubuntu X" |
|---|---|
| ![Screenshot from 2021-11-12 16-36-34](https://user-images.githubusercontent.com/140617/141493035-3618898c-2463-4ad9-936e-35c2df5b55ba.png) | ![Screenshot from 2021-11-12 16-40-48](https://user-images.githubusercontent.com/140617/141493554-e39495bd-419b-4b27-9b5e-f814d5ae64b3.png) |