### PR TITLE
Who are you: automatically focus the first input field

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
@@ -15,6 +15,7 @@ class _RealNameFormField extends StatelessWidget {
         context.select<WhoAreYouModel, String>((model) => model.realName);
 
     return ValidatedFormField(
+      autofocus: true,
       fieldWidth: fieldWidth,
       labelText: lang.whoAreYouPageRealNameLabel,
       successWidget: const SuccessIcon(),


### PR DESCRIPTION
It's convenient to start typing right away after entering the page.