### PR TITLE
Fix analysis issues

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -34,9 +34,9 @@ void runInstallerApp(List<String> args, {FlavorData? flavor}) {
 
   registerService(() => DiskStorageService(subiquityClient));
   registerService(() => JournalService(journalUnit));
-  registerService(() => KeyboardService());
-  registerService(() => NetworkService());
-  registerService(() => UdevService());
+  registerService(KeyboardService.new);
+  registerService(NetworkService.new);
+  registerService(UdevService.new);
 
   final appStatus = ValueNotifier(AppStatus.loading);
 

--- a/packages/ubuntu_wizard/test/service_test.dart
+++ b/packages/ubuntu_wizard/test/service_test.dart
@@ -11,8 +11,8 @@ void main() {
   });
 
   test('re-register service', () {
-    expect(() => registerService(() => Service()), isNot(throwsAssertionError));
-    expect(() => registerService(() => Service()), throwsAssertionError);
+    expect(() => registerService(Service.new), isNot(throwsAssertionError));
+    expect(() => registerService(Service.new), throwsAssertionError);
   });
 
   test('re-register service instance', () {
@@ -22,7 +22,7 @@ void main() {
   });
 
   test('locate service', () {
-    registerService(() => Service());
+    registerService(Service.new);
     expect(getService<Service>(), isNotNull);
   });
 


### PR DESCRIPTION
These slipped in because the Dart SDK version and the service locator
changes were done in different branches around the same time.