### PR TITLE
Let subiquity decide the initial timezone

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -18,7 +18,6 @@ import 'slides.dart';
 export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
 export 'slides.dart';
 
-const _kGeoIPUrl = 'https://geoip.ubuntu.com/lookup';
 const _kGeonameUrl = 'https://geoname-lookup.ubuntu.com/';
 const _kSystemdUnit = 'snap.ubuntu-desktop-installer.subiquity-server.service';
 
@@ -48,11 +47,10 @@ void runInstallerApp(
     loadTimezones: () => rootBundle.loadString('assets/timeZones.txt'),
   );
 
-  final geoip = GeoIP(url: _kGeoIPUrl, geodata: geodata);
   final geoname = Geoname(url: _kGeonameUrl, geodata: geodata);
 
   registerService(() => DiskStorageService(subiquityClient));
-  registerService(() => GeoService(geoip, sources: [geodata, geoname]));
+  registerService(() => GeoService(sources: [geodata, geoname]));
   registerService(() => JournalService(journalUnit));
   registerService(KeyboardService.new);
   registerService(NetworkService.new);

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_model.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -25,10 +26,13 @@ class WhereAreYouModel extends ChangeNotifier {
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
-    _service.init().then((location) {
+    return _client.timezone().then((data) async {
+      if (data.timezone != null) {
+        final timezones = await _service.searchTimezone(data.timezone!);
+        _selectedLocation = timezones.firstOrNull;
+      }
       _initialized = true;
-      _selectedLocation = location;
-      log.debug('Initialized $location');
+      log.debug('Initialized $_selectedLocation');
       notifyListeners();
     });
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -70,7 +70,6 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
                               formatLocation(model.selectedLocation);
                         }
                         return TextFormField(
-                          autofocus: true,
                           focusNode: focusNode,
                           controller: controller,
                           decoration: InputDecoration(

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -47,7 +47,6 @@ dependencies:
   udev:
     path: ../udev
   upower: ^0.6.1
-  xml: ^5.3.1
   yaru: ^0.2.0
   yaru_icons: ^0.1.2
   yaru_widgets: 1.0.2

--- a/packages/ubuntu_desktop_installer/test/where_are_you/geo_service_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/geo_service_test.mocks.dart
@@ -381,31 +381,6 @@ class MockDio extends _i1.Mock implements _i7.Dio {
   String toString() => super.toString();
 }
 
-/// A class which mocks [GeoIP].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockGeoIP extends _i1.Mock implements _i10.GeoIP {
-  MockGeoIP() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  String get url =>
-      (super.noSuchMethod(Invocation.getter(#url), returnValue: '') as String);
-  @override
-  _i8.Future<_i10.GeoLocation?> lookup() =>
-      (super.noSuchMethod(Invocation.method(#lookup, []),
-              returnValue: Future<_i10.GeoLocation?>.value())
-          as _i8.Future<_i10.GeoLocation?>);
-  @override
-  _i8.Future<void> cancel() =>
-      (super.noSuchMethod(Invocation.method(#cancel, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i8.Future<void>);
-  @override
-  String toString() => super.toString();
-}
-
 /// A class which mocks [GeoSource].
 ///
 /// See the documentation for Mockito's code generation for more information.

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/where_are_you/where_are_you_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -13,15 +14,18 @@ void main() {
     final location = GeoLocation(name: 'Stockholm');
 
     final client = MockSubiquityClient();
+    when(client.timezone())
+        .thenAnswer((_) async => TimezoneData(timezone: location.name));
     final service = MockGeoService();
-    when(service.init()).thenAnswer((_) async => location);
+    when(service.searchTimezone(location.name))
+        .thenAnswer((_) async => [location]);
 
     final model = WhereAreYouModel(client: client, service: service);
     expect(model.isInitialized, isFalse);
 
     await model.init();
 
-    verify(service.init()).called(1);
+    verify(client.timezone()).called(1);
     expect(model.isInitialized, isTrue);
     expect(model.selectedLocation, equals(location));
   });

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.mocks.dart
@@ -24,11 +24,6 @@ class MockGeoService extends _i1.Mock implements _i2.GeoService {
   }
 
   @override
-  _i3.Future<_i2.GeoLocation?> init() =>
-      (super.noSuchMethod(Invocation.method(#init, []),
-              returnValue: Future<_i2.GeoLocation?>.value())
-          as _i3.Future<_i2.GeoLocation?>);
-  @override
   void addSource(_i2.GeoSource? source) =>
       super.noSuchMethod(Invocation.method(#addSource, [source]),
           returnValueForMissingStub: null);

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
@@ -184,21 +184,13 @@ void main() {
     );
   });
 
-  testWidgets('focus text field', (tester) async {
-    final model = buildModel();
-    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
-
-    final field = find.byType(EditableText);
-    expect(field, findsNWidgets(2));
-    expect(tester.widget<EditableText>(field.first).focusNode.hasFocus, isTrue);
-  });
-
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
+    when(client.timezone()).thenAnswer((_) async => TimezoneData());
     registerMockService<SubiquityClient>(client);
 
     final service = MockGeoService();
-    when(service.init()).thenAnswer((_) async => null);
+    when(service.searchTimezone(any)).thenAnswer((_) async => []);
     registerMockService<GeoService>(service);
 
     await tester.pumpWidget(tester.buildApp(WhereAreYouPage.create));


### PR DESCRIPTION
Request the initial timezone from subiquity, and let it do the GeoIP
lookup instead of looking up geoip.ubuntu.com directly from the UI.

This removes a nice chunk of GeoIP lookup code, and fixes the issue
that the installer did not remember a previously applied timezone, and
fixes the issue that the installer is currently doing geoip lookups when
running integration tests.