### PR TITLE
Tests: add shared tester.buildApp() to reduce boilerplate

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,7 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.mocks.dart"
     - "**/l10n/*.dart"
-    - "**/test/**.dart"
+#    - "**/test/**.dart"
 
 linter:
   rules:

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
@@ -3,26 +3,21 @@ import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_model.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'allocate_disk_space_page_test.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
 
 void main() {
-  setUpAll(() => LangTester.context = AlertDialog);
+  setUpAll(() => UbuntuTester.context = AlertDialog);
 
   testWidgets('create partition', (tester) async {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-
     final testDisk = Disk(freeForPartitions: 1000000);
     final model = buildModel(selectedDisk: testDisk);
 
@@ -32,13 +27,7 @@ void main() {
           ChangeNotifierProvider<AllocateDiskSpaceModel>.value(value: model),
           Provider<UdevService>(create: (_) => MockUdevService()),
         ],
-        child: MaterialApp(
-          supportedLocales: AppLocalizations.supportedLocales,
-          localizationsDelegates: localizationsDelegates,
-          home: Wizard(
-            routes: {'/': WizardRoute(builder: (_) => AllocateDiskSpacePage())},
-          ),
-        ),
+        child: tester.buildApp((_) => AllocateDiskSpacePage()),
       ),
     );
 
@@ -100,13 +89,7 @@ void main() {
           ChangeNotifierProvider<AllocateDiskSpaceModel>.value(value: model),
           Provider<UdevService>(create: (_) => MockUdevService()),
         ],
-        child: MaterialApp(
-          supportedLocales: AppLocalizations.supportedLocales,
-          localizationsDelegates: localizationsDelegates,
-          home: Wizard(
-            routes: {'/': WizardRoute(builder: (_) => AllocateDiskSpacePage())},
-          ),
-        ),
+        child: tester.buildApp((_) => AllocateDiskSpacePage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
@@ -6,12 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_model.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'allocate_disk_space_model_test.mocks.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
@@ -112,25 +110,9 @@ void main() {
     );
   }
 
-  Widget buildApp(WidgetTester tester, AllocateDiskSpaceModel model) {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: (_) => buildPage(model),
-            onNext: (settings) => '/',
-          ),
-        },
-      ),
-    );
-  }
-
   testWidgets('list of disks and partitions', (tester) async {
     final model = buildModel(disks: testDisks);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     for (final disk in testDisks) {
       expect(find.text(disk.path!), findsOneWidget);
@@ -146,7 +128,7 @@ void main() {
 
   testWidgets('select storage', (tester) async {
     final model = buildModel(disks: testDisks);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tap(find.text(testDisks.first.path!));
     await tester.pumpAndSettle();
@@ -171,7 +153,7 @@ void main() {
         canEditPartition: false,
         canRemovePartition: false,
         canReformatDisk: false);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final addButton = find.ancestor(
       of: find.byIcon(Icons.add),
@@ -204,7 +186,7 @@ void main() {
 
   testWidgets('can add', (tester) async {
     final model = buildModel(disks: testDisks, canAddPartition: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final addButton = find.ancestor(
       of: find.byIcon(Icons.add),
@@ -216,7 +198,7 @@ void main() {
 
   testWidgets('can edit', (tester) async {
     final model = buildModel(disks: testDisks, canEditPartition: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final editButton = find.ancestor(
       of: find.text(tester.lang.changeButtonText),
@@ -230,7 +212,7 @@ void main() {
     final disk = testDisks.first;
     final partition = disk.partitions!.first;
     final model = buildModel(disks: testDisks);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final checkbox = find.byType(Checkbox);
     expect(checkbox, findsWidgets);
@@ -248,7 +230,7 @@ void main() {
       selectedPartition: partition,
       canRemovePartition: true,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final removeButton = find.ancestor(
       of: find.byIcon(Icons.remove),
@@ -268,7 +250,7 @@ void main() {
       selectedDisk: disk,
       canReformatDisk: true,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final resetButton = find.ancestor(
       of: find.text(tester.lang.newPartitionTable),
@@ -283,7 +265,7 @@ void main() {
 
   testWidgets('revert', (tester) async {
     final model = buildModel();
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final revertButton = find.ancestor(
       of: find.text(tester.lang.revertButtonText),
@@ -298,7 +280,7 @@ void main() {
 
   testWidgets('boot disk', (tester) async {
     final model = buildModel(disks: testDisks, bootDiskIndex: 1);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tap(find.byTypeOf<DropdownButton<int>>());
     await tester.pumpAndSettle();
@@ -315,7 +297,7 @@ void main() {
 
   testWidgets('set storage', (tester) async {
     final model = buildModel(isValid: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -329,7 +311,7 @@ void main() {
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -345,22 +327,12 @@ void main() {
     when(storage.needRoot).thenReturn(false);
     when(storage.needBoot).thenReturn(false);
 
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: MultiProvider(
-        providers: [
-          Provider<DiskStorageService>.value(value: storage),
-          Provider<UdevService>(create: (_) => MockUdevService()),
-        ],
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: AllocateDiskSpacePage.create,
-              onNext: (settings) => '/',
-            )
-          },
-        ),
-      ),
+    await tester.pumpWidget(MultiProvider(
+      providers: [
+        Provider<DiskStorageService>.value(value: storage),
+        Provider<UdevService>(create: (_) => MockUdevService()),
+      ],
+      child: tester.buildApp(AllocateDiskSpacePage.create),
     ));
 
     final page = find.byType(AllocateDiskSpacePage);

--- a/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look_page_test.dart
@@ -9,6 +9,7 @@ import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import 'choose_your_look_page_test.mocks.dart';
+import 'widget_tester_extensions.dart';
 
 @GenerateMocks([Settings])
 void main() {
@@ -23,14 +24,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider.value(
         value: settings,
-        child: MaterialApp(
-          localizationsDelegates: localizationsDelegates,
-          home: Wizard(
-            routes: {
-              '/': WizardRoute(builder: ChooseYourLookPage.create),
-            },
-          ),
-        ),
+        child: tester.buildApp(ChooseYourLookPage.create),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/configure_secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/configure_secure_boot_page_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/configure_secure_boot/configure_secure_boot_model.dart';
 import 'package:ubuntu_desktop_installer/pages/configure_secure_boot/configure_secure_boot_page.dart';
 import 'package:ubuntu_test/utils.dart';
@@ -41,22 +40,6 @@ void main() {
     );
   }
 
-  Widget buildApp(WidgetTester tester, ConfigureSecureBootModel model) {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: (_) => buildPage(model),
-            onNext: (settings) => '/',
-          )
-        },
-      ),
-    );
-  }
-
   testWidgets('security key input', (tester) async {
     final model = buildModel(
       secureBootMode: SecureBootMode.turnOff,
@@ -64,7 +47,7 @@ void main() {
       confirmKey: 'key',
       areTextFieldsEnabled: true,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final fields = find.widgetWithText(ValidatedFormField, 'key');
     expect(fields, findsNWidgets(2));
@@ -89,7 +72,7 @@ void main() {
 
   testWidgets('disabled input fields', (tester) async {
     final model = buildModel(areTextFieldsEnabled: false);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final fields = find.byType(ValidatedFormField);
     expect(fields, findsNWidgets(2));
@@ -99,14 +82,14 @@ void main() {
 
   testWidgets('empty security key', (tester) async {
     final model = buildModel(securityKey: '');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     expect(find.byType(SuccessIcon), findsNothing);
   });
 
   testWidgets('don\'t install', (tester) async {
     final model = buildModel(secureBootMode: SecureBootMode.dontInstall);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final radios = find.byTypeOf<RadioButton<SecureBootMode>>();
     expect(radios, findsNWidgets(2));
@@ -118,7 +101,7 @@ void main() {
 
   testWidgets('valid input', (tester) async {
     final model = buildModel(isFormValid: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -129,7 +112,7 @@ void main() {
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isFormValid: false);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,

--- a/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
@@ -4,39 +4,25 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_model.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_page.dart';
 import 'package:ubuntu_test/mocks.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'installation_complete_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
 
 @GenerateMocks([InstallationCompleteModel])
 void main() {
-  Widget buildApp(InstallationCompleteModel model) {
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: (_) {
-              return Provider<InstallationCompleteModel>.value(
-                value: model,
-                child: InstallationCompletePage(),
-              );
-            },
-            onNext: (settings) => '/',
-          ),
-        },
-      ),
+  Widget buildPage(InstallationCompleteModel model) {
+    return Provider<InstallationCompleteModel>.value(
+      value: model,
+      child: InstallationCompletePage(),
     );
   }
 
   testWidgets('restart', (tester) async {
     final model = MockInstallationCompleteModel();
-    await tester.pumpWidget(buildApp(model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final restartButton = find.textContaining(tester.lang.restartButtonText);
     expect(restartButton, findsOneWidget);
@@ -47,7 +33,7 @@ void main() {
 
   testWidgets('shutdown', (tester) async {
     final model = MockInstallationCompleteModel();
-    await tester.pumpWidget(buildApp(model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final shutdownButton =
         find.widgetWithText(OutlinedButton, tester.lang.shutdown);
@@ -59,16 +45,9 @@ void main() {
 
   testWidgets('creates a model', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: localizationsDelegates,
-        home: Provider<SubiquityClient>(
-          create: (_) => MockSubiquityClient(),
-          child: Wizard(
-            routes: {
-              '/': WizardRoute(builder: InstallationCompletePage.create),
-            },
-          ),
-        ),
+      Provider<SubiquityClient>(
+        create: (_) => MockSubiquityClient(),
+        child: tester.buildApp(InstallationCompletePage.create),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type_dialogs_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_page.dart';
@@ -13,12 +12,9 @@ import 'installation_type_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
 
 void main() {
-  setUpAll(() => LangTester.context = AlertDialog);
+  setUpAll(() => UbuntuTester.context = AlertDialog);
 
   testWidgets('select advanced features', (tester) async {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-
     final model = MockInstallationTypeModel();
     when(model.existingOS).thenReturn(null);
     when(model.installationType).thenReturn(InstallationType.erase);
@@ -28,13 +24,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
         value: model,
-        child: MaterialApp(
-          supportedLocales: AppLocalizations.supportedLocales,
-          localizationsDelegates: localizationsDelegates,
-          home: Wizard(
-            routes: {'/': WizardRoute(builder: (_) => InstallationTypePage())},
-          ),
-        ),
+        child: tester.buildApp((_) => InstallationTypePage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_dialogs_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_widgets.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -12,12 +11,9 @@ import 'package:ubuntu_test/mocks.dart';
 import 'widget_tester_extensions.dart';
 
 void main() {
-  setUpAll(() => LangTester.context = DetectKeyboardLayoutView);
+  setUpAll(() => UbuntuTester.context = DetectKeyboardLayoutView);
 
   testWidgets('detect layout', (tester) async {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(null)).thenAnswer((_) async {
       return KeyboardStep.pressKey(symbols: [
@@ -39,10 +35,8 @@ void main() {
     await tester.pumpWidget(
       Provider<SubiquityClient>.value(
         value: client,
-        child: MaterialApp(
-          supportedLocales: AppLocalizations.supportedLocales,
-          localizationsDelegates: localizationsDelegates,
-          home: DetectKeyboardLayoutView(
+        child: tester.buildApp(
+          (_) => DetectKeyboardLayoutView(
             pressKey: null,
             keyPresent: null,
             onKeyPress: (_) {},

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_widgets_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_widgets_test.dart
@@ -1,22 +1,18 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_widgets.dart';
 
 import 'widget_tester_extensions.dart';
 
 void main() {
-  setUpAll(() => LangTester.context = DetectKeyboardLayoutView);
+  setUpAll(() => UbuntuTester.context = DetectKeyboardLayoutView);
 
   testWidgets('press key', (tester) async {
     int? keyPress;
 
     await tester.pumpWidget(
-      MaterialApp(
-        supportedLocales: AppLocalizations.supportedLocales,
-        localizationsDelegates: localizationsDelegates,
-        home: DetectKeyboardLayoutView(
+      tester.buildApp(
+        (_) => DetectKeyboardLayoutView(
           pressKey: ['x', 'y', 'z'],
           onKeyPress: (code) => keyPress = code,
         ),
@@ -38,13 +34,7 @@ void main() {
 
   testWidgets('find key', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        supportedLocales: AppLocalizations.supportedLocales,
-        localizationsDelegates: localizationsDelegates,
-        home: DetectKeyboardLayoutView(
-          keyPresent: 'x',
-        ),
-      ),
+      tester.buildApp((_) => DetectKeyboardLayoutView(keyPresent: 'x')),
     );
 
     expect(find.byType(KeyPresentView), findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -4,12 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
@@ -54,23 +52,9 @@ void main() {
     );
   }
 
-  Widget buildApp(WidgetTester tester, SelectGuidedStorageModel model) {
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: (_) => buildPage(model),
-            onNext: (settings) => '/',
-          ),
-        },
-      ),
-    );
-  }
-
   testWidgets('list of guided storages', (tester) async {
     final model = buildModel(storages: testStorages);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tap(find.byTypeOf<DropdownButton<int>>());
     await tester.pumpAndSettle();
@@ -88,7 +72,7 @@ void main() {
 
   testWidgets('select a guided storage', (tester) async {
     final model = buildModel(storages: testStorages);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tap(find.byTypeOf<DropdownButton<int>>());
     await tester.pumpAndSettle();
@@ -109,14 +93,14 @@ void main() {
       storages: testStorages,
       selectedStorage: selectedStorage,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
     expect(find.text(selectedStorage.path!), findsOneWidget);
     expect(find.text(filesize(selectedStorage.size)), findsOneWidget);
   });
 
   testWidgets('loads and saves guided storages', (tester) async {
     final model = buildModel(storages: testStorages);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     verify(model.loadGuidedStorage()).called(1);
     verifyNever(model.saveGuidedStorage());
@@ -133,20 +117,12 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getGuidedStorage()).thenAnswer((_) async => testStorages);
 
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Provider<DiskStorageService>.value(
+    await tester.pumpWidget(
+      Provider<DiskStorageService>.value(
         value: service,
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: SelectGuidedStoragePage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+        child: tester.buildApp(SelectGuidedStoragePage.create),
       ),
-    ));
+    );
 
     final page = find.byType(SelectGuidedStoragePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker_page_test.dart
@@ -3,10 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/turn_off_bitlocker/turn_off_bitlocker_model.dart';
 import 'package:ubuntu_desktop_installer/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'turn_off_bitlocker_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
@@ -17,21 +15,9 @@ void main() {
     final model = MockTurnOffBitLockerModel();
 
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: localizationsDelegates,
-        home: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: (_) {
-                return Provider<TurnOffBitLockerModel>.value(
-                  value: model,
-                  child: TurnOffBitLockerPage(),
-                );
-              },
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      Provider<TurnOffBitLockerModel>.value(
+        value: model,
+        child: tester.buildApp((_) => TurnOffBitLockerPage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst_page_test.dart
@@ -3,10 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/turn_off_rst/turn_off_rst_model.dart';
 import 'package:ubuntu_desktop_installer/pages/turn_off_rst/turn_off_rst_page.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'turn_off_rst_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
@@ -17,21 +15,9 @@ void main() {
     final model = MockTurnOffRSTModel();
 
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: localizationsDelegates,
-        home: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: (_) {
-                return Provider<TurnOffRSTModel>.value(
-                  value: model,
-                  child: TurnOffRSTPage(),
-                );
-              },
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      Provider<TurnOffRSTModel>.value(
+        value: model,
+        child: tester.buildApp((_) => TurnOffRSTPage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
@@ -4,7 +4,6 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_model.dart';
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_page.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -38,21 +37,9 @@ void main() {
     );
   }
 
-  Widget buildApp(WidgetTester tester, UpdateOtherSoftwareModel model) {
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(builder: (_) => buildPage(model)),
-          '/next': WizardRoute(builder: (_) => Text('Next page')),
-        },
-      ),
-    );
-  }
-
   testWidgets('installation mode', (tester) async {
     final model = buildModel(installationMode: InstallationMode.normal);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final normalInstallationTile = find.widgetWithText(
       typeOf<RadioButton<InstallationMode>>(),
@@ -89,7 +76,7 @@ void main() {
   // https://github.com/canonical/ubuntu-desktop-installer/issues/373
   // testWidgets('install third-party software', (tester) async {
   //   final model = buildModel(installThirdParty: true);
-  //   await tester.pumpWidget(buildApp(tester, model));
+  //   await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
   //   final installThirdPartyTile = find.widgetWithText(
   //     CheckButton,
@@ -108,7 +95,7 @@ void main() {
 
   testWidgets('continue on the next page', (tester) async {
     final model = buildModel(installationMode: InstallationMode.normal);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -123,20 +110,12 @@ void main() {
   });
 
   testWidgets('creates a model', (tester) async {
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Provider<SubiquityClient>(
+    await tester.pumpWidget(
+      Provider<SubiquityClient>(
         create: (_) => MockSubiquityClient(),
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: UpdatesOtherSoftwarePage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+        child: tester.buildApp(UpdatesOtherSoftwarePage.create),
       ),
-    ));
+    );
 
     final page = find.byType(UpdatesOtherSoftwarePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you_page_test.dart
@@ -7,7 +7,6 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_model.dart';
 import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_page.dart';
 import 'package:ubuntu_wizard/l10n.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 import 'who_are_you_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
@@ -45,25 +44,9 @@ void main() {
     );
   }
 
-  Widget buildApp(WidgetTester tester, WhoAreYouModel model) {
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(
-        routes: {
-          '/': WizardRoute(
-            builder: (_) => buildPage(model),
-            onNext: (settings) => '/',
-          ),
-        },
-      ),
-    );
-  }
-
   testWidgets('real name input', (tester) async {
     final model = buildModel(realName: 'real name');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final textField = find.widgetWithText(TextField, 'real name');
     expect(textField, findsOneWidget);
@@ -73,7 +56,7 @@ void main() {
 
   testWidgets('host name input', (tester) async {
     final model = buildModel(hostname: 'host name');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final textField = find.widgetWithText(TextField, 'host name');
     expect(textField, findsOneWidget);
@@ -83,7 +66,7 @@ void main() {
 
   testWidgets('username input', (tester) async {
     final model = buildModel(username: 'username');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final textField = find.widgetWithText(TextField, 'username');
     expect(textField, findsOneWidget);
@@ -93,7 +76,7 @@ void main() {
 
   testWidgets('password input', (tester) async {
     final model = buildModel(password: 'password');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final textField = find.widgetWithText(TextField, 'password');
     expect(textField, findsOneWidget);
@@ -103,7 +86,7 @@ void main() {
 
   testWidgets('password confirmation', (tester) async {
     final model = buildModel(password: 'passwd', confirmedPassword: 'passwd');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final textField = find.widgetWithText(TextField, 'passwd');
     expect(textField, findsNWidgets(2));
@@ -115,7 +98,7 @@ void main() {
 
   testWidgets('empty password', (tester) async {
     final model = buildModel(password: '');
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
@@ -131,7 +114,7 @@ void main() {
       password: 'not empty',
       passwordStrength: PasswordStrength.weak,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
@@ -144,7 +127,7 @@ void main() {
       password: 'not empty',
       passwordStrength: PasswordStrength.fair,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
@@ -157,7 +140,7 @@ void main() {
       password: 'not empty',
       passwordStrength: PasswordStrength.good,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
@@ -170,7 +153,7 @@ void main() {
       password: 'not empty',
       passwordStrength: PasswordStrength.strong,
     );
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(WhoAreYouPage));
     final lang = UbuntuLocalizations.of(context);
@@ -180,7 +163,7 @@ void main() {
 
   testWidgets('valid input', (tester) async {
     final model = buildModel(isValid: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -191,7 +174,7 @@ void main() {
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,
@@ -203,7 +186,7 @@ void main() {
   // https://github.com/canonical/ubuntu-desktop-installer/issues/373
   // testWidgets('login strategy', (tester) async {
   //   final model = buildModel(loginStrategy: LoginStrategy.autoLogin);
-  //   await tester.pumpWidget(buildApp(tester, model));
+  //   await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
   //   final autoLoginTile = find.widgetWithText(
   //     typeOf<RadioButton<LoginStrategy>>(),
@@ -235,7 +218,7 @@ void main() {
 
   testWidgets('save identity', (tester) async {
     final model = buildModel(isValid: true);
-    await tester.pumpWidget(buildApp(tester, model));
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
       OutlinedButton,

--- a/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_tester_extensions.dart
@@ -1,9 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/l10n.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-/// An extension on [WidgetTester] that exposes a [lang] property.
+/// An extension on [WidgetTester] for building test apps.
 ///
 /// The additional [lang] property returns the [AppLocalizations] instance
 /// associated with the current [WizardPage], for easy access to the
@@ -14,10 +15,10 @@ import 'package:ubuntu_wizard/widgets.dart';
 /// import 'widget_tester_extensions.dart';
 ///
 /// void main() {
-///   Widget buildApp(WidgetTester tester) { [...] }
+///   Widget buildPage(WidgetTester tester) { [...] }
 ///
 ///   testWidgets('test description', (tester) async {
-///     await tester.pumpWidget(buildApp(tester));
+///     await tester.pumpWidget(tester.buildApp((_) => buildPage(tester)));
 ///
 ///     expect(find.text(tester.lang.someTranslatableString), findsOneWidget);
 ///   });
@@ -25,7 +26,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 /// ```
 ///
 /// If the tested widget is not in a [WizardPage], you can use the static
-/// [LangTester.context] property to specify the appropriate context to use.
+/// [UbuntuTester.context] property to specify the appropriate context to use.
 ///
 /// For example:
 /// ```dart
@@ -33,7 +34,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 ///   setUpAll(() => LangTester.context = MyWidget);
 /// }
 /// ```
-extension LangTester on WidgetTester {
+extension UbuntuTester on WidgetTester {
   static Type context = WizardPage;
 
   AppLocalizations get lang {
@@ -44,5 +45,24 @@ extension LangTester on WidgetTester {
   UbuntuLocalizations get ulang {
     final view = element(find.byType(context).first);
     return UbuntuLocalizations.of(view);
+  }
+
+  Widget buildApp(WidgetBuilder builder) {
+    binding.window.devicePixelRatioTestValue = 1;
+    binding.window.physicalSizeTestValue = const Size(960, 680);
+    return MaterialApp(
+      localizationsDelegates: localizationsDelegates,
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: builder,
+            onNext: (settings) => '/next',
+          ),
+          '/next': WizardRoute(
+            builder: (_) => const Text('Next page'),
+          ),
+        },
+      ),
+    );
   }
 }


### PR DESCRIPTION
A similar buildApp() helper was in most page tests. Since setting up
the wizard and its routes is an irrelevant detail for widget tests,
share the logic in one place. Also, when FlavorData will be taken into
use, it doesn't need to be sprinkled all around the tests.