### PR TITLE
WSL: fix language selection in the integration test

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -111,7 +111,8 @@ Future<void> testSelectYourLanguagePage(
   if (language != null) {
     final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
     expect(tile, findsOneWidget);
-    await tester.scrollUntilVisible(tile, kMinInteractiveDimension);
+    final viewRect = tester.getRect(find.byType(ListView));
+    await tester.scrollUntilVisible(tile, viewRect.height / 2);
     await tester.pump();
     await tester.tap(tile);
     await tester.pump();

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -109,7 +109,11 @@ Future<void> testSelectYourLanguagePage(
   expectPage(tester, SelectLanguagePage, (lang) => lang.selectLanguageTitle);
 
   if (language != null) {
-    await tester.tap(find.widgetWithText(ListTile, language));
+    final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
+    expect(tile, findsOneWidget);
+    await tester.scrollUntilVisible(tile, kMinInteractiveDimension);
+    await tester.pump();
+    await tester.tap(tile);
     await tester.pump();
   }
   await tester.pumpAndSettle();


### PR DESCRIPTION
The test was assuming that the "French" list item was visible on the
screen by default. However, #530 added a long list of supported
languages, which pushed the "French" item out of the screen when the
default "English" item is selected on startup. Consequently, the test
would not be able to tap the "French" item. This commit fixes the issue
by scrolling the list until the "French" item becomes visible, before
trying to tap it.