### PR TITLE
Integration tests: update resolving of the .subiquity directory

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -49,11 +49,11 @@ abstract class SubiquityServer {
 
   // Returns the location of the local subiquity submodule.
   Future<String> _getSubiquityPath() async {
-    return _subiquityPath ??= await _findSubiquityPath();
+    return _subiquityPath ??= await findSubiquityPath();
   }
 
   // Finds local subiquity relative to the `subiquity_client` Dart package.
-  Future<String> _findSubiquityPath() async {
+  static Future<String> findSubiquityPath() async {
     Object? error;
     final config = await findPackageConfig(
       Directory.current,


### PR DESCRIPTION
Integration tests were accidentally broken by #610. The tests are no
longer correctly locating the .subiquity directory. Exposing the lookup
logic in SubiquityServer allows integration tests to locate .subiquity
for verifying output files.