### PR TITLE
ProductInfoExtractor: parse product version

### DIFF
--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -53,7 +53,7 @@ void main() {
       MockDiskStorageService(),
       MockTelemetryService(),
     );
-    expect(model.productInfo, isNotEmpty);
+    expect(model.productInfo.name, isNotEmpty);
   });
 
   test('save talks to telemetry service', () async {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -9,6 +9,7 @@ import 'package:ubuntu_desktop_installer/pages/installation_type/installation_ty
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_test/utils.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../widget_tester_extensions.dart';
@@ -20,7 +21,7 @@ void main() {
     InstallationType? installationType,
     AdvancedFeature? advancedFeature,
     bool? encryption,
-    String? productInfo,
+    ProductInfo? productInfo,
     String? existingOS,
   }) {
     final model = MockInstallationTypeModel();
@@ -29,7 +30,7 @@ void main() {
     when(model.advancedFeature)
         .thenReturn(advancedFeature ?? AdvancedFeature.none);
     when(model.encryption).thenReturn(encryption ?? false);
-    when(model.productInfo).thenReturn(productInfo ?? '');
+    when(model.productInfo).thenReturn(productInfo ?? ProductInfo(name: ''));
     when(model.existingOS).thenReturn(existingOS);
     return model;
   }
@@ -54,7 +55,7 @@ void main() {
 
   testWidgets('alongside', (tester) async {
     final model = buildModel(
-      productInfo: 'Ubuntu 21.10',
+      productInfo: ProductInfo(name: 'Ubuntu 21.10'),
       existingOS: 'Ubuntu 18.04 LTS',
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -2,12 +2,13 @@
 // in ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i3;
-import 'dart:ui' as _i4;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_model.dart'
-    as _i2;
+    as _i3;
+import 'package:ubuntu_wizard/utils.dart' as _i2;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -17,33 +18,35 @@ import 'package:ubuntu_desktop_installer/pages/installation_type/installation_ty
 // ignore_for_file: prefer_const_constructors
 // ignore_for_file: unnecessary_parenthesis
 
+class _FakeProductInfo_0 extends _i1.Fake implements _i2.ProductInfo {}
+
 /// A class which mocks [InstallationTypeModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockInstallationTypeModel extends _i1.Mock
-    implements _i2.InstallationTypeModel {
+    implements _i3.InstallationTypeModel {
   MockInstallationTypeModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  String get productInfo =>
-      (super.noSuchMethod(Invocation.getter(#productInfo), returnValue: '')
-          as String);
+  _i2.ProductInfo get productInfo =>
+      (super.noSuchMethod(Invocation.getter(#productInfo),
+          returnValue: _FakeProductInfo_0()) as _i2.ProductInfo);
   @override
-  _i2.InstallationType get installationType =>
+  _i3.InstallationType get installationType =>
       (super.noSuchMethod(Invocation.getter(#installationType),
-          returnValue: _i2.InstallationType.erase) as _i2.InstallationType);
+          returnValue: _i3.InstallationType.erase) as _i3.InstallationType);
   @override
-  set installationType(_i2.InstallationType? type) =>
+  set installationType(_i3.InstallationType? type) =>
       super.noSuchMethod(Invocation.setter(#installationType, type),
           returnValueForMissingStub: null);
   @override
-  _i2.AdvancedFeature get advancedFeature =>
+  _i3.AdvancedFeature get advancedFeature =>
       (super.noSuchMethod(Invocation.getter(#advancedFeature),
-          returnValue: _i2.AdvancedFeature.none) as _i2.AdvancedFeature);
+          returnValue: _i3.AdvancedFeature.none) as _i3.AdvancedFeature);
   @override
-  set advancedFeature(_i2.AdvancedFeature? feature) =>
+  set advancedFeature(_i3.AdvancedFeature? feature) =>
       super.noSuchMethod(Invocation.setter(#advancedFeature, feature),
           returnValueForMissingStub: null);
   @override
@@ -59,19 +62,19 @@ class MockInstallationTypeModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
+  _i4.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  void addListener(_i4.VoidCallback? listener) =>
+  void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
+  void removeListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override

--- a/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
@@ -50,7 +50,7 @@ class ProductInfoExtractor {
 
   static ProductInfo? _extractIsoInfo(File file) {
     // versions on ISO are stored in format - Ubuntu 20.04.2.0 LTS "Focal Fossa" - Release amd64 (20210209.1)
-    // we want to read system name and version without code name, so we extract them before the second quote
+    // we want to read system name and version without code name, so we extract them before the first quote
     final isoName =
         file.readAsLinesSync().firstWhere((l) => l.trim().isNotEmpty);
     return _parseProductName(isoName.substring(0, isoName.indexOf('"') - 1));

--- a/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
@@ -4,9 +4,20 @@ import 'package:file/local.dart';
 const String isoPath = '/cdrom/.disk/info';
 const String localPath = '/etc/os-release';
 
-/// A class which reads current system version
+/// A class which contains the system name and version
+class ProductInfo {
+  ProductInfo({required this.name, this.version});
+
+  final String name;
+  final String? version;
+
+  @override
+  String toString() => [name, version].whereType<String>().join(' ');
+}
+
+/// A class which reads current system info
 class ProductInfoExtractor {
-  static String _cachedProductInfo = '';
+  static ProductInfo? _cachedProductInfo;
 
   final FileSystem _fileSystem;
 
@@ -19,50 +30,54 @@ class ProductInfoExtractor {
   ///
   /// Returned value is cached.
   /// Optionally cache can be cleared by specifing `shouldResetCache` to `true`
-  String getProductInfo({bool shouldResetCache = false}) {
+  ProductInfo getProductInfo({bool shouldResetCache = false}) {
     if (shouldResetCache) {
-      _cachedProductInfo = '';
+      _cachedProductInfo = null;
     }
 
-    if (_cachedProductInfo.isNotEmpty) {
-      return _cachedProductInfo;
-    }
+    try {
+      _cachedProductInfo ??= _extractIsoInfo(_fileSystem.file(isoPath));
+    } on Exception {}
 
-    if (_fileSystem.file(isoPath).existsSync()) {
-      try {
-        final content = _fileSystem
-            .file(isoPath)
-            .readAsLinesSync()
-            .firstWhere((line) => line.trim().isNotEmpty);
+    try {
+      _cachedProductInfo ??= _extractLocalInfo(_fileSystem.file(localPath));
+    } on Exception {}
 
-        // versions on ISO are stored in format - Ubuntu 20.04.2.0 LTS "Focal Fossa" - Release amd64 (20210209.1)
-        // we want to read system name and version without code name, so we extract it before second quote
-        _cachedProductInfo = content.substring(0, content.indexOf('"') - 1);
-      } on Exception {
-        _extractLocalVersion(localPath);
-      }
-    } else {
-      _extractLocalVersion(localPath);
-    }
+    _cachedProductInfo ??= ProductInfo(name: 'Ubuntu');
 
-    return _cachedProductInfo;
+    return _cachedProductInfo!;
   }
 
-  void _extractLocalVersion(String localPath) {
-    if (_fileSystem.file(localPath).existsSync()) {
-      try {
-        final content = _fileSystem
-            .file(localPath)
-            .readAsLinesSync()
-            .firstWhere((line) => line.startsWith('PRETTY_NAME'));
+  static ProductInfo? _extractIsoInfo(File file) {
+    // versions on ISO are stored in format - Ubuntu 20.04.2.0 LTS "Focal Fossa" - Release amd64 (20210209.1)
+    // we want to read system name and version without code name, so we extract them before the second quote
+    final isoName =
+        file.readAsLinesSync().firstWhere((l) => l.trim().isNotEmpty);
+    return _parseProductName(isoName.substring(0, isoName.indexOf('"') - 1));
+  }
 
-        _cachedProductInfo = content.substring(
-            content.indexOf("\"") + 1, content.lastIndexOf("\""));
-      } on Exception {
-        _cachedProductInfo = 'Ubuntu';
-      }
-    } else {
-      _cachedProductInfo = 'Ubuntu';
-    }
+  static ProductInfo _extractLocalInfo(File file) {
+    // PRETTY_NAME="Ubuntu 20.04.2 LTS"
+    final content = file
+        .readAsLinesSync()
+        .firstWhere((line) => line.startsWith('PRETTY_NAME'));
+    final localName =
+        content.substring(content.indexOf("\"") + 1, content.lastIndexOf("\""));
+    return _parseProductName(localName);
+  }
+
+  static ProductInfo _parseProductName(String info) {
+    // extract an optional version string from the end of "Ubuntu 20.04.2.0 LTS".
+    // the version is expected to be in format "<x>.<y>(.<z>...)" and may be
+    // followed by a textual identifier such as "LTS".
+    final match = RegExp(r'\d+\.\d+(?:\.\d+)*').firstMatch(info);
+
+    // the product name up until the optional version
+    final name = info.substring(0, match?.start ?? info.length);
+
+    return ProductInfo(
+      name: name.trim(),
+      version: match != null ? info.substring(match.start) : null,
+    );
   }
 }

--- a/packages/ubuntu_wizard/test/product_info_extractor_test.dart
+++ b/packages/ubuntu_wizard/test/product_info_extractor_test.dart
@@ -21,10 +21,12 @@ void main() {
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Ubuntu 21.04');
     });
 
     test('should return product info from disk when iso file doesnt exists',
@@ -48,17 +50,21 @@ UBUNTU_CODENAME=hirsute
 
           ''');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Ubuntu 21.04');
     });
 
     test('should return Ubuntu as fallback value', () {
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, isNull);
+      expect(info.toString(), 'Ubuntu');
     });
 
     test('should return product info with LTS when iso file exists', () async {
@@ -68,10 +74,12 @@ UBUNTU_CODENAME=hirsute
         f.writeAsString(
             'Ubuntu 20.04.2.0 LTS "Focal Fossa" - Release amd64 (20210209.1)');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu 20.04.2.0 LTS');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, '20.04.2.0 LTS');
+      expect(info.toString(), 'Ubuntu 20.04.2.0 LTS');
     });
 
     test('should return product info LTS from disk when iso file doesnt exists',
@@ -95,10 +103,12 @@ UBUNTU_CODENAME=focal
 
           ''');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu 20.04.2 LTS');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, '20.04.2 LTS');
+      expect(info.toString(), 'Ubuntu 20.04.2 LTS');
     });
 
     test('should return product info for kubuntu', () async {
@@ -108,10 +118,12 @@ UBUNTU_CODENAME=focal
         f.writeAsString(
             'Kubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Kubuntu 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Kubuntu');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Kubuntu 21.04');
     });
 
     test('should return product info for kubuntu', () async {
@@ -121,10 +133,12 @@ UBUNTU_CODENAME=focal
         f.writeAsString(
             'Kubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Kubuntu 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Kubuntu');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Kubuntu 21.04');
     });
 
     test('should return product info for ubuntu mate', () async {
@@ -134,10 +148,12 @@ UBUNTU_CODENAME=focal
         f.writeAsString(
             'Ubuntu-MATE 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      final info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu-MATE 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu-MATE');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Ubuntu-MATE 21.04');
     });
 
     test('should cache product info', () async {
@@ -147,17 +163,19 @@ UBUNTU_CODENAME=focal
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      var version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      var info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
             'Ubuntu-MATE 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
 
-      version = productInfoExtractor?.getProductInfo();
+      info = productInfoExtractor?.getProductInfo();
 
-      expect(version, 'Ubuntu 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Ubuntu 21.04');
     });
 
     test('should reset cache when paramter is passed', () async {
@@ -167,17 +185,19 @@ UBUNTU_CODENAME=focal
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      var version =
-          productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      var info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
             'Ubuntu-MATE 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
 
-      version = productInfoExtractor?.getProductInfo(shouldResetCache: true);
+      info = productInfoExtractor?.getProductInfo(shouldResetCache: true);
 
-      expect(version, 'Ubuntu-MATE 21.04');
+      expect(info, isNotNull);
+      expect(info!.name, 'Ubuntu-MATE');
+      expect(info.version, '21.04');
+      expect(info.toString(), 'Ubuntu-MATE 21.04');
     });
   });
 }


### PR DESCRIPTION
This is required for #428 for comparing the versions of existing Ubuntu
installations.