### PR TITLE
snapcraft: bundle util-linux

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -15,7 +15,7 @@ export PYTHON=$SNAP/usr/bin/python3.8
 export PY3OR2_PYTHON=$PYTHON
 
 # set the PATH so subiquity finds curtin
-export PATH=$PATH:$SNAP/bin
+export PATH=$SNAP/bin:$PATH
 
 # base directory for subiquity to locate resources
 export SUBIQUITY_ROOT=$SNAP/bin/subiquity

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
       - python3-pyudev
       - python3-systemd
       - python3-urwid
+      - util-linux
     prime:
       - -lib/systemd/system/*
 


### PR DESCRIPTION
Curtin expects a certain output format from util-linux, which seems to
have changed in the util-linux in Jammy.  Bundle util-linux so that we
have a predictable tool version.  Also adjust PATH to find the tools in
the snap before the system ones.

Fixes #513