### PR TITLE
subiquity_client_test: remove assumption on subiquity's location

### DIFF
--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:test/test.dart';
@@ -23,7 +25,7 @@ void main() {
         '--machine-config',
         'examples/simple.json',
         '--source-catalog',
-        '../test/install-sources.yaml',
+        '${Directory.current.path}/test/install-sources.yaml',
         '--bootloader',
         'uefi',
       ]);


### PR DESCRIPTION
Pass full path to the source catalog so that subiquity can find it
regardless of where subiquity is run from.