### PR TITLE
Speed up allocate_disk_space_page_test

### DIFF
--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -287,10 +287,7 @@ void main() {
 
     final continueButton = find.descendant(
       of: find.byType(AlertDialog),
-      matching: find.widgetWithText(
-        OutlinedButton,
-        tester.ulang.continueAction,
-      ),
+      matching: find.text(tester.ulang.continueAction),
     );
     expect(continueButton, findsOneWidget);
 


### PR DESCRIPTION
For some reason, find.widgetWithText() takes awfully long for finding
an OutlinedButton with specific text in the confirmation dialog's
widget tree. Replacing it with find.text() makes the operation almost
instant. This does the job fine in this context because tap events
propagate from the non-interactive text label to the OutlinedButton
ancestor.

Before, ~20s:

    $ flutter test test/allocate_disk_space
    00:20 +40: All tests passed!

After, ~5s:

    $ flutter test test/allocate_disk_space
    00:05 +40: All tests passed!