### PR TITLE
ValidatedFormField: only set default spacing if appropriate

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -77,12 +77,13 @@ class ValidatedFormField extends StatefulWidget {
     this.helperText,
     this.obscureText = false,
     this.successWidget,
-    this.spacing = _kIconSpacing,
+    double? spacing,
     this.fieldWidth,
     this.autovalidateMode = AutovalidateMode.onUserInteraction,
     this.enabled = true,
     this.suffixIcon,
   })  : validator = validator ?? _NoValidator(),
+        spacing = spacing ?? (successWidget != null ? _kIconSpacing : null),
         super(key: key);
 
   @override

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -112,6 +112,24 @@ void main() {
     expect(tester.getRect(field).width, equals(123 - 45));
   });
 
+  testWidgets('default spacing', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SizedBox(
+              width: 123,
+              child: ValidatedFormField(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final field = find.byType(TextFormField);
+    expect(tester.getRect(field).width, equals(123));
+  });
+
   testWidgets('icon baseline alignment', (tester) async {
     Widget buildWithHelperText(String? helperText) {
       return MaterialApp(


### PR DESCRIPTION
If there's no "success widget" at all, don't inject empty spacing at the
end because it would cause misalignment in a column together with other
widgets.