### PR TITLE
Partial revert of e6693ec5 to restore analyzer for tests/

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,10 +6,9 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.mocks.dart"
     - "**/l10n/*.dart"
-#    - "**/test/**.dart"
 
 linter:
   rules:
     constant_identifier_names: false
     lines_longer_than_80_chars: false
-    prefer_const_constructors: true
+    # prefer_const_constructors: true


### PR DESCRIPTION
Consequently, the `prefer_const_constructors` linter rule has been
temporarily commented out because there would be a lot of warnings
in `tests/`.

Close: #510