### PR TITLE
ValidatedFormField: expose focus node

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -30,6 +30,9 @@ class ValidatedFormField extends StatefulWidget {
   /// Whether this input field should focus itself automatically.
   final bool autofocus;
 
+  /// Defines the keyboard focus for the [TextField].
+  final FocusNode? focusNode;
+
   /// The label above the [TextField]
   final String? labelText;
 
@@ -69,6 +72,7 @@ class ValidatedFormField extends StatefulWidget {
     this.onChanged,
     FieldValidator<String?>? validator,
     this.autofocus = false,
+    this.focusNode,
     this.labelText,
     this.helperText,
     this.obscureText = false,
@@ -87,13 +91,14 @@ class ValidatedFormField extends StatefulWidget {
 
 class _ValidatedFormFieldState extends State<ValidatedFormField> {
   late final TextEditingController _controller;
-  final _focusNode = FocusNode();
+  late final FocusNode _focusNode;
 
   @override
   void initState() {
     super.initState();
     _controller =
         widget.controller ?? TextEditingController(text: widget.initialValue);
+    _focusNode = widget.focusNode ?? FocusNode();
   }
 
   @override

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -201,8 +201,26 @@ void main() {
     expect(find.text('not equal'), findsNothing);
   });
 
-  testWidgets('focus', (tester) async {
+  testWidgets('focus node is attached', (tester) async {
     final focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(focusNode: focusNode),
+        ),
+      ),
+    );
+
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).focusNode,
+      equals(focusNode),
+    );
+  });
+
+  testWidgets('initial autofocus', (tester) async {
+    final focusNode = FocusNode();
+    expect(focusNode.hasFocus, isFalse);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -213,9 +231,62 @@ void main() {
     );
 
     expect(focusNode.hasFocus, isTrue);
-    expect(
-      tester.widget<TextField>(find.byType(TextField)).focusNode,
-      equals(focusNode),
+  });
+
+  testWidgets('no initial autofocus', (tester) async {
+    final focusNode = FocusNode();
+    expect(focusNode.hasFocus, isFalse);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(autofocus: false, focusNode: focusNode),
+        ),
+      ),
     );
+
+    expect(focusNode.hasFocus, isFalse);
+  });
+
+  testWidgets('initial focus with focus node', (tester) async {
+    final focusNode = FocusNode();
+    expect(focusNode.hasFocus, isFalse);
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isFalse); // the focus node is not yet attached
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(focusNode: focusNode),
+        ),
+      ),
+    );
+
+    expect(focusNode.hasFocus, isTrue);
+  });
+
+  testWidgets('request focus and unfocus', (tester) async {
+    final focusNode = FocusNode();
+    expect(focusNode.hasFocus, isFalse);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(focusNode: focusNode),
+        ),
+      ),
+    );
+
+    expect(focusNode.hasFocus, isFalse);
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    focusNode.unfocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isFalse);
   });
 }

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -200,4 +200,22 @@ void main() {
     expect(find.text('equal'), findsOneWidget);
     expect(find.text('not equal'), findsNothing);
   });
+
+  testWidgets('focus', (tester) async {
+    final focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(autofocus: true, focusNode: focusNode),
+        ),
+      ),
+    );
+
+    expect(focusNode.hasFocus, isTrue);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).focusNode,
+      equals(focusNode),
+    );
+  });
 }


### PR DESCRIPTION
Hidden Wi-Fi entries require more fine-grained control over focus. The
existing `autofocus` property is not enough because keyboard focus must
be dynamically requested and removed whenever the hidden Wi-Fi view is
expanded or collapsed.