### PR TITLE
Upgrade to Dart SDK 2.15

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -7,7 +7,7 @@ ignore:
   - synthetic_package
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 scripts:
   # analyze all packages

--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -220,19 +220,15 @@ class SubiquityClient {
     await _receive("setSsh(${jsonEncode(ssh.toJson())})", response);
   }
 
-  String _formatState(ApplicationState? state) =>
-      state?.toString().split('.').last ?? 'null';
-
   /// Get the installer state.
   Future<ApplicationStatus> status({ApplicationState? current}) async {
     late Map<String, dynamic> statusJson;
-    final currentState = _formatState(current);
 
     if (current != null) {
       final request = Request('GET',
-          Uri.http('localhost', 'meta/status', {'cur': '"$currentState"'}));
+          Uri.http('localhost', 'meta/status', {'cur': '"${current.name}"'}));
       final response = await _send(request);
-      statusJson = await _receiveJson('status("$currentState")', response);
+      statusJson = await _receiveJson('status("${current.name}")', response);
     } else {
       final request = Request('GET', Uri.http('localhost', 'meta/status'));
       final response = await _send(request);
@@ -240,7 +236,7 @@ class SubiquityClient {
     }
 
     final result = ApplicationStatus.fromJson(statusJson);
-    log.info('state: $currentState => ${_formatState(result.state)}');
+    log.info('state: ${current?.name} => ${result.state?.name}');
 
     return result;
   }

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -12,9 +12,7 @@ extension VariantString on Variant {
     return Variant.values.firstWhere((v) => value == v.toVariantString());
   }
 
-  String toVariantString() {
-    return toString().split('.').last.toLowerCase();
-  }
+  String toVariantString() => name.toLowerCase();
 }
 
 @freezed

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/canonical/ubuntu-desktop-installer
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   dartx: ^0.8.0

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
@@ -80,8 +80,7 @@ class ConnectToInternetModel extends SafeChangeNotifier
     newModel.onSelected();
     newModel.addListener(notifyListeners);
     _connectMode = newModel.connectMode;
-    log.debug(() =>
-        'Selected connection mode: ${_connectMode.toString().split('.')[1]}');
+    log.debug(() => 'Selected connection mode: ${_connectMode.name}');
     notifyListeners();
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
@@ -155,7 +155,7 @@ class NetworkDevice extends PropertyStreamNotifier {
 
   @override
   String toString() =>
-      '$runtimeType(vendor: $vendor, model: $model, state: ${describeEnum(state)})';
+      '$runtimeType(vendor: $vendor, model: $model, state: ${state.name})';
 
   final UdevService? _udev;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
@@ -25,7 +25,7 @@ class PressKeyView extends StatelessWidget {
           child: Wrap(
             spacing: 24,
             alignment: WrapAlignment.spaceEvenly,
-            children: _pressKey.map((key) => Text(key)).toList(),
+            children: _pressKey.map(Text.new).toList(),
           ),
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -1,6 +1,5 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
@@ -32,7 +31,7 @@ class TryOrInstallModel extends ChangeNotifier {
   void selectOption(Option option) {
     if (_option == option) return;
     _option = option;
-    log.info('Selected ${describeEnum(option)} option');
+    log.info('Selected ${option.name} option');
     notifyListeners();
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_model.dart
@@ -42,7 +42,7 @@ class UpdateOtherSoftwareModel extends ChangeNotifier {
     }
 
     _mode = mode;
-    log.info('Selected ${describeEnum(mode)} installation mode');
+    log.info('Selected ${mode.name} installation mode');
     notifyListeners();
   }
 

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Shared test extensions and mocks.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -3,7 +3,7 @@ description: Shared library for Ubuntu wizards.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/ubuntu_wizard/test/slide_show_test.dart
+++ b/packages/ubuntu_wizard/test/slide_show_test.dart
@@ -8,7 +8,7 @@ extension AppTester on WidgetTester {
     return pumpWidget(MaterialApp(
       home: SlideShow(
         interval: interval ?? const Duration(seconds: 5),
-        slides: slides.map((label) => Text(label)).toList(),
+        slides: slides.map(Text.new).toList(),
         wrap: wrap,
       ),
     ));

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -3,7 +3,7 @@ description: Ubuntu WSL OOBE Setup Wizard
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Dart 2.15+ is available in Flutter 2.8+. The most useful new features
are built-in string <=> enum conversions and constructor tear-offs that
can replace factory methods.

https://medium.com/dartlang/dart-2-15-7e7a598e508a