### PR TITLE
ValidatedFormField: test initial value rebuild

### DIFF
--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -78,6 +78,29 @@ void main() {
     expect(find.text('ubuntu'), findsOneWidget);
   });
 
+  testWidgets('rebuild initial value', (tester) async {
+    final controller = TextEditingController(text: 'initial');
+
+    Widget buildValidatedFormField({String? initialValue}) {
+      return MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            controller: controller,
+            initialValue: initialValue,
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildValidatedFormField(initialValue: null));
+    expect(find.widgetWithText(TextField, 'initial'), findsOneWidget);
+    expect(controller.text, equals('initial'));
+
+    await tester.pumpWidget(buildValidatedFormField(initialValue: 'rebuild'));
+    expect(find.widgetWithText(TextField, 'rebuild'), findsOneWidget);
+    expect(controller.text, equals('rebuild'));
+  });
+
   testWidgets('fixed field width', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
This is an additional test cherry-picked from #541 for a currently untested use case that regressed during the refactoring.