### PR TITLE
WhoAreYouPage: ignore the "show password" button for tab focus traversal

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
@@ -135,12 +135,16 @@ class _PasswordFormField extends StatelessWidget {
         final model = Provider.of<WhoAreYouModel>(context, listen: false);
         model.password = value;
       },
-      suffixIcon: IconButton(
-        onPressed: () {
-          final model = Provider.of<WhoAreYouModel>(context, listen: false);
-          model.obscureText = !model.obscureText;
-        },
-        icon: Icon(obscureText ? YaruIcons.hide : YaruIcons.view),
+      suffixIcon: Focus(
+        canRequestFocus: false,
+        descendantsAreFocusable: false,
+        child: IconButton(
+          onPressed: () {
+            final model = Provider.of<WhoAreYouModel>(context, listen: false);
+            model.obscureText = !model.obscureText;
+          },
+          icon: Icon(obscureText ? YaruIcons.hide : YaruIcons.view),
+        ),
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -96,6 +97,30 @@ void main() {
     verify(model.password = 'ubuntu').called(1);
     await tester.enterText(textField.last, 'ubuntu');
     verify(model.confirmedPassword = 'ubuntu').called(1);
+  });
+
+  testWidgets('password tab focus', (tester) async {
+    final model = buildModel(password: 'passwd', confirmedPassword: 'confirm');
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final passwordField = find.widgetWithText(TextField, 'passwd');
+    expect(passwordField, findsOneWidget);
+
+    await tester.tap(passwordField);
+
+    final passwordFocus = tester.widget<TextField>(passwordField).focusNode;
+    expect(passwordFocus?.hasFocus, isTrue);
+
+    final confirmPasswordField = find.widgetWithText(TextField, 'confirm');
+    expect(confirmPasswordField, findsOneWidget);
+
+    final confirmPasswordFocus =
+        tester.widget<TextField>(confirmPasswordField).focusNode;
+    expect(confirmPasswordFocus?.hasFocus, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+    expect(confirmPasswordFocus?.hasFocus, isTrue);
   });
 
   testWidgets('empty password', (tester) async {


### PR DESCRIPTION
Split off from #541.

Before, it took 2 steps to move keyboard focus from the password field to the password confirmation field. Now, the icon button is skipped so that the password fields are adjacent nodes in the focus chain. The downside is that there's no way to access the "show password" button via keyboard...