### PR TITLE
Define SNAP_XXX environment variables for subiquity in dry-run mode

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -126,6 +126,11 @@ abstract class SubiquityServer {
       workingDirectory: workingDirectory,
       environment: {
         ..._pythonPath(subiquityPath),
+        // so subiquity doesn't think it's some other snap (e.g. flutter or vs code)
+        'SNAP': '.',
+        'SNAP_NAME': 'subiquity',
+        'SNAP_REVISION': '',
+        'SNAP_VERSION': '',
         ...?environment,
       },
     ).then((process) {

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -83,13 +83,6 @@ void runInstallerApp(
         options['machine-config'],
       ],
     ],
-    serverEnvironment: {
-      // so subiquity doesn't think it's the installer or flutter snap...
-      'SNAP': '.',
-      'SNAP_NAME': 'subiquity',
-      'SNAP_REVISION': '',
-      'SNAP_VERSION': '',
-    },
     onInitSubiquity: (client) {
       appStatus.value = AppStatus.ready;
       client.setVariant(Variant.DESKTOP);


### PR DESCRIPTION
The environment was only defined when running the UI, not when running
subiquity_client tests. Therefore, running subiquity_client tests from
VS Code snap would fail:

    FAIL: Don't know how to fake GET response to ('v2/snaps/code', {})