### PR TITLE
WSL setup: mark "filesystem" configured

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -38,6 +38,7 @@ screens, yet allowing user to overwrite any of those during setup.
     subiquityServer: SubiquityServer.wsl(),
     onInitSubiquity: (client) {
       client.variant().then((value) => variant.value = value);
+      client.markConfigured(['filesystem']);
     },
     serverArgs: serverArgs,
     serverEnvironment: {


### PR DESCRIPTION
This is necessary since canonical/subiquity#1146.