### PR TITLE
Fix analysis warnings (unnecessary_import)

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:json_annotation/json_annotation.dart';
 
 part 'types.freezed.dart';
 part 'types.g.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
 
 import '../../l10n.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -2,7 +2,6 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:flutter_html/style.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_detector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_detector_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_detector.dart';
 import 'package:ubuntu_test/mocks.dart';
 

--- a/packages/ubuntu_desktop_installer/test/network_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network_model_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:nm/nm.dart';
 import 'package:ubuntu_desktop_installer/pages/connect_to_internet/network_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 

--- a/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome_page_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';

--- a/packages/ubuntu_wizard/lib/settings.dart
+++ b/packages/ubuntu_wizard/lib/settings.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';

--- a/packages/ubuntu_wizard/test/settings_test.dart
+++ b/packages/ubuntu_wizard/test/settings_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';


### PR DESCRIPTION
These appeared with the latest Flutter stable:
```
   info • The import of 'package:json_annotation/json_annotation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:freezed_annotation/freezed_annotation.dart' • lib/src/types.dart:2:8 • unnecessary_import
   info • The import of 'package:flutter/foundation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/widgets.dart' • lib/pages/installation_slides/installation_slides_model.dart:3:8 • unnecessary_import
   info • The import of 'package:subiquity_client/subiquity_client.dart' is unnecessary because all of the used elements are also provided by the import of 'keyboard_layout_detector.dart' • lib/pages/keyboard_layout/keyboard_layout_dialogs.dart:3:8 • unnecessary_import
   info • The import of 'package:flutter/rendering.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • lib/pages/keyboard_layout/keyboard_layout_page.dart:2:8 • unnecessary_import
   info • The import of 'package:meta/meta.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/foundation.dart' • lib/pages/try_or_install/try_or_install_model.dart:5:8 • unnecessary_import
   info • The import of 'package:flutter/rendering.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • lib/pages/turn_off_rst/turn_off_rst_page.dart:2:8 • unnecessary_import
   info • The import of 'package:flutter_html/style.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter_html/flutter_html.dart' • lib/pages/turn_off_rst/turn_off_rst_page.dart:4:8 • unnecessary_import
   info • The import of 'package:subiquity_client/subiquity_client.dart' is unnecessary because all of the used elements are also provided by the import of 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_detector.dart' • test/keyboard_layout_detector_test.dart:5:8 • unnecessary_import
   info • The import of 'package:nm/nm.dart' is unnecessary because all of the used elements are also provided by the import of 'package:ubuntu_desktop_installer/services.dart' • test/network_model_test.dart:6:8 • unnecessary_import
   info • The import of 'package:flutter/widgets.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • test/welcome_page_test.dart:2:8 • unnecessary_import
   info • The import of 'dart:ui' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • lib/settings.dart:1:8 • unnecessary_import
   info • The import of 'dart:ui' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • test/settings_test.dart:1:8 • unnecessary_import
   info • The import of 'dart:ui' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • test/app_test.dart:1:8 • unnecessary_import
```