### PR TITLE
CI/generate: swap diff & warnings

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -111,13 +111,13 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         if [ -n "$(git status --porcelain)" ]; then
+          git diff
           for f in $(git ls-files --modified); do
             echo "::warning ::$f may be outdated"
           done
           for f in $(git ls-files --others --exclude-standard); do
             echo "::warning ::$f may be untracked"
           done
-          git diff
           exit 1
         fi
 


### PR DESCRIPTION
When you click the details link for the generate step, GitHub
automatically scrolls all the way to the bottom. Showing the diff
first takes you straight to the summary of warnings, which is the
important part of the detailed output.