### PR TITLE
Use host Python over flutter-snap's Python

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -120,8 +120,11 @@ abstract class SubiquityServer {
       Process.killPid(pid);
     }
 
+    // Use `/usr/bin/python3` over `/snap/flutter/current/usr/bin/python3` when
+    // developing with flutter-snap on the desktop. This ensures that subiquity
+    // has locally installed Python module dependencies available. (#364)
     _serverProcess = await Process.start(
-      'python3',
+      Platform.environment['SNAP_PYTHON'] ?? '/usr/bin/python3',
       subiquityCmd,
       workingDirectory: workingDirectory,
       environment: {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ apps:
       GIO_MODULE_DIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gio/modules
       LIVE_RUN: 1
       LOG_LEVEL: debug
+      SNAP_PYTHON: python3
 
   probert:
     command: bin/probert


### PR DESCRIPTION
Use `/usr/bin/python3` over `/snap/flutter/current/usr/bin/python3`
when developing with flutter-snap on the desktop. This ensures that
subiquity has locally installed Python module dependencies available.

Fix: #364