### PR TITLE
Limit the window size to the available workarea

### DIFF
--- a/packages/ubuntu_desktop_installer/linux/my_application.cc
+++ b/packages/ubuntu_desktop_installer/linux/my_application.cc
@@ -30,8 +30,7 @@ static gboolean my_application_fit_to_workarea(GtkWindow* window) {
   gboolean fits_workarea =
       allocation.width < workarea.width || allocation.height < workarea.height;
   if (!fits_workarea) {
-    gtk_window_move(window, workarea.x, workarea.y);
-    gtk_window_resize(window, workarea.width, workarea.height);
+    gtk_window_maximize(window);
   }
   return fits_workarea;
 }


### PR DESCRIPTION
When the available workarea is smaller than the default window size,
maximize the window to let the window manager take care of filling the
available workarea. This ensures that the window fits on the screen
even if the resolution is relatively low. For example, the default in
Virtual Box is 800x600.

Ref: #518