### PR TITLE
Add Routes.initial for convenience

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -143,7 +143,7 @@ class _UbuntuDesktopInstallerWizardState
     final service = Provider.of<DiskStorageService>(context, listen: false);
 
     return Wizard(
-      initialRoute: widget.initialRoute ?? Routes.welcome,
+      initialRoute: widget.initialRoute ?? Routes.initial,
       routes: <String, WizardRoute>{
         Routes.welcome: const WizardRoute(
           builder: WelcomePage.create,

--- a/packages/ubuntu_desktop_installer/lib/routes.dart
+++ b/packages/ubuntu_desktop_installer/lib/routes.dart
@@ -1,4 +1,5 @@
 abstract class Routes {
+  static const initial = welcome;
   static const welcome = '/welcome';
   static const tryOrInstall = '/tryorinstall';
   static const turnOffRST = '/turnoffrst';


### PR DESCRIPTION
Even though there's a --initial-route command-line argument, it's often
easier and faster to edit the initial route on the fly and hot restart
the app, especially if the app is already running anyway.

Definiting the initial route in routes.dart makes it quick to find and
edit the initial route, rather than searching for it in installer.dart.