### PR TITLE
Decouple services from the widget tree

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -32,6 +32,12 @@ void runInstallerApp(List<String> args, {FlavorData? flavor}) {
 
   final journalUnit = isLiveRun(options) ? _kSystemdUnit : null;
 
+  registerService(() => DiskStorageService(subiquityClient));
+  registerService(() => JournalService(journalUnit));
+  registerService(() => KeyboardService());
+  registerService(() => NetworkService());
+  registerService(() => UdevService());
+
   final appStatus = ValueNotifier(AppStatus.loading);
 
   runWizardApp(
@@ -61,13 +67,6 @@ void runInstallerApp(List<String> args, {FlavorData? flavor}) {
       'SNAP_REVISION': '',
       'SNAP_VERSION': '',
     },
-    providers: [
-      Provider(create: (_) => DiskStorageService(subiquityClient)),
-      Provider(create: (_) => JournalService(journalUnit)),
-      Provider(create: (_) => KeyboardService()),
-      Provider(create: (_) => NetworkService()),
-      Provider(create: (_) => UdevService()),
-    ],
     onInitSubiquity: (client) {
       appStatus.value = AppStatus.ready;
       client.setVariant(Variant.DESKTOP);
@@ -160,7 +159,7 @@ class _UbuntuDesktopInstallerWizard extends StatefulWidget {
   final String? initialRoute;
 
   static Widget create(BuildContext context, String? initialRoute) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => _UbuntuDesktopInstallerModel(client),
       child: _UbuntuDesktopInstallerWizard(initialRoute: initialRoute),
@@ -185,7 +184,7 @@ class _UbuntuDesktopInstallerWizardState
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<_UbuntuDesktopInstallerModel>(context);
-    final service = Provider.of<DiskStorageService>(context, listen: false);
+    final service = getService<DiskStorageService>();
 
     return Wizard(
       initialRoute: widget.initialRoute ?? Routes.initial,

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -17,7 +17,7 @@ class AllocateDiskSpacePage extends StatefulWidget {
   }) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<DiskStorageService>(context, listen: false);
+    final service = getService<DiskStorageService>();
     return ChangeNotifierProvider(
       create: (_) => AllocateDiskSpaceModel(service),
       child: const AllocateDiskSpacePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -8,6 +8,7 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'choose_security_key_model.dart';
 
 part 'choose_security_key_widgets.dart';
@@ -25,7 +26,7 @@ class ChooseSecurityKeyPage extends StatefulWidget {
 
   /// Creates an instance with [ChooseSecurityKeyModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => ChooseSecurityKeyModel(client),
       child: const ChooseSecurityKeyPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -17,8 +17,8 @@ class ConnectToInternetPage extends StatefulWidget {
   const ConnectToInternetPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final udev = Provider.of<UdevService>(context, listen: false);
-    final service = Provider.of<NetworkService>(context, listen: false);
+    final udev = getService<UdevService>();
+    final service = getService<NetworkService>();
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => ConnectToInternetModel(service)),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'installation_complete_model.dart';
 
 const _kAvatarBorder = Color(0xFFe5e5e5);
@@ -14,7 +15,7 @@ class InstallationCompletePage extends StatelessWidget {
   const InstallationCompletePage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return Provider(
       create: (_) => InstallationCompleteModel(client),
       child: const InstallationCompletePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -17,8 +17,8 @@ class InstallationSlidesPage extends StatefulWidget {
 
   /// Creates a [InstallationSlidesPage] with [InstallationSlidesModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
-    final journal = Provider.of<JournalService>(context, listen: false);
+    final client = getService<SubiquityClient>();
+    final journal = getService<JournalService>();
     return ChangeNotifierProvider(
       create: (_) => InstallationSlidesModel(client, journal),
       child: const InstallationSlidesPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -20,8 +20,8 @@ class InstallationTypePage extends StatefulWidget {
 
   /// Creates a [InstallationTypePage] with [InstallationTypeModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
-    final service = Provider.of<DiskStorageService>(context, listen: false);
+    final client = getService<SubiquityClient>();
+    final service = getService<DiskStorageService>();
     return ChangeNotifierProvider(
       create: (context) => InstallationTypeModel(client, service),
       child: const InstallationTypePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:ubuntu_wizard/constants.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'keyboard_layout_detector.dart';
 import 'keyboard_layout_widgets.dart';
 
@@ -13,7 +13,7 @@ const _kDialogHeightFactor = 0.15;
 /// and confirm keys. Returns the result with a keyboard layout and variant
 /// codes or null if canceled.
 Future<StepResult?> showDetectKeyboardLayoutDialog(BuildContext context) async {
-  final client = Provider.of<SubiquityClient>(context, listen: false);
+  final client = getService<SubiquityClient>();
 
   return showDialog<StepResult?>(
     context: context,

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -19,8 +19,8 @@ class KeyboardLayoutPage extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => KeyboardLayoutModel(
-        client: Provider.of<SubiquityClient>(context, listen: false),
-        keyboardService: Provider.of<KeyboardService>(context, listen: false),
+        client: getService<SubiquityClient>(),
+        keyboardService: getService<KeyboardService>(),
       ),
       child: const KeyboardLayoutPage(),
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -17,7 +17,7 @@ class SelectGuidedStoragePage extends StatefulWidget {
 
   /// Creates a [SelectGuidedStoragePage] with [SelectGuidedStorageModel].
   static Widget create(BuildContext context) {
-    final service = Provider.of<DiskStorageService>(context, listen: false);
+    final service = getService<DiskStorageService>();
     return ChangeNotifierProvider(
       create: (context) => SelectGuidedStorageModel(service),
       child: const SelectGuidedStoragePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -7,11 +7,12 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'turn_off_bitlocker_model.dart';
 
 class TurnOffBitLockerPage extends StatelessWidget {
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return Provider(
       create: (_) => TurnOffBitLockerModel(client),
       child: TurnOffBitLockerPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'turn_off_rst_model.dart';
 
 class TurnOffRSTPage extends StatelessWidget {
@@ -15,7 +16,7 @@ class TurnOffRSTPage extends StatelessWidget {
   }) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return Provider(
       create: (_) => TurnOffRSTModel(client),
       child: const TurnOffRSTPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -5,6 +5,7 @@ import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'updates_other_software_model.dart';
 
 class UpdatesOtherSoftwarePage extends StatefulWidget {
@@ -15,7 +16,7 @@ class UpdatesOtherSoftwarePage extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => UpdateOtherSoftwareModel(
-          client: Provider.of<SubiquityClient>(context, listen: false),
+          client: getService<SubiquityClient>(),
           installationMode: InstallationMode.normal),
       child: UpdatesOtherSoftwarePage(),
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'welcome_model.dart';
 
 class WelcomePage extends StatefulWidget {
@@ -14,7 +15,7 @@ class WelcomePage extends StatefulWidget {
   }) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => WelcomeModel(client),
       child: const WelcomePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -8,6 +8,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 import '../../l10n.dart';
+import '../../services.dart';
 import 'who_are_you_model.dart';
 
 part 'who_are_you_widgets.dart';
@@ -24,7 +25,7 @@ class WhoAreYouPage extends StatefulWidget {
 
   /// Creates an instance with [WhoAreYouModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => WhoAreYouModel(client),
       child: const WhoAreYouPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -18,8 +18,8 @@ class WriteChangesToDiskPage extends StatefulWidget {
   }) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
-    final service = Provider.of<DiskStorageService>(context, listen: false);
+    final client = getService<SubiquityClient>();
+    final service = getService<DiskStorageService>();
     return ChangeNotifierProvider(
       create: (_) => WriteChangesToDiskModel(client, service),
       child: const WriteChangesToDiskPage(),

--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -1,3 +1,5 @@
+export 'package:ubuntu_wizard/services.dart';
+
 export 'services/disk_storage_service.dart' hide log;
 export 'services/journal_service.dart';
 export 'services/keyboard_service.dart';

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_dialogs_test.dart
@@ -21,12 +21,11 @@ void main() {
     final testDisk = Disk(freeForPartitions: 1000000);
     final model = buildModel(selectedDisk: testDisk);
 
+    registerMockService<UdevService>(MockUdevService());
+
     await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider<AllocateDiskSpaceModel>.value(value: model),
-          Provider<UdevService>(create: (_) => MockUdevService()),
-        ],
+      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
+        value: model,
         child: tester.buildApp((_) => AllocateDiskSpacePage()),
       ),
     );
@@ -83,12 +82,11 @@ void main() {
     ]);
     final model = buildModel(selectedDisk: testDisk);
 
+    registerMockService<UdevService>(MockUdevService());
+
     await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider<AllocateDiskSpaceModel>.value(value: model),
-          Provider<UdevService>(create: (_) => MockUdevService()),
-        ],
+      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
+        value: model,
         child: tester.buildApp((_) => AllocateDiskSpacePage()),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space_page_test.dart
@@ -100,12 +100,10 @@ void main() {
     final sdb = MockUdevDeviceInfo();
     when(sdb.fullName).thenReturn('SDB');
     when(udev.bySysname('sdb')).thenReturn(sdb);
+    registerMockService<UdevService>(udev);
 
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<AllocateDiskSpaceModel>.value(value: model),
-        Provider<UdevService>.value(value: udev),
-      ],
+    return ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
+      value: model,
       child: const AllocateDiskSpacePage(),
     );
   }
@@ -364,14 +362,10 @@ void main() {
     when(storage.getStorage()).thenAnswer((_) async => testDisks);
     when(storage.needRoot).thenReturn(false);
     when(storage.needBoot).thenReturn(false);
+    registerMockService<DiskStorageService>(storage);
+    registerMockService<UdevService>(MockUdevService());
 
-    await tester.pumpWidget(MultiProvider(
-      providers: [
-        Provider<DiskStorageService>.value(value: storage),
-        Provider<UdevService>(create: (_) => MockUdevService()),
-      ],
-      child: tester.buildApp(AllocateDiskSpacePage.create),
-    ));
+    await tester.pumpWidget(tester.buildApp(AllocateDiskSpacePage.create));
 
     final page = find.byType(AllocateDiskSpacePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/choose_security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key_page_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/choose_security_key/choose_security_key_model.dart';
 import 'package:ubuntu_desktop_installer/pages/choose_security_key/choose_security_key_page.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
 import 'choose_security_key_page_test.mocks.dart';
@@ -96,13 +97,9 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.identity()).thenAnswer((_) async => IdentityData());
+    registerMockService<SubiquityClient>(client);
 
-    await tester.pumpWidget(
-      Provider<SubiquityClient>.value(
-        value: client,
-        child: tester.buildApp(ChooseSecurityKeyPage.create),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(ChooseSecurityKeyPage.create));
 
     final page = find.byType(ChooseSecurityKeyPage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet_page_test.dart
@@ -202,20 +202,10 @@ void main() {
     when(service.wiredDevices).thenReturn([]);
     when(service.wirelessDevices).thenReturn([]);
     when(service.wirelessEnabled).thenReturn(true);
+    registerMockService<NetworkService>(service);
+    registerMockService<UdevService>(MockUdevService());
 
-    await tester.pumpWidget(
-      tester.buildApp(
-        (_) => MultiProvider(
-          providers: [
-            Provider<NetworkService>.value(value: service),
-            Provider<UdevService>(create: (_) => MockUdevService()),
-          ],
-          child: const Wizard(
-            routes: {'/': WizardRoute(builder: ConnectToInternetPage.create)},
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(ConnectToInternetPage.create));
 
     final page = find.byType(ConnectToInternetPage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete_page_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_model.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_page.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
 import 'installation_complete_page_test.mocks.dart';
@@ -44,12 +45,9 @@ void main() {
   });
 
   testWidgets('creates a model', (tester) async {
-    await tester.pumpWidget(
-      Provider<SubiquityClient>(
-        create: (_) => MockSubiquityClient(),
-        child: tester.buildApp(InstallationCompletePage.create),
-      ),
-    );
+    registerMockService<SubiquityClient>(MockSubiquityClient());
+
+    await tester.pumpWidget(tester.buildApp(InstallationCompletePage.create));
 
     final page = find.byType(InstallationCompletePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type_page_test.dart
@@ -109,16 +109,10 @@ void main() {
     when(client.isOpen).thenAnswer((_) async => true);
     when(client.getGuidedStorage())
         .thenAnswer((_) async => GuidedStorageResponse());
+    registerMockService<SubiquityClient>(client);
+    registerMockService<DiskStorageService>(DiskStorageService(client));
 
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          Provider<SubiquityClient>.value(value: client),
-          Provider(create: (_) => DiskStorageService(client)),
-        ],
-        child: tester.buildApp(InstallationTypePage.create),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(InstallationTypePage.create));
 
     final page = find.byType(InstallationTypePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_dialogs_test.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_widgets.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
 import 'widget_tester_extensions.dart';
@@ -31,16 +31,14 @@ void main() {
     when(client.getKeyboardStep('60')).thenAnswer((_) async {
       return KeyboardStep.result(layout: 'd', variant: 'e');
     });
+    registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(
-      Provider<SubiquityClient>.value(
-        value: client,
-        child: tester.buildApp(
-          (_) => DetectKeyboardLayoutView(
-            pressKey: null,
-            keyPresent: null,
-            onKeyPress: (_) {},
-          ),
+      tester.buildApp(
+        (_) => DetectKeyboardLayoutView(
+          pressKey: null,
+          keyPresent: null,
+          onKeyPress: (_) {},
         ),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout_page_test.dart
@@ -45,11 +45,10 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(any))
         .thenAnswer((_) async => KeyboardStep.pressKey());
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<KeyboardLayoutModel>.value(value: model),
-        Provider<SubiquityClient>.value(value: client),
-      ],
+    registerMockService<SubiquityClient>(client);
+
+    return ChangeNotifierProvider<KeyboardLayoutModel>.value(
+      value: model,
       child: KeyboardLayoutPage(),
     );
   }
@@ -162,19 +161,13 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.keyboard()).thenAnswer((_) async => KeyboardSetup());
+    registerMockService<SubiquityClient>(client);
 
     final service = MockKeyboardService();
     when(service.layouts).thenReturn([]);
+    registerMockService<KeyboardService>(service);
 
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          Provider<KeyboardService>.value(value: service),
-          Provider<SubiquityClient>.value(value: client),
-        ],
-        child: tester.buildApp(KeyboardLayoutPage.create),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(KeyboardLayoutPage.create));
 
     final page = find.byType(KeyboardLayoutPage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage_page_test.dart
@@ -103,13 +103,9 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final service = MockDiskStorageService();
     when(service.getGuidedStorage()).thenAnswer((_) async => testStorages);
+    registerMockService<DiskStorageService>(service);
 
-    await tester.pumpWidget(
-      Provider<DiskStorageService>.value(
-        value: service,
-        child: tester.buildApp(SelectGuidedStoragePage.create),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(SelectGuidedStoragePage.create));
 
     final page = find.byType(SelectGuidedStoragePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software_page_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_model.dart';
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_page.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -27,12 +28,10 @@ void main() {
   }
 
   Widget buildPage(UpdateOtherSoftwareModel model) {
-    final client = MockSubiquityClient();
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<UpdateOtherSoftwareModel>.value(value: model),
-        Provider<SubiquityClient>.value(value: client),
-      ],
+    registerMockService<SubiquityClient>(MockSubiquityClient());
+
+    return ChangeNotifierProvider<UpdateOtherSoftwareModel>.value(
+      value: model,
       child: UpdatesOtherSoftwarePage(),
     );
   }
@@ -110,12 +109,9 @@ void main() {
   });
 
   testWidgets('creates a model', (tester) async {
-    await tester.pumpWidget(
-      Provider<SubiquityClient>(
-        create: (_) => MockSubiquityClient(),
-        child: tester.buildApp(UpdatesOtherSoftwarePage.create),
-      ),
-    );
+    registerMockService<SubiquityClient>(MockSubiquityClient());
+
+    await tester.pumpWidget(tester.buildApp(UpdatesOtherSoftwarePage.create));
 
     final page = find.byType(UpdatesOtherSoftwarePage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/widget_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_test.dart
@@ -29,13 +29,14 @@ void main() {
     when(client.getGuidedStorage())
         .thenAnswer((_) async => GuidedStorageResponse());
     when(client.isOpen).thenAnswer((_) async => true);
+    registerMockService<SubiquityClient>(client);
+    registerMockService<DiskStorageService>(DiskStorageService(client));
+    registerMockService<KeyboardService>(KeyboardService());
 
-    await tester.pumpWidget(MultiProvider(providers: [
-      Provider<SubiquityClient>.value(value: client),
-      Provider(create: (context) => DiskStorageService(client)),
-      Provider(create: (context) => KeyboardService()),
-      ChangeNotifierProvider(create: (_) => Settings(MockGSettings())),
-    ], child: UbuntuDesktopInstallerApp()));
+    await tester.pumpWidget(ChangeNotifierProvider(
+      create: (_) => Settings(MockGSettings()),
+      child: UbuntuDesktopInstallerApp(),
+    ));
     await tester.pumpAndSettle();
     expect(find.byType(WelcomePage), findsOneWidget);
   });

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk_page_test.dart
@@ -79,12 +79,10 @@ void main() {
     when(sdb.modelName).thenReturn('SDB');
     when(sdb.vendorName).thenReturn('ATA');
     when(udev.bySysname('sdb')).thenReturn(sdb);
+    registerMockService<UdevService>(udev);
 
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<WriteChangesToDiskModel>.value(value: model),
-        Provider<UdevService>.value(value: udev),
-      ],
+    return ChangeNotifierProvider<WriteChangesToDiskModel>.value(
+      value: model,
       child: const WriteChangesToDiskPage(),
     );
   }
@@ -118,20 +116,13 @@ void main() {
 
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
+    registerMockService<SubiquityClient>(client);
+
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => testDisks);
+    registerMockService<DiskStorageService>(service);
 
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          Provider<SubiquityClient>.value(value: client),
-          Provider<DiskStorageService>.value(
-            value: service,
-          ),
-        ],
-        child: tester.buildApp(WriteChangesToDiskPage.create),
-      ),
-    );
+    await tester.pumpWidget(tester.buildApp(WriteChangesToDiskPage.create));
 
     final page = find.byType(WriteChangesToDiskPage);
     expect(page, findsOneWidget);

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -7,12 +7,12 @@ import 'package:flutter/widgets.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
-import 'package:provider/single_child_widget.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
+import 'services.dart';
 import 'settings.dart';
 import 'utils.dart';
 
@@ -39,7 +39,6 @@ Future<void> runWizardApp(
   SubiquityInitCallback? onInitSubiquity,
   List<String>? serverArgs,
   Map<String, String>? serverEnvironment,
-  List<SingleChildWidget>? providers,
 }) async {
   final interfaceSettings = GSettings('org.gnome.desktop.interface');
 
@@ -71,6 +70,8 @@ Future<void> runWizardApp(
     ]);
   });
 
+  registerServiceInstance(subiquityClient);
+
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();
 
@@ -85,12 +86,8 @@ Future<void> runWizardApp(
       log.error('Unhandled exception', error.exception, error.stack);
     };
 
-    return runApp(MultiProvider(
-      providers: [
-        Provider.value(value: subiquityClient),
-        ChangeNotifierProvider(create: (_) => Settings(interfaceSettings)),
-        ...?providers,
-      ],
+    return runApp(ChangeNotifierProvider(
+      create: (_) => Settings(interfaceSettings),
       child: app,
     ));
   }, (error, stack) => log.error('Unhandled exception', error, stack));

--- a/packages/ubuntu_wizard/lib/services.dart
+++ b/packages/ubuntu_wizard/lib/services.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:get_it/get_it.dart';
+import 'package:meta/meta.dart';
+
+final _locator = GetIt.instance;
+
+/// Locates and returns an injected service.
+T getService<T extends Object>() => _locator<T>();
+
+/// Registers a service with the locator.
+void registerService<T extends Object>(
+  T Function() create, {
+  FutureOr<void> Function(T service)? dispose,
+}) {
+  assert(!_locator.isRegistered<T>());
+  _locator.registerLazySingleton<T>(create, dispose: dispose);
+}
+
+/// Registers a service instance with the locator.
+void registerServiceInstance<T extends Object>(T service) {
+  assert(!_locator.isRegistered<T>());
+  _locator.registerSingleton<T>(service);
+}
+
+/// Register a mock service for testing purposes.
+///
+/// Unlike [registerService] and [registerServiceInstance], this method does
+/// allow re-registration of the same service type.
+///
+/// Under normal circumstances, services should not be replaced or re-registered
+/// during the lifetime of the application. Testing is an exception to this rule
+/// because each test must be allowed to inject a unique mock service instance.
+@visibleForTesting
+void registerMockService<T extends Object>(T mock) {
+  unregisterMockService<T>();
+  registerServiceInstance<T>(mock);
+}
+
+/// Unregisters a mock service for testing purposes.
+@visibleForTesting
+void unregisterMockService<T extends Object>() {
+  if (_locator.isRegistered<T>()) _locator.unregister<T>();
+}

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   form_field_validator: ^1.1.0
+  get_it: ^7.2.0
   gsettings: ^0.2.0
   intl: ^0.17.0
   password_strength: ^0.2.0

--- a/packages/ubuntu_wizard/test/service_test.dart
+++ b/packages/ubuntu_wizard/test/service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wizard/services.dart';
+
+class Service extends Object {}
+
+void main() {
+  tearDown(() => unregisterMockService<Service>());
+
+  test('unknown service', () {
+    expect(() => getService<Service>(), throwsAssertionError);
+  });
+
+  test('re-register service', () {
+    expect(() => registerService(() => Service()), isNot(throwsAssertionError));
+    expect(() => registerService(() => Service()), throwsAssertionError);
+  });
+
+  test('re-register service instance', () {
+    final service = Service();
+    expect(() => registerServiceInstance(service), isNot(throwsAssertionError));
+    expect(() => registerServiceInstance(service), throwsAssertionError);
+  });
+
+  test('locate service', () {
+    registerService(() => Service());
+    expect(getService<Service>(), isNotNull);
+  });
+
+  test('locate service instance', () {
+    final service = Service();
+    registerServiceInstance(service);
+    expect(getService<Service>(), equals(service));
+  });
+
+  test('mock service', () {
+    final mock1 = Service();
+    final mock2 = Service();
+    expect(mock1, isNot(equals(mock2)));
+
+    registerMockService(mock1);
+    expect(getService<Service>(), equals(mock1));
+
+    registerMockService(mock2);
+    expect(getService<Service>(), equals(mock2));
+  });
+}

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -4,16 +4,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/app.dart';
+import 'package:ubuntu_wizard/services.dart';
 
 import 'wizard_app_test.mocks.dart';
 
 @GenerateMocks([IOSink])
 void main() {
+  tearDown(() => unregisterMockService<SubiquityClient>());
+
   testWidgets('initializes subiquity', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
@@ -35,23 +37,20 @@ void main() {
     verify(client.setVariant(Variant.DESKTOP)).called(1);
   });
 
-  testWidgets('provides the client', (tester) async {
+  testWidgets('registers the client', (tester) async {
+    final client = MockSubiquityClient();
     final server = MockSubiquityServer();
     when(server.start(any,
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer((_) async => '');
 
     await runWizardApp(
-      Container(key: ValueKey('app')),
-      subiquityClient: MockSubiquityClient(),
+      SizedBox(),
+      subiquityClient: client,
       subiquityServer: server,
     );
 
-    final app = find.byKey(ValueKey('app'));
-    expect(app, findsOneWidget);
-
-    final context = tester.element(app);
-    expect(context.read<SubiquityClient>(), isNotNull);
+    expect(getService<SubiquityClient>(), equals(client));
   });
 
   testWidgets('parse command-line arguments', (tester) async {

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -3,6 +3,7 @@ import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
@@ -24,7 +25,7 @@ class AdvancedSetupPage extends StatefulWidget {
 
   /// Creates an instance with [AdvancedSetupModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => AdvancedSetupModel(client),
       child: const AdvancedSetupPage(),

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
@@ -17,7 +18,7 @@ class ConfigurationUIPage extends StatefulWidget {
 
   /// Creates an instance with [ConfigurationUIModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => ConfigurationUIModel(client),
       child: const ConfigurationUIPage(),

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -4,6 +4,7 @@ import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -24,7 +25,7 @@ class ProfileSetupPage extends StatefulWidget {
 
   /// Creates an instance with [ProfileSetupModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => ProfileSetupModel(client),
       child: const ProfileSetupPage(),

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
@@ -14,7 +15,7 @@ class SelectLanguagePage extends StatefulWidget {
   }) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => SelectLanguageModel(client),
       child: const SelectLanguagePage(),

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
@@ -22,7 +23,7 @@ class SetupCompletePage extends StatefulWidget {
 
   /// Creates an instance with [SetupCompleteModel].
   static Widget create(BuildContext context) {
-    final client = Provider.of<SubiquityClient>(context, listen: false);
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
       create: (_) => SetupCompleteModel(client),
       child: const SetupCompletePage(),

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_html: ^2.1.1
+  get_it: ^7.2.0
   provider: ^6.0.0
   scroll_to_index: ^2.0.0
   ubuntu_localizations:

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/advanced_setup/advanced_setup_model.dart';
@@ -138,19 +139,17 @@ void main() {
     final client = MockSubiquityClient();
     when(client.wslConfigurationBase())
         .thenAnswer((_) async => WSLConfigurationBase());
+    registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,
-      home: Provider<SubiquityClient>.value(
-        value: client,
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: AdvancedSetupPage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: AdvancedSetupPage.create,
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     ));
 

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/app.dart';
@@ -16,16 +17,14 @@ void main() {
   testWidgets('create an app instance', (tester) async {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en');
+    registerMockService<SubiquityClient>(client);
 
     final settings = MockSettings();
     when(settings.locale).thenReturn(Locale('en'));
     when(settings.theme).thenReturn(ThemeMode.light);
 
-    await tester.pumpWidget(MultiProvider(
-      providers: [
-        ChangeNotifierProvider<Settings>.value(value: settings),
-        Provider<SubiquityClient>.value(value: client),
-      ],
+    await tester.pumpWidget(ChangeNotifierProvider<Settings>.value(
+      value: settings,
       child: const UbuntuWslSetupApp(variant: Variant.WSL_SETUP),
     ));
 

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/configuration_ui/configuration_ui_model.dart';
@@ -167,19 +168,17 @@ void main() {
     final client = MockSubiquityClient();
     when(client.wslConfigurationAdvanced())
         .thenAnswer((_) async => WSLConfigurationAdvanced());
+    registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,
-      home: Provider<SubiquityClient>.value(
-        value: client,
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: ConfigurationUIPage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: ConfigurationUIPage.create,
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     ));
 

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -7,6 +7,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
@@ -229,19 +230,17 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.identity()).thenAnswer((_) async => IdentityData());
+    registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,
-      home: Provider<SubiquityClient>.value(
-        value: client,
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: ProfileSetupPage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: ProfileSetupPage.create,
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     ));
 

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
@@ -96,17 +97,15 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en_US.UTF-8');
+    registerMockService<SubiquityClient>(client);
 
     final settings = MockSettings();
     when(settings.locale).thenReturn(Locale('en_US'));
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,
-      home: MultiProvider(
-        providers: [
-          ChangeNotifierProvider<Settings>.value(value: settings),
-          Provider<SubiquityClient>.value(value: client),
-        ],
+      home: ChangeNotifierProvider<Settings>.value(
+        value: settings,
         child: Wizard(
           routes: {
             '/': WizardRoute(

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/setup_complete/setup_complete_model.dart';
@@ -75,19 +76,17 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.identity()).thenAnswer((_) async => IdentityData());
+    registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,
-      home: Provider<SubiquityClient>.value(
-        value: client,
-        child: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: SetupCompletePage.create,
-              onNext: (settings) => '/',
-            ),
-          },
-        ),
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: SetupCompletePage.create,
+            onNext: (settings) => '/',
+          ),
+        },
       ),
     ));
 


### PR DESCRIPTION
Compared to Provider, GetIt offers a simpler mechanism for injecting
services, and faster O(1) service locator. Registering and accessing
services is more intuitive and is not coupled with the widget / build
context tree.