### PR TITLE
Promote the show/hide password button to ValidatedFormField

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
@@ -44,7 +44,6 @@ class WhoAreYouModel extends ChangeNotifier {
       _confirmedPassword,
       _loginStrategy,
       _productName,
-      _obscureText,
     ]).addListener(notifyListeners);
   }
 
@@ -57,7 +56,6 @@ class WhoAreYouModel extends ChangeNotifier {
   final _loginStrategy =
       ValueNotifier<LoginStrategy>(LoginStrategy.requirePassword);
   final _productName = ValueNotifier<String>('');
-  final _obscureText = ValueNotifier<bool>(true);
 
   /// The current real name.
   String get realName => _realName.value ?? '';
@@ -125,10 +123,6 @@ class WhoAreYouModel extends ChangeNotifier {
     log.info('Saved identity: ${identity.description}');
     return _client.setIdentity(identity);
   }
-
-  /// Defines if the password text is obscured
-  bool get obscureText => _obscureText.value;
-  set obscureText(bool value) => _obscureText.value = value;
 }
 
 /// The DMI product name file. Available for testing.

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -5,7 +5,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
@@ -119,13 +119,11 @@ class _PasswordFormField extends StatelessWidget {
         context.select<WhoAreYouModel, String>((model) => model.password);
     final passwordStrength = context.select<WhoAreYouModel, PasswordStrength>(
         (model) => model.passwordStrength);
-    final obscureText =
-        context.select<WhoAreYouModel, bool>((model) => model.obscureText);
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
       labelText: lang.whoAreYouPagePasswordLabel,
-      obscureText: obscureText,
+      obscureText: true,
       successWidget: PasswordStrengthLabel(strength: passwordStrength),
       initialValue: password,
       validator: RequiredValidator(
@@ -135,13 +133,6 @@ class _PasswordFormField extends StatelessWidget {
         final model = Provider.of<WhoAreYouModel>(context, listen: false);
         model.password = value;
       },
-      suffixIcon: IconButton(
-        onPressed: () {
-          final model = Provider.of<WhoAreYouModel>(context, listen: false);
-          model.obscureText = !model.obscureText;
-        },
-        icon: Icon(obscureText ? YaruIcons.hide : YaruIcons.view),
-      ),
     );
   }
 }
@@ -161,11 +152,9 @@ class _ConfirmPasswordFormField extends StatelessWidget {
         context.select<WhoAreYouModel, String>((model) => model.password);
     final confirmedPassword = context
         .select<WhoAreYouModel, String>((model) => model.confirmedPassword);
-    final obscureText =
-        context.select<WhoAreYouModel, bool>((model) => model.obscureText);
 
     return ValidatedFormField(
-      obscureText: obscureText,
+      obscureText: true,
       fieldWidth: fieldWidth,
       labelText: lang.whoAreYouPageConfirmPasswordLabel,
       successWidget: password.isNotEmpty ? const SuccessIcon() : null,

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
@@ -38,7 +38,6 @@ void main() {
     expect(model.username, equals(identity.username));
     expect(model.password, isEmpty); // not loaded
     expect(model.hostname, equals(identity.hostname));
-    expect(model.obscureText, true);
   });
 
   test('empty username and hostname', () async {

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
@@ -6,7 +6,6 @@ import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_model.dart';
 import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_page.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 import '../widget_tester_extensions.dart';
 import 'who_are_you_page_test.mocks.dart';
@@ -22,7 +21,6 @@ void main() {
     String? confirmedPassword,
     PasswordStrength? passwordStrength,
     LoginStrategy? loginStrategy,
-    bool? obscureText,
   }) {
     final model = MockWhoAreYouModel();
     when(model.isValid).thenReturn(isValid ?? false);
@@ -35,7 +33,6 @@ void main() {
         .thenReturn(passwordStrength ?? PasswordStrength.weak);
     when(model.loginStrategy)
         .thenReturn(loginStrategy ?? LoginStrategy.autoLogin);
-    when(model.obscureText).thenReturn(obscureText ?? false);
     return model;
   }
 
@@ -217,17 +214,6 @@ void main() {
 
   //   verify(model.loginStrategy = LoginStrategy.requirePassword).called(1);
   // });
-
-  testWidgets('obscure text', (tester) async {
-    final model = buildModel(obscureText: true);
-    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
-
-    final obscureTextButton = find.widgetWithIcon(IconButton, YaruIcons.hide);
-    expect(obscureTextButton, findsOneWidget);
-
-    await tester.tap(obscureTextButton);
-    verify(model.obscureText = false).called(1);
-  });
 
   testWidgets('save identity', (tester) async {
     final model = buildModel(isValid: true);

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
@@ -83,14 +83,6 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
-  bool get obscureText =>
-      (super.noSuchMethod(Invocation.getter(#obscureText), returnValue: false)
-          as bool);
-  @override
-  set obscureText(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#obscureText, value),
-          returnValueForMissingStub: null);
-  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);

--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 // The spacing between the form field and the success icon.
 const _kIconSpacing = 10.0;
@@ -39,9 +40,10 @@ class ValidatedFormField extends StatefulWidget {
   /// The label below the [TextField]
   final String? helperText;
 
-  /// This boolean is forwarded to the [TextField] to decide
-  /// if the digits should be obscured.
-  final bool obscureText;
+  /// If specified, this boolean is forwarded to the [TextField] to decide
+  /// if the digits should be obscured, and a show/hide icon button is shown
+  /// to toggle between the obscured and non-obscured state.
+  final bool? obscureText;
 
   /// The specific widget shown right to the [TextField] if the
   /// input value is valid.
@@ -75,7 +77,7 @@ class ValidatedFormField extends StatefulWidget {
     this.focusNode,
     this.labelText,
     this.helperText,
-    this.obscureText = false,
+    this.obscureText,
     this.successWidget,
     double? spacing,
     this.fieldWidth,
@@ -87,13 +89,16 @@ class ValidatedFormField extends StatefulWidget {
         super(key: key);
 
   @override
-  State<ValidatedFormField> createState() => _ValidatedFormFieldState();
+  State<ValidatedFormField> createState() => ValidatedFormFieldState();
 }
 
-class _ValidatedFormFieldState extends State<ValidatedFormField> {
+@visibleForTesting
+class ValidatedFormFieldState extends State<ValidatedFormField> {
   late final TextEditingController _controller;
   FocusNode? _focusNode;
+  bool? _obscureText;
 
+  bool get obscureText => _obscureText ?? false;
   FocusNode get focusNode => widget.focusNode ?? _focusNode!;
 
   @override
@@ -104,6 +109,7 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
     if (widget.focusNode == null) {
       _focusNode ??= FocusNode();
     }
+    _obscureText = widget.obscureText;
   }
 
   @override
@@ -134,12 +140,20 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
       focusNode: focusNode,
       onChanged: widget.onChanged,
       validator: widget.validator,
-      obscureText: widget.obscureText,
+      obscureText: obscureText,
       enabled: widget.enabled,
       decoration: InputDecoration(
         labelText: widget.labelText,
         helperText: widget.helperText,
-        suffixIcon: widget.suffixIcon,
+        suffixIcon: widget.suffixIcon != null
+            ? widget.suffixIcon
+            : widget.obscureText == true && _controller.text.isNotEmpty
+                ? IconButton(
+                    onPressed: () =>
+                        setState(() => _obscureText = !obscureText),
+                    icon: Icon(obscureText ? YaruIcons.hide : YaruIcons.view),
+                  )
+                : null,
       ),
     );
 

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
       path: packages/ubuntu_logger
   wizard_router: ^0.7.0
   yaru: ^0.2.0
+  yaru_icons: ^0.1.2
 
 dev_dependencies:
   build_runner: ^2.0.5

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -4,6 +4,7 @@ import 'package:form_field_validator/form_field_validator.dart';
 
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 void main() {
   testWidgets('input validation', (tester) async {
@@ -217,6 +218,83 @@ void main() {
 
     expect(find.text('equal'), findsOneWidget);
     expect(find.text('not equal'), findsNothing);
+  });
+
+  testWidgets('toggle obscure text', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            obscureText: true,
+            initialValue: 'password',
+          ),
+        ),
+      ),
+    );
+
+    final viewButton = find.widgetWithIcon(IconButton, YaruIcons.view);
+    final hideButton = find.widgetWithIcon(IconButton, YaruIcons.hide);
+
+    final state =
+        tester.state<ValidatedFormFieldState>(find.byType(ValidatedFormField));
+    expect(state.obscureText, isTrue);
+    expect(viewButton, findsNothing);
+    expect(hideButton, findsOneWidget);
+
+    await tester.tap(hideButton);
+    await tester.pump();
+    expect(state.obscureText, isFalse);
+    expect(viewButton, findsOneWidget);
+    expect(hideButton, findsNothing);
+  });
+
+  testWidgets('no obscure text', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            obscureText: false,
+            initialValue: 'password',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.widgetWithIcon(IconButton, YaruIcons.view), findsNothing);
+    expect(find.widgetWithIcon(IconButton, YaruIcons.hide), findsNothing);
+  });
+
+  testWidgets('empty obscure text', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            obscureText: true,
+            initialValue: '',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.widgetWithIcon(IconButton, YaruIcons.view), findsNothing);
+    expect(find.widgetWithIcon(IconButton, YaruIcons.hide), findsNothing);
+  });
+
+  testWidgets('override obscure button', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            obscureText: true,
+            initialValue: 'password',
+            suffixIcon: SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.widgetWithIcon(IconButton, YaruIcons.view), findsNothing);
+    expect(find.widgetWithIcon(IconButton, YaruIcons.hide), findsNothing);
   });
 
   testWidgets('focus node is attached', (tester) async {


### PR DESCRIPTION
This PR promotes the show/hide password logic from the _Who are you?_ -page to the `ValidatedFormField` widget.

Currently, only the password field in the _Who are you?_ -page has a show/hide password button. All other password and passphrase fields, including the WSL profile password, active directory password, and encryption passphrase should also have the same "show password" button. Now, simply specifying `obscureText: true` is enough to enable the built-in show/hide password functionality.

Ref: #347