### PR TITLE
Flavor-compatible package dependencies

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -37,7 +37,8 @@ dependencies:
   split_view: ^3.2.1
   stdlibc: ^0.1.0
   subiquity_client:
-    path: ../subiquity_client
+    git:
+      url: https://github.com/jpnurmi/subiquity_client.dart.git
   timezone_map:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
@@ -50,7 +51,9 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
   ubuntu_wizard:
-    path: ../ubuntu_wizard
+    git:
+      url: https://github.com/canonical/ubuntu-desktop-installer.git
+      path: packages/ubuntu_wizard
   udev: ^0.0.2
   upower: ^0.7.0
   yaru: ^0.5.0

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   stdlibc: ^0.1.0
   subiquity_client:
     git:
-      url: https://github.com/jpnurmi/subiquity_client.dart.git
+      url: https://github.com/canonical/subiquity_client.dart.git
   timezone_map:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git

--- a/packages/ubuntu_desktop_installer/pubspec_overrides.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  subiquity_client:
+    path: ../subiquity_client
+  ubuntu_wizard:
+    path: ../ubuntu_wizard

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -17,12 +17,16 @@ dependencies:
   mockito: 5.3.2
   path: ^1.8.0
   subiquity_client:
-    path: ../subiquity_client
+    git:
+      url: https://github.com/canonical/ubuntu-desktop-installer.git
+      path: packages/subiquity_client
   ubuntu_localizations: ^0.0.3
   ubuntu_widgets:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
   ubuntu_wizard:
-    path: ../ubuntu_wizard
+    git:
+      url: https://github.com/canonical/ubuntu-desktop-installer.git
+      path: packages/ubuntu_wizard
   yaru_widgets: ^2.0.0

--- a/packages/ubuntu_test/pubspec_overrides.yaml
+++ b/packages/ubuntu_test/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  subiquity_client:
+    path: ../subiquity_client
+  ubuntu_wizard:
+    path: ../ubuntu_wizard

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   safe_change_notifier: ^0.2.0
   subiquity_client:
     git:
-      url: https://github.com/jpnurmi/subiquity_client.dart.git
+      url: https://github.com/canonical/subiquity_client.dart.git
   ubuntu_localizations: ^0.0.3
   ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -22,7 +22,8 @@ dependencies:
   path: ^1.8.0
   safe_change_notifier: ^0.2.0
   subiquity_client:
-    path: ../subiquity_client
+    git:
+      url: https://github.com/jpnurmi/subiquity_client.dart.git
   ubuntu_localizations: ^0.0.3
   ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0

--- a/packages/ubuntu_wizard/pubspec_overrides.yaml
+++ b/packages/ubuntu_wizard/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  subiquity_client:
+    path: ../subiquity_client

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -19,7 +19,9 @@ dependencies:
   safe_change_notifier: ^0.2.0
   scroll_to_index: ^3.0.0
   subiquity_client:
-    path: ../subiquity_client
+    git:
+      url: https://github.com/canonical/ubuntu-desktop-installer.git
+      path: packages/subiquity_client
   ubuntu_localizations: ^0.0.3
   ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0
@@ -28,7 +30,9 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
   ubuntu_wizard:
-    path: ../ubuntu_wizard
+    git:
+      url: https://github.com/canonical/ubuntu-desktop-installer.git
+      path: packages/ubuntu_wizard
   yaru: ^0.5.0
   yaru_icons: ^1.0.0
   yaru_widgets: ^2.0.0

--- a/packages/ubuntu_wsl_setup/pubspec_overrides.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  subiquity_client:
+    path: ../subiquity_client
+  ubuntu_wizard:
+    path: ../ubuntu_wizard


### PR DESCRIPTION
Default to git, override by a local path.

This makes it possible to depend on `ubuntu_wizard` and `ubuntu_desktop_installer` from Git when building installer flavors.

```yaml
dependencies:
  ubuntu_desktop_installer:
    git:
      url: https://github.com/canonical/ubuntu-desktop-installer.git
      path: packages/ubuntu_desktop_installer
      ref: <ref>
```

Without this change, flavors would get errors for local dependencies:
```
 Invalid description in the "ubuntu_desktop_installer" pubspec on the "subiquity_client" dependency: "../subiquity_client" is a relative path, but this isn't a local pubspec.
```

By using `dependency_overrides` in the installer, we get back the same old behavior that local packages are used from path when developing the installer.

Notice that this change makes the Pub tool print some _harmless_ warnings:
```
$ flutter pub get
Warning: You are using these overridden dependencies:
! subiquity_client 0.0.1 from path ../subiquity_client
! ubuntu_wizard 0.0.0 from path ../ubuntu_wizard
Running "flutter pub get" in ubuntu_desktop_installer...
```