### PR TITLE
Use disk model and vendor names from subiquity 

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -237,6 +237,8 @@ class Disk with _$Disk {
     String? ptable,
     bool? preserve,
     bool? bootDevice,
+    String? model,
+    String? vendor,
   }) = _Disk;
 
   factory Disk.fromJson(Map<String, dynamic> json) => _$DiskFromJson(json);

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -2749,7 +2749,9 @@ class _$DiskTearOff {
       bool? okForGuided,
       String? ptable,
       bool? preserve,
-      bool? bootDevice}) {
+      bool? bootDevice,
+      String? model,
+      String? vendor}) {
     return _Disk(
       id: id,
       label: label,
@@ -2763,6 +2765,8 @@ class _$DiskTearOff {
       ptable: ptable,
       preserve: preserve,
       bootDevice: bootDevice,
+      model: model,
+      vendor: vendor,
     );
   }
 
@@ -2788,6 +2792,8 @@ mixin _$Disk {
   String? get ptable => throw _privateConstructorUsedError;
   bool? get preserve => throw _privateConstructorUsedError;
   bool? get bootDevice => throw _privateConstructorUsedError;
+  String? get model => throw _privateConstructorUsedError;
+  String? get vendor => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -2810,7 +2816,9 @@ abstract class $DiskCopyWith<$Res> {
       bool? okForGuided,
       String? ptable,
       bool? preserve,
-      bool? bootDevice});
+      bool? bootDevice,
+      String? model,
+      String? vendor});
 }
 
 /// @nodoc
@@ -2835,6 +2843,8 @@ class _$DiskCopyWithImpl<$Res> implements $DiskCopyWith<$Res> {
     Object? ptable = freezed,
     Object? preserve = freezed,
     Object? bootDevice = freezed,
+    Object? model = freezed,
+    Object? vendor = freezed,
   }) {
     return _then(_value.copyWith(
       id: id == freezed
@@ -2885,6 +2895,14 @@ class _$DiskCopyWithImpl<$Res> implements $DiskCopyWith<$Res> {
           ? _value.bootDevice
           : bootDevice // ignore: cast_nullable_to_non_nullable
               as bool?,
+      model: model == freezed
+          ? _value.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String?,
+      vendor: vendor == freezed
+          ? _value.vendor
+          : vendor // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -2906,7 +2924,9 @@ abstract class _$DiskCopyWith<$Res> implements $DiskCopyWith<$Res> {
       bool? okForGuided,
       String? ptable,
       bool? preserve,
-      bool? bootDevice});
+      bool? bootDevice,
+      String? model,
+      String? vendor});
 }
 
 /// @nodoc
@@ -2932,6 +2952,8 @@ class __$DiskCopyWithImpl<$Res> extends _$DiskCopyWithImpl<$Res>
     Object? ptable = freezed,
     Object? preserve = freezed,
     Object? bootDevice = freezed,
+    Object? model = freezed,
+    Object? vendor = freezed,
   }) {
     return _then(_Disk(
       id: id == freezed
@@ -2982,6 +3004,14 @@ class __$DiskCopyWithImpl<$Res> extends _$DiskCopyWithImpl<$Res>
           ? _value.bootDevice
           : bootDevice // ignore: cast_nullable_to_non_nullable
               as bool?,
+      model: model == freezed
+          ? _value.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String?,
+      vendor: vendor == freezed
+          ? _value.vendor
+          : vendor // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -3002,7 +3032,9 @@ class _$_Disk implements _Disk {
       this.okForGuided,
       this.ptable,
       this.preserve,
-      this.bootDevice});
+      this.bootDevice,
+      this.model,
+      this.vendor});
 
   factory _$_Disk.fromJson(Map<String, dynamic> json) =>
       _$_$_DiskFromJson(json);
@@ -3031,10 +3063,14 @@ class _$_Disk implements _Disk {
   final bool? preserve;
   @override
   final bool? bootDevice;
+  @override
+  final String? model;
+  @override
+  final String? vendor;
 
   @override
   String toString() {
-    return 'Disk(id: $id, label: $label, path: $path, type: $type, size: $size, usageLabels: $usageLabels, partitions: $partitions, freeForPartitions: $freeForPartitions, okForGuided: $okForGuided, ptable: $ptable, preserve: $preserve, bootDevice: $bootDevice)';
+    return 'Disk(id: $id, label: $label, path: $path, type: $type, size: $size, usageLabels: $usageLabels, partitions: $partitions, freeForPartitions: $freeForPartitions, okForGuided: $okForGuided, ptable: $ptable, preserve: $preserve, bootDevice: $bootDevice, model: $model, vendor: $vendor)';
   }
 
   @override
@@ -3070,7 +3106,11 @@ class _$_Disk implements _Disk {
                     .equals(other.preserve, preserve)) &&
             (identical(other.bootDevice, bootDevice) ||
                 const DeepCollectionEquality()
-                    .equals(other.bootDevice, bootDevice)));
+                    .equals(other.bootDevice, bootDevice)) &&
+            (identical(other.model, model) ||
+                const DeepCollectionEquality().equals(other.model, model)) &&
+            (identical(other.vendor, vendor) ||
+                const DeepCollectionEquality().equals(other.vendor, vendor)));
   }
 
   @override
@@ -3087,7 +3127,9 @@ class _$_Disk implements _Disk {
       const DeepCollectionEquality().hash(okForGuided) ^
       const DeepCollectionEquality().hash(ptable) ^
       const DeepCollectionEquality().hash(preserve) ^
-      const DeepCollectionEquality().hash(bootDevice);
+      const DeepCollectionEquality().hash(bootDevice) ^
+      const DeepCollectionEquality().hash(model) ^
+      const DeepCollectionEquality().hash(vendor);
 
   @JsonKey(ignore: true)
   @override
@@ -3113,7 +3155,9 @@ abstract class _Disk implements Disk {
       bool? okForGuided,
       String? ptable,
       bool? preserve,
-      bool? bootDevice}) = _$_Disk;
+      bool? bootDevice,
+      String? model,
+      String? vendor}) = _$_Disk;
 
   factory _Disk.fromJson(Map<String, dynamic> json) = _$_Disk.fromJson;
 
@@ -3141,6 +3185,10 @@ abstract class _Disk implements Disk {
   bool? get preserve => throw _privateConstructorUsedError;
   @override
   bool? get bootDevice => throw _privateConstructorUsedError;
+  @override
+  String? get model => throw _privateConstructorUsedError;
+  @override
+  String? get vendor => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$DiskCopyWith<_Disk> get copyWith => throw _privateConstructorUsedError;

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -313,6 +313,8 @@ _$_Disk _$_$_DiskFromJson(Map<String, dynamic> json) {
     ptable: json['ptable'] as String?,
     preserve: json['preserve'] as bool?,
     bootDevice: json['boot_device'] as bool?,
+    model: json['model'] as String?,
+    vendor: json['vendor'] as String?,
   );
 }
 
@@ -329,6 +331,8 @@ Map<String, dynamic> _$_$_DiskToJson(_$_Disk instance) => <String, dynamic>{
       'ptable': instance.ptable,
       'preserve': instance.preserve,
       'boot_device': instance.bootDevice,
+      'model': instance.model,
+      'vendor': instance.vendor,
     };
 
 _$_GuidedChoice _$_$_GuidedChoiceFromJson(Map<String, dynamic> json) {

--- a/packages/subiquity_client/test/types_test.dart
+++ b/packages/subiquity_client/test/types_test.dart
@@ -156,6 +156,8 @@ void main() {
       ptable: 'tst',
       preserve: true,
       bootDevice: true,
+      model: 'QEMU',
+      vendor: 'ATA',
     );
 
     final json = <String, dynamic>{
@@ -174,6 +176,8 @@ void main() {
       'ptable': 'tst',
       'preserve': true,
       'boot_device': true,
+      'model': 'QEMU',
+      'vendor': 'ATA',
     };
 
     expect(disk.toJson(), equals(json));

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -6,7 +6,6 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/widgets/yaru_icons.dart';
 
 import '../../l10n.dart';
-import '../../services.dart';
 import 'allocate_disk_space_dialogs.dart';
 import 'allocate_disk_space_model.dart';
 
@@ -394,11 +393,14 @@ class BootDiskSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<AllocateDiskSpaceModel>(context);
-    final udev = Provider.of<UdevService>(context, listen: false);
     final lang = AppLocalizations.of(context);
 
     String prettyFormatDisk(Disk disk) {
-      return '${disk.path} ${udev.bySysname(disk.sysname).fullName} (${disk.prettySize})';
+      final fullName = <String?>[
+        disk.model,
+        disk.vendor,
+      ].where((p) => p?.isNotEmpty == true).join(' ');
+      return '${disk.path} $fullName (${disk.prettySize})';
     }
 
     return Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -44,10 +44,9 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
 
   /// Formats a disk in a pretty way e.g. "/dev/sda ATA Maxtor (123 GB)"
   String prettyFormatStorage(Disk disk) {
-    final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.bySysname(disk.sysname).modelName,
-      udev.bySysname(disk.sysname).vendorName,
+      disk.model,
+      disk.vendor,
     ].where((p) => p?.isNotEmpty == true).join(' ');
 
     final size = filesize(disk.size);

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -40,10 +40,9 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
   }
 
   String prettyFormatDisk(Disk disk) {
-    final udev = Provider.of<UdevService>(context, listen: false);
     final fullName = <String?>[
-      udev.bySysname(disk.sysname).modelName,
-      udev.bySysname(disk.sysname).vendorName,
+      disk.model,
+      disk.vendor,
     ].where((p) => p?.isNotEmpty == true).join(' ');
     return '$fullName (${disk.sysname})';
   }

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -13,11 +13,11 @@ import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
 import 'widget_tester_extensions.dart';
 
-@GenerateMocks([SelectGuidedStorageModel, UdevDeviceInfo, UdevService])
+@GenerateMocks([SelectGuidedStorageModel])
 void main() {
   const testStorages = <Disk>[
-    Disk(path: '/dev/sda', size: 12),
-    Disk(path: '/dev/sdb', size: 23),
+    Disk(path: '/dev/sda', size: 12, model: 'SDA', vendor: 'ATA'),
+    Disk(path: '/dev/sdb', size: 23, model: 'SDB', vendor: 'ATA'),
   ];
 
   SelectGuidedStorageModel buildModel({
@@ -33,21 +33,8 @@ void main() {
   }
 
   Widget buildPage(SelectGuidedStorageModel model) {
-    final udev = MockUdevService();
-    final sda = MockUdevDeviceInfo();
-    when(sda.modelName).thenReturn('SDA');
-    when(sda.vendorName).thenReturn('ATA');
-    when(udev.bySysname('sda')).thenReturn(sda);
-    final sdb = MockUdevDeviceInfo();
-    when(sdb.modelName).thenReturn('SDB');
-    when(sdb.vendorName).thenReturn('ATA');
-    when(udev.bySysname('sdb')).thenReturn(sdb);
-
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<SelectGuidedStorageModel>.value(value: model),
-        Provider<UdevService>.value(value: udev),
-      ],
+    return ChangeNotifierProvider<SelectGuidedStorageModel>.value(
+      value: model,
       child: const SelectGuidedStoragePage(),
     );
   }
@@ -63,7 +50,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byTypeOf<DropdownButton<int>>(),
-          matching: find.textContaining(storage.sysname.toUpperCase()),
+          matching: find.textContaining(storage.path!),
         ),
         findsOneWidget,
       );

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.mocks.dart
@@ -2,14 +2,13 @@
 // in ubuntu_desktop_installer/test/select_guided_storage_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i5;
-import 'dart:ui' as _i6;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i4;
+import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart'
-    as _i3;
-import 'package:ubuntu_desktop_installer/services.dart' as _i2;
+    as _i2;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -19,21 +18,19 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
-class _FakeUdevDeviceInfo_0 extends _i1.Fake implements _i2.UdevDeviceInfo {}
-
 /// A class which mocks [SelectGuidedStorageModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSelectGuidedStorageModel extends _i1.Mock
-    implements _i3.SelectGuidedStorageModel {
+    implements _i2.SelectGuidedStorageModel {
   MockSelectGuidedStorageModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  List<_i4.Disk> get storages => (super
-          .noSuchMethod(Invocation.getter(#storages), returnValue: <_i4.Disk>[])
-      as List<_i4.Disk>);
+  List<_i3.Disk> get storages => (super
+          .noSuchMethod(Invocation.getter(#storages), returnValue: <_i3.Disk>[])
+      as List<_i3.Disk>);
   @override
   int get selectedIndex =>
       (super.noSuchMethod(Invocation.getter(#selectedIndex), returnValue: 0)
@@ -47,26 +44,26 @@ class MockSelectGuidedStorageModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#selectStorage, [index]),
           returnValueForMissingStub: null);
   @override
-  _i5.Future<void> loadGuidedStorage() =>
+  _i4.Future<void> loadGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#loadGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i5.Future<void> saveGuidedStorage() =>
+  _i4.Future<void> saveGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#saveGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i5.Future<void> resetGuidedStorage() =>
+  _i4.Future<void> resetGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  void addListener(_i6.VoidCallback? listener) =>
+  void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
+  void removeListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override
@@ -76,45 +73,6 @@ class MockSelectGuidedStorageModel extends _i1.Mock
   void notifyListeners() =>
       super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
-  @override
-  String toString() => super.toString();
-}
-
-/// A class which mocks [UdevDeviceInfo].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
-  MockUdevDeviceInfo() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  String get fullName =>
-      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
-          as String);
-  @override
-  String toString() => super.toString();
-}
-
-/// A class which mocks [UdevService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockUdevService extends _i1.Mock implements _i2.UdevService {
-  MockUdevService() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
-  @override
-  _i2.UdevDeviceInfo bySysname(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
-          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
-  @override
-  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
-      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
-          returnValue: _FakeUdevDeviceInfo_0()) as _i2.UdevDeviceInfo);
   @override
   String toString() => super.toString();
 }


### PR DESCRIPTION
Disk model and vendor names were added in canonical/subiquity#1138. It's no longer necessary to lookup libudev through FFI, and as a bonus, the names match the machine config in dry-run mode.

Close: #415