### PR TITLE
Fix WSL setup failing due /sbin not in the PATH

### DIFF
--- a/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
+++ b/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
@@ -571,7 +571,8 @@ if [ -n "$SNAP_DESKTOP_DEBUG" ]; then
   echo "Now running: exec $*"
 fi
 
-PATH="${SNAP}/usr/bin:${SNAP}/bin:${SNAP_CORE_DIR}/bin:${SNAP_CORE_DIR}/usr/bin"
+PATH="${SNAP}/usr/sbin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin"
+PATH="${PATH}:${SNAP_CORE_DIR}/usr/sbin:${SNAP_CORE_DIR}/usr/bin:${SNAP_CORE_DIR}/sbin:${SNAP_CORE_DIR}/bin"
 
 # configure python environment
 export PYTHONIOENCODING=utf-8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -111,6 +111,9 @@ parts:
       - python3-systemd
       - python3-urwid
       - util-linux
+      # WSL specifics:
+      - language-selector-common
+      - locales
     prime:
       - -lib/systemd/system/*
 


### PR DESCRIPTION
Hello, @jpnurmi !

Testing the recent images with the installer seeded we failed under WSL environment due useradd, usermod and some locale related utility commands not found in snap PATH. To fix that we need to:
- Add core20/sbin to the PATH.
- Add to the snap two packages related to locale manipulation.