### PR TITLE
ChooseYourLook: use yaru_widgets.dart for images

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -32,7 +32,7 @@ class ChooseYourLookPage extends StatelessWidget {
                   children: [
                     SizedBox(
                       width: width / 3,
-                      child: ImageTile(
+                      child: YaruImageTile(
                         path: 'assets/Theme_thumbnails-Light.png',
                         currentlySelected:
                             Theme.of(context).brightness == Brightness.light,
@@ -55,7 +55,7 @@ class ChooseYourLookPage extends StatelessWidget {
                   children: [
                     SizedBox(
                       width: width / 3,
-                      child: ImageTile(
+                      child: YaruImageTile(
                         path: 'assets/Theme_thumbnails-Dark.png',
                         currentlySelected:
                             Theme.of(context).brightness == Brightness.dark,

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -14,6 +14,7 @@ class ChooseYourLookPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     final width = MediaQuery.of(context).size.width;
+    final settings = Settings.of(context, listen: false);
     return WizardPage(
       header: Text(lang.chooseYourLookPageHeader),
       actions: <WizardAction>[
@@ -36,7 +37,6 @@ class ChooseYourLookPage extends StatelessWidget {
                         currentlySelected:
                             Theme.of(context).brightness == Brightness.light,
                         onTap: () {
-                          final settings = Settings.of(context, listen: false);
                           settings.applyTheme(Brightness.light);
                         },
                       ),
@@ -60,7 +60,6 @@ class ChooseYourLookPage extends StatelessWidget {
                         currentlySelected:
                             Theme.of(context).brightness == Brightness.dark,
                         onTap: () {
-                          final settings = Settings.of(context, listen: false);
                           settings.applyTheme(Brightness.dark);
                         },
                       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 
@@ -12,6 +13,7 @@ class ChooseYourLookPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
+    final width = MediaQuery.of(context).size.width;
     return WizardPage(
       header: Text(lang.chooseYourLookPageHeader),
       actions: <WizardAction>[
@@ -19,39 +21,59 @@ class ChooseYourLookPage extends StatelessWidget {
         WizardAction.next(context),
       ],
       title: Text(lang.chooseYourLookPageTitle),
-      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 150),
       content: Center(
-        child: ListView(
-            shrinkWrap: true,
-            scrollDirection: Axis.horizontal,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: OptionCard(
-                  image: FlavorImage.asset('assets/Theme_thumbnails-Light.png'),
-                  title: Text(lang.chooseYourLookPageLightSetting),
-                  body: Text(lang.chooseYourLookPageLightBodyText),
-                  selected: Theme.of(context).brightness == Brightness.light,
-                  onSelected: () {
-                    final settings = Settings.of(context, listen: false);
-                    settings.applyTheme(Brightness.light);
-                  },
+        child: SingleChildScrollView(
+          child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Column(
+                  children: [
+                    SizedBox(
+                      width: width / 3,
+                      child: ImageTile(
+                        path: 'assets/Theme_thumbnails-Light.png',
+                        currentlySelected:
+                            Theme.of(context).brightness == Brightness.light,
+                        onTap: () {
+                          final settings = Settings.of(context, listen: false);
+                          settings.applyTheme(Brightness.light);
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text(lang.chooseYourLookPageLightSetting,
+                          style: Theme.of(context).textTheme.headline6),
+                    )
+                  ],
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: OptionCard(
-                  image: FlavorImage.asset('assets/Theme_thumbnails-Dark.png'),
-                  title: Text(lang.chooseYourLookPageDarkSetting),
-                  body: Text(lang.chooseYourLookPageDarkBodyText),
-                  selected: Theme.of(context).brightness == Brightness.dark,
-                  onSelected: () {
-                    final settings = Settings.of(context, listen: false);
-                    settings.applyTheme(Brightness.dark);
-                  },
+                SizedBox(
+                  width: width / 20,
                 ),
-              )
-            ]),
+                Column(
+                  children: [
+                    SizedBox(
+                      width: width / 3,
+                      child: ImageTile(
+                        path: 'assets/Theme_thumbnails-Dark.png',
+                        currentlySelected:
+                            Theme.of(context).brightness == Brightness.dark,
+                        onTap: () {
+                          final settings = Settings.of(context, listen: false);
+                          settings.applyTheme(Brightness.dark);
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text(lang.chooseYourLookPageDarkSetting,
+                          style: Theme.of(context).textTheme.headline6),
+                    )
+                  ],
+                )
+              ]),
+        ),
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -23,57 +23,72 @@ class ChooseYourLookPage extends StatelessWidget {
       ],
       title: Text(lang.chooseYourLookPageTitle),
       content: Center(
-        child: SingleChildScrollView(
-          child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Column(
-                  children: [
-                    SizedBox(
-                      width: width / 3,
-                      child: YaruImageTile(
-                        path: 'assets/Theme_thumbnails-Light.png',
-                        currentlySelected:
-                            Theme.of(context).brightness == Brightness.light,
-                        onTap: () {
-                          settings.applyTheme(Brightness.light);
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Text(lang.chooseYourLookPageLightSetting,
-                          style: Theme.of(context).textTheme.headline6),
-                    )
-                  ],
-                ),
-                SizedBox(
-                  width: width / 20,
-                ),
-                Column(
-                  children: [
-                    SizedBox(
-                      width: width / 3,
-                      child: YaruImageTile(
-                        path: 'assets/Theme_thumbnails-Dark.png',
-                        currentlySelected:
-                            Theme.of(context).brightness == Brightness.dark,
-                        onTap: () {
-                          settings.applyTheme(Brightness.dark);
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Text(lang.chooseYourLookPageDarkSetting,
-                          style: Theme.of(context).textTheme.headline6),
-                    )
-                  ],
-                )
-              ]),
-        ),
+        child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _ThemeOptionCard(
+                width: width / 3,
+                assetName: 'assets/Theme_thumbnails-Light.png',
+                selected: Theme.of(context).brightness == Brightness.light,
+                onTap: () {
+                  settings.applyTheme(Brightness.light);
+                },
+                preferenceName: lang.chooseYourLookPageLightSetting,
+              ),
+              SizedBox(
+                width: width / 20,
+              ),
+              _ThemeOptionCard(
+                width: width / 3,
+                assetName: 'assets/Theme_thumbnails-Dark.png',
+                selected: Theme.of(context).brightness == Brightness.dark,
+                onTap: () {
+                  settings.applyTheme(Brightness.dark);
+                },
+                preferenceName: lang.chooseYourLookPageDarkSetting,
+              ),
+            ]),
       ),
+    );
+  }
+}
+
+class _ThemeOptionCard extends StatelessWidget {
+  const _ThemeOptionCard({
+    Key? key,
+    required this.width,
+    required this.assetName,
+    required this.selected,
+    required this.onTap,
+    required this.preferenceName,
+  }) : super(key: key);
+
+  final double width;
+  final String assetName;
+  final bool selected;
+  final Function() onTap;
+  final String preferenceName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: width,
+          child: YaruSelectableContainer(
+            child: FlavorImage.asset(assetName),
+            selected: selected,
+            onTap: onTap,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(preferenceName,
+              style: Theme.of(context).textTheme.headline6),
+        )
+      ],
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   xml: ^5.3.1
   yaru: ^0.2.0
   yaru_icons: ^0.1.2
-  yaru_widgets: 1.0.0
+  yaru_widgets: 1.0.1
 
 dev_dependencies:
   build_runner: ^2.0.5

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   xml: ^5.3.1
   yaru: ^0.2.0
   yaru_icons: ^0.1.2
+  yaru_widgets: 1.0.0
 
 dev_dependencies:
   build_runner: ^2.0.5

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   xml: ^5.3.1
   yaru: ^0.2.0
   yaru_icons: ^0.1.2
-  yaru_widgets: 1.0.1
+  yaru_widgets: 1.0.2
 
 dev_dependencies:
   build_runner: ^2.0.5

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/choose_your_look_page.dart';
 import 'package:ubuntu_wizard/settings.dart';
-import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../widget_tester_extensions.dart';
 import 'choose_your_look_page_test.mocks.dart';
@@ -28,17 +28,17 @@ void main() {
       ),
     );
 
-    final lightOptionCard = find.widgetWithText(
-      OptionCard,
-      lang(tester).chooseYourLookPageLightSetting,
+    final lightOptionCard = find.widgetWithImage(
+      YaruSelectableContainer,
+      AssetImage('assets/Theme_thumbnails-Light.png'),
     );
     expect(lightOptionCard, findsOneWidget);
     await tester.tap(lightOptionCard);
     verify(settings.applyTheme(Brightness.light));
 
-    final darkOptionCard = find.widgetWithText(
-      OptionCard,
-      lang(tester).chooseYourLookPageDarkSetting,
+    final darkOptionCard = find.widgetWithImage(
+      YaruSelectableContainer,
+      AssetImage('assets/Theme_thumbnails-Dark.png'),
     );
     expect(darkOptionCard, findsOneWidget);
     await tester.tap(darkOptionCard);

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/choose_your_look_page.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -13,11 +12,6 @@ import 'choose_your_look_page_test.mocks.dart';
 
 @GenerateMocks([Settings])
 void main() {
-  AppLocalizations lang(WidgetTester tester) {
-    final page = tester.element(find.byType(ChooseYourLookPage));
-    return AppLocalizations.of(page);
-  }
-
   testWidgets('ChooseYourLookPage applies theme', (tester) async {
     final Settings settings = MockSettings();
 


### PR DESCRIPTION
| Before | After with 1/3 of the screenwidth | After with 1/4 of the screen width |
| --- | --- | --- |
|![grafik](https://user-images.githubusercontent.com/15329494/152045547-f13adfd3-f9ae-4208-bc9a-65ef5e94d67b.png) | ![grafik](https://user-images.githubusercontent.com/15329494/152044814-1bc6d350-f971-4799-b064-7631ee2f3898.png) | ![grafik](https://user-images.githubusercontent.com/15329494/152044909-b47500cf-b7ef-4333-a687-073d49781c6a.png) |

CC @jpnurmi @elioqoshi please have a look concerning the size of the images
~~I convert the PR to draft because I realized that I use the Yaru* suffix for all widgets in yaru_widgets.dart ... except the ImageTile~~ (fixed)

Closes #483 