### PR TITLE
Close and destroy subiquity sockets

### DIFF
--- a/packages/subiquity_client/lib/src/http_unix_client.dart
+++ b/packages/subiquity_client/lib/src/http_unix_client.dart
@@ -111,6 +111,7 @@ class HttpUnixClient extends BaseClient {
   Future<void> close() async {
     if (_socket != null) {
       await _socket!.close();
+      _socket!.destroy();
       _socket = null;
     }
   }

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -113,12 +113,12 @@ abstract class SubiquityServer {
     for (var i = 0; i < 10; ++i) {
       try {
         await client.send(request);
-        await client.close();
         break;
       } on Exception catch (_) {
         await Future.delayed(const Duration(seconds: 1));
       }
     }
+    await client.close();
   }
 
   static File _pidFile() {

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -113,6 +113,7 @@ abstract class SubiquityServer {
     for (var i = 0; i < 10; ++i) {
       try {
         await client.send(request);
+        await client.close();
         break;
       } on Exception catch (_) {
         await Future.delayed(const Duration(seconds: 1));


### PR DESCRIPTION
Close the clients that are used on startup to send status requests
to test whether subiquity is up and running, and fully destroy closed
sockets to ensure that no asynchronous operations are pending in the
background when sockets are closed and reopened at fast pace in
integration tests.