### PR TITLE
Bump url_launcher version & fix tests

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   udev:
     path: ../udev
   upower: ^0.6.1
-  url_launcher: ^6.0.3
+  url_launcher: ^6.0.20
   xml: ^5.3.1
   yaru: ^0.2.0
   yaru_icons: ^0.1.2

--- a/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
@@ -254,7 +254,8 @@ void main() {
 
     testWidgets('support', (tester) async {
       final launches = <MethodCall>[];
-      var channel = const MethodChannel('plugins.flutter.io/url_launcher');
+      var channel =
+          const MethodChannel('plugins.flutter.io/url_launcher_linux');
       channel.setMockMethodCallHandler((methodCall) async {
         launches.add(methodCall);
       });

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
@@ -80,7 +80,7 @@ void main() {
     expect(label, findsOneWidget);
 
     final launches = <MethodCall>[];
-    var channel = const MethodChannel('plugins.flutter.io/url_launcher');
+    var channel = const MethodChannel('plugins.flutter.io/url_launcher_linux');
     channel.setMockMethodCallHandler((methodCall) async {
       launches.add(methodCall);
     });

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
       path: packages/ubuntu_logger
   ubuntu_wizard:
     path: ../ubuntu_wizard
-  url_launcher: ^6.0.9
+  url_launcher: ^6.0.20
   yaru: ^0.2.0
 
 dev_dependencies:

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -215,7 +215,8 @@ void main() {
     await tester.pumpWidget(buildApp(tester, buildModel()));
 
     var urlLaunched = false;
-    final methodChannel = MethodChannel('plugins.flutter.io/url_launcher');
+    final methodChannel =
+        MethodChannel('plugins.flutter.io/url_launcher_linux');
     methodChannel.setMockMethodCallHandler((call) async {
       expect(call.method, equals('launch'));
       expect(call.arguments['url'], equals('https://aka.ms/wslusers'));


### PR DESCRIPTION
The plugins in the flutter/plugins repo have been moved away from shared
method channels in native plugins. In other words, the channel names
have been renamed from `url_launcher` to `url_launcher_<platform>`.

See flutter/plugins#4719 and flutter/flutter#94224 for details.