### PR TITLE
Installer: increase the visual density of lists and tables

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -106,8 +106,12 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
   static FlavorData get defaultFlavor {
     return FlavorData(
       name: 'Ubuntu',
-      theme: yaruLight,
-      darkTheme: yaruDark,
+      theme: yaruLight.copyWith(
+        listTileTheme: ListTileThemeData(dense: true),
+      ),
+      darkTheme: yaruDark.copyWith(
+        listTileTheme: ListTileThemeData(dense: true),
+      ),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -272,6 +272,7 @@ class PartitionTable extends StatelessWidget {
                 showCheckboxColumn: false,
                 headingTextStyle: Theme.of(context).textTheme.subtitle2,
                 dataTextStyle: Theme.of(context).textTheme.bodyText2,
+                dataRowHeight: defaultTileHeight(context),
                 columns: <DataColumn>[
                   DataColumn(label: Text(lang.diskHeadersDevice)),
                   DataColumn(label: Text(lang.diskHeadersType)),

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -133,6 +133,7 @@ void main() {
 
     verify(model.selectStorage(0)).called(1);
 
+    await tester.ensureVisible(find.text(testDisks.last.path!));
     await tester.tap(find.text(testDisks.last.path!));
     await tester.pumpAndSettle();
 

--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -26,8 +26,12 @@ class UbuntuWslSetupApp extends StatelessWidget {
         setWindowTitle(lang.windowTitle);
         return lang.appTitle;
       },
-      theme: yaruLight,
-      darkTheme: yaruDark,
+      theme: yaruLight.copyWith(
+        listTileTheme: ListTileThemeData(dense: true),
+      ),
+      darkTheme: yaruDark.copyWith(
+        listTileTheme: ListTileThemeData(dense: true),
+      ),
       themeMode: Settings.of(context).theme,
       debugShowCheckedModeBanner: false,
       localizationsDelegates: localizationsDelegates,


### PR DESCRIPTION
As suggested in [Material design guidelines](https://material.io/design/layout/applying-density.html#usage):

> By making more content available on-screen, increasing the density of lists, tables, and long forms makes information easier to scan, view, and compare.

## Desktop Installer

| Before | After |
|---|---|
| ![Screenshot from 2022-02-01 10-50-07](https://user-images.githubusercontent.com/140617/151948587-1d28e85c-3140-4777-a8d4-73a9fe38dc5c.png) | ![Screenshot from 2022-02-01 10-50-26](https://user-images.githubusercontent.com/140617/151948586-07231f9d-68c6-471d-a1e1-1746fa0ac0fa.png) |
| ![Screenshot from 2022-02-01 10-50-38](https://user-images.githubusercontent.com/140617/151948584-a380e220-a5a5-4833-8590-f3711e3b5d19.png) | ![Screenshot from 2022-02-01 10-50-46](https://user-images.githubusercontent.com/140617/151948579-baf44fb3-9c9b-4a72-81b1-f9ff2e8ae2ca.png) |
|  ![Screenshot from 2022-02-01 10-51-12](https://user-images.githubusercontent.com/140617/151948577-a46b3027-1e52-4bf2-a541-25c12be99412.png) | ![Screenshot from 2022-02-01 10-51-19](https://user-images.githubusercontent.com/140617/151948575-92c5ed2f-695b-4b26-8acd-7404f4cc3240.png) |
| ![Screenshot from 2022-02-01 10-51-53](https://user-images.githubusercontent.com/140617/151948573-1488bb32-0151-4266-8394-7c28dc897417.png) | ![Screenshot from 2022-02-01 10-51-59](https://user-images.githubusercontent.com/140617/151948571-7b5d440b-39d7-42d7-9f66-de52a42f7d8d.png) |

## WSL Setup

| Before | After |
|---|---|
| ![Screenshot from 2022-02-01 10-54-43](https://user-images.githubusercontent.com/140617/151948569-5a897a36-0a55-4fe5-8e03-602fb544cee6.png) | ![Screenshot from 2022-02-01 10-55-04](https://user-images.githubusercontent.com/140617/151948566-edb5e2d9-f8d3-411c-830b-0a1589a3b6d6.png) |

Close: #546