### PR TITLE
Fix analysis issues for the latest Flutter stable 2.10

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services/geo_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/geo_service.dart
@@ -297,6 +297,7 @@ class Geodata implements GeoSource {
     } on XmlException {
       log.error('Invalid GeoIP data: $xml');
     }
+    return null;
   }
 
   @override
@@ -395,6 +396,7 @@ class GeoIP {
         log.error('GeoIP lookup error: ${e.message}');
       }
     }
+    return null;
   }
 
   /// Cancels an ongoing lookup.

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_model_test.dart
@@ -10,7 +10,7 @@ void main() async {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });
@@ -28,7 +28,7 @@ void main() async {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -17,7 +17,7 @@ void main() async {
   final methodChannel = MethodChannel('ubuntu_wizard');
 
   setUp(() {
-    methodChannel.setMockMethodCallHandler((_) {});
+    methodChannel.setMockMethodCallHandler((_) async {});
   });
 
   test('client status query loop', () async {
@@ -115,7 +115,7 @@ void main() async {
 
   test('reboot', () async {
     var windowClosed = false;
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });
@@ -131,7 +131,7 @@ void main() async {
 
   test('non-closable window', () async {
     final windowClosable = StreamController<bool>.broadcast();
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('setWindowClosable'));
       windowClosable.add(call.arguments[0] as bool);
     });

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
@@ -44,7 +44,7 @@ void main() {
                   case Option.installUbuntu:
                     return Routes.keyboardLayout;
                   default:
-                    break;
+                    return null;
                 }
               },
             ),

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_model_test.dart
@@ -10,7 +10,7 @@ void main() async {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_model_test.dart
@@ -11,7 +11,7 @@ void main() async {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });

--- a/packages/ubuntu_wizard/test/system_shutdown_test.dart
+++ b/packages/ubuntu_wizard/test/system_shutdown_test.dart
@@ -19,7 +19,7 @@ void main() async {
   Future<void> testSystemShutdown(SystemShutdownTester tester) async {
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
@@ -53,7 +53,7 @@ void main() {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -216,7 +216,7 @@ void main() {
 
     var urlLaunched = false;
     final methodChannel = MethodChannel('plugins.flutter.io/url_launcher');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('launch'));
       expect(call.arguments['url'], equals('https://aka.ms/wslusers'));
       urlLaunched = true;

--- a/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_model_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     var windowClosed = false;
     final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) {
+    methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('closeWindow'));
       windowClosed = true;
     });


### PR DESCRIPTION
body_might_complete_normally_nullable:

    info • This function has a nullable return type of 'Future<dynamic>?', but ends without returning a value