### PR TITLE
Allow re-registration of services for integration tests

### DIFF
--- a/packages/ubuntu_wizard/lib/services.dart
+++ b/packages/ubuntu_wizard/lib/services.dart
@@ -13,13 +13,13 @@ void registerService<T extends Object>(
   T Function() create, {
   FutureOr<void> Function(T service)? dispose,
 }) {
-  assert(!_locator.isRegistered<T>());
+  if (_locator.isRegistered<T>()) _locator.unregister<T>();
   _locator.registerLazySingleton<T>(create, dispose: dispose);
 }
 
 /// Registers a service instance with the locator.
 void registerServiceInstance<T extends Object>(T service) {
-  assert(!_locator.isRegistered<T>());
+  if (_locator.isRegistered<T>()) _locator.unregister<T>();
   _locator.registerSingleton<T>(service);
 }
 

--- a/packages/ubuntu_wizard/test/service_test.dart
+++ b/packages/ubuntu_wizard/test/service_test.dart
@@ -11,14 +11,16 @@ void main() {
   });
 
   test('re-register service', () {
-    expect(() => registerService(Service.new), isNot(throwsAssertionError));
-    expect(() => registerService(Service.new), throwsAssertionError);
+    expect(() => registerService(Service.new), isNot(throwsA(anything)));
+    // re-registration required in integration tests
+    expect(() => registerService(Service.new), isNot(throwsA(anything)));
   });
 
   test('re-register service instance', () {
     final service = Service();
-    expect(() => registerServiceInstance(service), isNot(throwsAssertionError));
-    expect(() => registerServiceInstance(service), throwsAssertionError);
+    expect(() => registerServiceInstance(service), isNot(throwsA(anything)));
+    // re-registration required in integration tests
+    expect(() => registerServiceInstance(service), isNot(throwsA(anything)));
   });
 
   test('locate service', () {


### PR DESCRIPTION
Under normal circumstances, services are never supposed to be registered
multiple times.

Integration tests are an exception because they are run by calling the
app entry point multiple times in the same process. Since each app
instance registers its services, the re-registration assertion would
fail.

Relax the rules by removing the unimportant assert that was originally
added there for sanity checking the expected behavior described above,
without taking integration tests into account.