### PR TITLE
Remove --no-fatal-infos for analysis

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -13,7 +13,7 @@ scripts:
   # analyze all packages
   analyze: >
     melos exec -c 1 -- \
-      flutter analyze --no-fatal-infos .
+      flutter analyze .
 
   # collect coverage information for all packages
   coverage: >


### PR DESCRIPTION
There used to be a lot of false positives due to `public_member_api_docs`. Now that it has been turned off, we can remove `--not-fatal-infos` to avoid other analysis issues slipping in.

Ref: #467