### PR TITLE
Fix slow subiquity startup

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -35,11 +35,8 @@ class SubiquityClient {
   Future<bool> get isOpen => _isOpen.future;
 
   void open(String socketPath) {
-    // Use a relative path to avoid hitting AF_UNIX path length limit because
-    // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
-    // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
-    log.info('Opening socket $socketPath');
-    _client = HttpUnixClient(p.relative(socketPath));
+    log.info('Opening socket ${p.absolute(socketPath)}');
+    _client = HttpUnixClient(socketPath);
     _isOpen.complete(true);
   }
 

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -40,7 +40,10 @@ abstract class SubiquityServer {
   // to be resolved based on the location of the `subiquity_client` package.
   Future<String> _getSocketPath(ServerMode mode) async {
     if (mode == ServerMode.DRY_RUN) {
-      return p.join(await _getSubiquityPath(), '.subiquity/socket');
+      // Use a relative path to avoid hitting AF_UNIX path length limit because
+      // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
+      // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
+      return p.relative(p.join(await _getSubiquityPath(), '.subiquity/socket'));
     }
     return '/run/subiquity/socket';
   }


### PR DESCRIPTION
The socket path that was passed to `_waitSubiquity()` was absolute, not
relative. If the socket was deep enough in the directory hierarchy, the
connect would refuse to establish which caused a 10s startup delay (full
10x wait loop). Yet, it would connect fine after the wait loop because
at that point, a relative path was used.