### PR TITLE
Allow flavors to pass localization delegates

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -112,7 +112,10 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
         darkTheme: flavor.darkTheme,
         themeMode: Settings.of(context).theme,
         debugShowCheckedModeBanner: false,
-        localizationsDelegates: localizationsDelegates,
+        localizationsDelegates: <LocalizationsDelegate>[
+          ...localizationsDelegates,
+          ...?flavor.localizationsDelegates,
+        ],
         supportedLocales: supportedLocales,
         home: buildApp(context),
       ),

--- a/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 /// Defines the configuration of a flavor.
@@ -8,6 +9,7 @@ class FlavorData {
     required this.name,
     this.theme,
     this.darkTheme,
+    this.localizationsDelegates,
     this.package = '',
   });
 
@@ -20,6 +22,9 @@ class FlavorData {
   /// The dark theme of the application.
   final ThemeData? darkTheme;
 
+  /// A list of additional flavor-specific localization delegates.
+  final List<LocalizationsDelegate>? localizationsDelegates;
+
   /// The package name of the application. This is used to determine the
   /// fallback package for assets. This is set by the application - specifying
   /// one in a flavor has no effect.
@@ -30,12 +35,15 @@ class FlavorData {
     String? name,
     ThemeData? theme,
     ThemeData? darkTheme,
+    List<LocalizationsDelegate>? localizationsDelegates,
     String? package,
   }) {
     return FlavorData(
       name: name ?? this.name,
       theme: theme ?? this.theme,
       darkTheme: darkTheme ?? this.darkTheme,
+      localizationsDelegates:
+          localizationsDelegates ?? this.localizationsDelegates,
       package: package ?? this.package,
     );
   }
@@ -43,16 +51,18 @@ class FlavorData {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
+    final listEquals = const ListEquality().equals;
     return other is FlavorData &&
         other.name == name &&
         other.theme == theme &&
         other.darkTheme == darkTheme &&
+        listEquals(other.localizationsDelegates, localizationsDelegates) &&
         other.package == package;
   }
 
   @override
-  int get hashCode => Object.hash(
-      name.hashCode, theme.hashCode, darkTheme.hashCode, package.hashCode);
+  int get hashCode =>
+      Object.hash(name, theme, darkTheme, localizationsDelegates, package);
 
   @override
   String toString() =>

--- a/packages/ubuntu_wizard/test/flavor_test.dart
+++ b/packages/ubuntu_wizard/test/flavor_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 void main() {
@@ -8,6 +10,7 @@ void main() {
       name: 'Test Flavor 1',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       package: 'test_package_1',
     );
     expect(flavor1, equals(flavor1));
@@ -19,6 +22,7 @@ void main() {
       name: 'Test Flavor 2',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalUbuntuLocalizations.delegates,
       package: 'test_package_2',
     );
     expect(flavor2, isNot(equals(flavor1)));
@@ -31,6 +35,7 @@ void main() {
           name: 'Test Flavor',
           theme: ThemeData.light(),
           darkTheme: ThemeData.dark(),
+          localizationsDelegates: GlobalUbuntuLocalizations.delegates,
           package: 'test_package',
         ),
         child: Builder(builder: (_) => MaterialApp()),
@@ -42,6 +47,8 @@ void main() {
     expect(flavor.name, equals('Test Flavor'));
     expect(flavor.theme, equals(ThemeData.light()));
     expect(flavor.darkTheme, equals(ThemeData.dark()));
+    expect(flavor.localizationsDelegates,
+        equals(GlobalUbuntuLocalizations.delegates));
     expect(flavor.package, equals('test_package'));
   });
 
@@ -50,6 +57,7 @@ void main() {
       name: 'Test Flavor',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       package: 'test_package',
     );
 
@@ -58,6 +66,8 @@ void main() {
     expect(namedFlavor.name, equals('New Flavor'));
     expect(namedFlavor.theme, equals(flavor.theme));
     expect(namedFlavor.darkTheme, equals(flavor.darkTheme));
+    expect(namedFlavor.localizationsDelegates,
+        equals(flavor.localizationsDelegates));
     expect(namedFlavor.package, equals(flavor.package));
 
     final themedFlavor = flavor.copyWith(
@@ -69,6 +79,21 @@ void main() {
     expect(themedFlavor.name, equals(flavor.name));
     expect(themedFlavor.theme, equals(flavor.darkTheme));
     expect(themedFlavor.darkTheme, equals(flavor.theme));
+    expect(themedFlavor.localizationsDelegates,
+        equals(flavor.localizationsDelegates));
     expect(themedFlavor.package, equals(flavor.package));
+
+    final localizedFlavor = flavor.copyWith(
+      localizationsDelegates: GlobalUbuntuLocalizations.delegates,
+    );
+    expect(localizedFlavor, isNot(equals(flavor)));
+    expect(localizedFlavor, isNot(equals(namedFlavor)));
+    expect(localizedFlavor, isNot(equals(themedFlavor)));
+    expect(localizedFlavor.name, equals(flavor.name));
+    expect(localizedFlavor.theme, equals(flavor.theme));
+    expect(localizedFlavor.darkTheme, equals(flavor.darkTheme));
+    expect(localizedFlavor.localizationsDelegates,
+        equals(GlobalUbuntuLocalizations.delegates));
+    expect(localizedFlavor.package, equals(flavor.package));
   });
 }

--- a/packages/ubuntu_wizard/test/flavor_test.dart
+++ b/packages/ubuntu_wizard/test/flavor_test.dart
@@ -61,8 +61,13 @@ void main() {
       package: 'test_package',
     );
 
+    final copy = flavor.copyWith();
+    expect(copy, equals(flavor));
+    expect(copy.hashCode, equals(flavor.hashCode));
+
     final namedFlavor = flavor.copyWith(name: 'New Flavor');
     expect(namedFlavor, isNot(equals(flavor)));
+    expect(namedFlavor.hashCode, isNot(equals(flavor.hashCode)));
     expect(namedFlavor.name, equals('New Flavor'));
     expect(namedFlavor.theme, equals(flavor.theme));
     expect(namedFlavor.darkTheme, equals(flavor.darkTheme));
@@ -76,6 +81,7 @@ void main() {
     );
     expect(themedFlavor, isNot(equals(flavor)));
     expect(themedFlavor, isNot(equals(namedFlavor)));
+    expect(themedFlavor.hashCode, isNot(equals(flavor.hashCode)));
     expect(themedFlavor.name, equals(flavor.name));
     expect(themedFlavor.theme, equals(flavor.darkTheme));
     expect(themedFlavor.darkTheme, equals(flavor.theme));
@@ -87,6 +93,7 @@ void main() {
       localizationsDelegates: GlobalUbuntuLocalizations.delegates,
     );
     expect(localizedFlavor, isNot(equals(flavor)));
+    expect(localizedFlavor.hashCode, isNot(equals(flavor.hashCode)));
     expect(localizedFlavor, isNot(equals(namedFlavor)));
     expect(localizedFlavor, isNot(equals(themedFlavor)));
     expect(localizedFlavor.name, equals(flavor.name));


### PR DESCRIPTION
Additional flavor-specific localization delegates are necessary for flavors to be able to translate their own custom slides, for example (#42).