### PR TITLE
Allow flavors to pass localization delegates

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -111,7 +111,10 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         darkTheme: flavor.darkTheme,
         themeMode: Settings.of(context).theme,
         debugShowCheckedModeBanner: false,
-        localizationsDelegates: localizationsDelegates,
+        localizationsDelegates: [
+          ...localizationsDelegates,
+          ...?flavor.localizationsDelegates,
+        ],
         supportedLocales: AppLocalizations.supportedLocales,
         home: buildApp(context),
       ),

--- a/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
@@ -8,6 +8,7 @@ class FlavorData {
     required this.name,
     this.theme,
     this.darkTheme,
+    this.localizationsDelegates,
     this.package = '',
   });
 
@@ -20,6 +21,9 @@ class FlavorData {
   /// The dark theme of the application.
   final ThemeData? darkTheme;
 
+  /// The list of localizations for the application.
+  final List<LocalizationsDelegate>? localizationsDelegates;
+
   /// The package name of the application. This is used to determine the
   /// fallback package for assets. This is set by the application - specifying
   /// one in a flavor has no effect.
@@ -30,12 +34,15 @@ class FlavorData {
     String? name,
     ThemeData? theme,
     ThemeData? darkTheme,
+    List<LocalizationsDelegate>? localizationsDelegates,
     String? package,
   }) {
     return FlavorData(
       name: name ?? this.name,
       theme: theme ?? this.theme,
       darkTheme: darkTheme ?? this.darkTheme,
+      localizationsDelegates:
+          localizationsDelegates ?? this.localizationsDelegates,
       package: package ?? this.package,
     );
   }
@@ -47,12 +54,13 @@ class FlavorData {
         other.name == name &&
         other.theme == theme &&
         other.darkTheme == darkTheme &&
+        other.localizationsDelegates == localizationsDelegates &&
         other.package == package;
   }
 
   @override
-  int get hashCode => Object.hash(
-      name.hashCode, theme.hashCode, darkTheme.hashCode, package.hashCode);
+  int get hashCode => Object.hashAll(
+      [name, theme, darkTheme, ...?localizationsDelegates, package]);
 
   @override
   String toString() =>

--- a/packages/ubuntu_wizard/test/flavor_test.dart
+++ b/packages/ubuntu_wizard/test/flavor_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 void main() {
@@ -8,6 +10,7 @@ void main() {
       name: 'Test Flavor 1',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       package: 'test_package_1',
     );
     expect(flavor1, equals(flavor1));
@@ -19,6 +22,7 @@ void main() {
       name: 'Test Flavor 2',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalUbuntuLocalizations.delegates,
       package: 'test_package_2',
     );
     expect(flavor2, isNot(equals(flavor1)));
@@ -31,6 +35,7 @@ void main() {
           name: 'Test Flavor',
           theme: ThemeData.light(),
           darkTheme: ThemeData.dark(),
+          localizationsDelegates: GlobalUbuntuLocalizations.delegates,
           package: 'test_package',
         ),
         child: Builder(builder: (_) => MaterialApp()),
@@ -42,6 +47,8 @@ void main() {
     expect(flavor.name, equals('Test Flavor'));
     expect(flavor.theme, equals(ThemeData.light()));
     expect(flavor.darkTheme, equals(ThemeData.dark()));
+    expect(flavor.localizationsDelegates,
+        equals(GlobalUbuntuLocalizations.delegates));
     expect(flavor.package, equals('test_package'));
   });
 
@@ -50,6 +57,7 @@ void main() {
       name: 'Test Flavor',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       package: 'test_package',
     );
 
@@ -58,6 +66,8 @@ void main() {
     expect(namedFlavor.name, equals('New Flavor'));
     expect(namedFlavor.theme, equals(flavor.theme));
     expect(namedFlavor.darkTheme, equals(flavor.darkTheme));
+    expect(namedFlavor.localizationsDelegates,
+        equals(flavor.localizationsDelegates));
     expect(namedFlavor.package, equals(flavor.package));
 
     final themedFlavor = flavor.copyWith(
@@ -69,6 +79,21 @@ void main() {
     expect(themedFlavor.name, equals(flavor.name));
     expect(themedFlavor.theme, equals(flavor.darkTheme));
     expect(themedFlavor.darkTheme, equals(flavor.theme));
+    expect(themedFlavor.localizationsDelegates,
+        equals(flavor.localizationsDelegates));
     expect(themedFlavor.package, equals(flavor.package));
+
+    final localizedFlavor = flavor.copyWith(
+      localizationsDelegates: GlobalUbuntuLocalizations.delegates,
+    );
+    expect(localizedFlavor, isNot(equals(flavor)));
+    expect(localizedFlavor, isNot(equals(namedFlavor)));
+    expect(localizedFlavor, isNot(equals(themedFlavor)));
+    expect(localizedFlavor.name, equals(flavor.name));
+    expect(localizedFlavor.theme, equals(flavor.theme));
+    expect(localizedFlavor.darkTheme, equals(flavor.darkTheme));
+    expect(localizedFlavor.localizationsDelegates,
+        equals(GlobalUbuntuLocalizations.delegates));
+    expect(localizedFlavor.package, equals(flavor.package));
   });
 }


### PR DESCRIPTION
This is necessary for flavors to be able to translate slides (#42).