### PR TITLE
subiquity-server: permit autoinstall w/ override

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -22,6 +22,12 @@ export SUBIQUITY_ROOT=$SNAP/bin/subiquity
 
 # run subiquity server
 cd $SCRIPT_DIR/subiquity
-# autoinstall is explicitly disabled until UI support is present.
-# Remove this autoinstall argument when that is resolved.
-$PYTHON -m subiquity.cmd.server --autoinstall=""
+
+args=()
+if grep -qv "experimental-autoinstall" /proc/cmdline; then
+    # autoinstall is explicitly disabled until UI support is present.
+    # Remove this autoinstall argument when that is resolved.
+    args+=(--autoinstall="")
+fi
+
+$PYTHON -m subiquity.cmd.server "${args[@]}"


### PR DESCRIPTION
If experimental-autoinstall is found in the kernel command line,
allow autoinstall to be enabled.  It was disabled in the first place due
to UI support not yet being implemented.

Fixes: #581