### PR TITLE
ValidatedFormField: don't dispose an external/unowned focus node

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -91,27 +91,31 @@ class ValidatedFormField extends StatefulWidget {
 
 class _ValidatedFormFieldState extends State<ValidatedFormField> {
   late final TextEditingController _controller;
-  late final FocusNode _focusNode;
+  FocusNode? _focusNode;
+
+  FocusNode get focusNode => widget.focusNode ?? _focusNode!;
 
   @override
   void initState() {
     super.initState();
     _controller =
         widget.controller ?? TextEditingController(text: widget.initialValue);
-    _focusNode = widget.focusNode ?? FocusNode();
+    if (widget.focusNode == null) {
+      _focusNode ??= FocusNode();
+    }
   }
 
   @override
   void dispose() {
     _controller.dispose();
-    _focusNode.dispose();
+    _focusNode?.dispose();
     super.dispose();
   }
 
   @override
   void didUpdateWidget(ValidatedFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!_focusNode.hasFocus &&
+    if (!focusNode.hasFocus &&
         widget.initialValue != null &&
         oldWidget.initialValue != widget.initialValue) {
       scheduleMicrotask(() {
@@ -126,7 +130,7 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
       autofocus: widget.autofocus,
       autovalidateMode: widget.autovalidateMode,
       controller: _controller,
-      focusNode: _focusNode,
+      focusNode: focusNode,
       onChanged: widget.onChanged,
       validator: widget.validator,
       obscureText: widget.obscureText,

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -289,4 +289,23 @@ void main() {
     await tester.pump();
     expect(focusNode.hasFocus, isFalse);
   });
+
+  testWidgets('focus node disposal', (tester) async {
+    final externalFocusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(focusNode: externalFocusNode),
+        ),
+      ),
+    );
+    await tester.pumpWidget(MaterialApp());
+    await tester.pumpAndSettle();
+
+    await expectLater(
+      () => externalFocusNode.addListener(() {}),
+      isNot(throwsAssertionError),
+    );
+  });
 }


### PR DESCRIPTION
Split off from #541. When a focus node is passed from the outside, the form field does not own it and therefore must not dispose it either because the call site might still use it (a hidden Wi-Fi network name field).