### PR TITLE
subiquity_client: add support for more environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo python3 -m subiquity.cmd.server
 In another terminal run:
 ```sh
 cd /path/to/ubuntu-desktop-installer/packages/ubuntu_desktop_installer
-LIVE_RUN=1 flutter run
+SUBIQUITY_MODE=live flutter run
 ```
 
 ## Contributing

--- a/packages/subiquity_client/README.md
+++ b/packages/subiquity_client/README.md
@@ -1,0 +1,9 @@
+# subiquity_client
+
+Supported environment variables:
+
+| Name | Value | Description |
+|---|---|---|
+| SUBIQUITY_MODE | <li>`live`: Start Subiquity in live mode</li><li>`dry-run`: Start Subiquity in dry-run mode (default)</li><li>`none`: Do not start Subiquity</li> | Whether Subiquity server is automatically started in live or dry-run mode. |
+| SUBIQUITY_PATH | For example: <li>`/home/user/dev/subiquity`</li> | Start Subiquity from the specified location. Defaults to the `subiquity_client/subiquity` submodule. |
+| SUBIQUITY_SOCKET_PATH | For example: <li>`/tmp/subiquity.sock`</li> | Use the specified socket to communicate with Subiquity. Defaults to `/run/subiquity/socket` in live, and `.subiquity/socket` in dry-run mode. |

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -21,7 +21,7 @@ void main() {
     setUpAll(() async {
       _testServer = SubiquityServer();
       _client = SubiquityClient();
-      _socketPath = await _testServer.start(ServerMode.DRY_RUN, args: [
+      _socketPath = await _testServer.start(args: [
         '--machine-config',
         'examples/simple.json',
         '--source-catalog',
@@ -417,7 +417,7 @@ void main() {
     setUpAll(() async {
       _testServer = SubiquityServer.wsl();
       _client = SubiquityClient();
-      _socketPath = await _testServer.start(ServerMode.DRY_RUN);
+      _socketPath = await _testServer.start();
       _client.open(_socketPath);
     });
 

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -42,7 +42,7 @@ void runInstallerApp(
   final subiquityClient = SubiquityClient();
   final subiquityServer = SubiquityServer();
 
-  final journalUnit = isLiveRun(options) ? _kSystemdUnit : null;
+  final journalUnit = isDryRun() ? null : _kSystemdUnit;
 
   final geodata = Geodata(
     loadCities: () => assetBundle.loadString('assets/cities15000.txt'),

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -367,11 +367,11 @@ class MockSubiquityServer extends _i1.Mock implements _i7.SubiquityServer {
   }
 
   @override
-  _i5.Future<String> start(_i7.ServerMode? serverMode,
+  _i5.Future<String> start(
           {List<String>? args, Map<String, String>? environment}) =>
       (super.noSuchMethod(
           Invocation.method(
-              #start, [serverMode], {#args: args, #environment: environment}),
+              #start, [], {#args: args, #environment: environment}),
           returnValue: Future<String>.value('')) as _i5.Future<String>);
   @override
   _i5.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -23,8 +23,8 @@ final log = Logger(_appName);
 /// is called when the server connection has been established.
 typedef SubiquityInitCallback = void Function(SubiquityClient client);
 
-bool isLiveRun(ArgResults? options) {
-  return options != null && options['dry-run'] != true;
+bool isDryRun() {
+  return SubiquityServer.serverMode == ServerMode.DRY_RUN;
 }
 
 /// Initializes and runs the given [app].
@@ -49,10 +49,8 @@ Future<void> runWizardApp(
     );
   }
 
-  final serverMode = isLiveRun(options) ? ServerMode.LIVE : ServerMode.DRY_RUN;
-
   subiquityServer
-      .start(serverMode, args: serverArgs, environment: serverEnvironment)
+      .start(args: serverArgs, environment: serverEnvironment)
       .then((socketPath) {
     subiquityClient.open(socketPath);
 
@@ -119,9 +117,6 @@ ArgResults? parseCommandLine(
 }) {
   final parser = ArgParser();
   parser.addFlag('help', abbr: 'h', negatable: false);
-  parser.addFlag('dry-run',
-      defaultsTo: io.Platform.environment['LIVE_RUN'] != '1',
-      help: 'Run Subiquity server in dry-run mode');
   parser.addOption('initial-route', hide: true);
   parser.addOption(
     'log-file',

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/services.dart';
@@ -19,7 +18,7 @@ void main() {
   testWidgets('initializes subiquity', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
-    when(server.start(any,
+    when(server.start(
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer((_) async => 'socket path');
 
@@ -31,8 +30,8 @@ void main() {
       serverEnvironment: {'baz': 'qux'},
       onInitSubiquity: (client) => client.setVariant(Variant.DESKTOP),
     );
-    verify(server.start(ServerMode.DRY_RUN,
-        args: ['--foo', 'bar'], environment: {'baz': 'qux'})).called(1);
+    verify(server.start(args: ['--foo', 'bar'], environment: {'baz': 'qux'}))
+        .called(1);
     verify(client.open('socket path')).called(1);
     verify(client.setVariant(Variant.DESKTOP)).called(1);
   });
@@ -40,7 +39,7 @@ void main() {
   testWidgets('registers the client', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
-    when(server.start(any,
+    when(server.start(
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer((_) async => '');
 
@@ -56,14 +55,6 @@ void main() {
   testWidgets('parse command-line arguments', (tester) async {
     int? didExit;
     final out = MockIOSink();
-
-    final dryRun = parseCommandLine(
-      ['--dry-run'],
-      exit: (exitCode) => didExit = exitCode,
-    );
-    expect(didExit, isNull);
-    expect(dryRun, isNotNull);
-    expect(dryRun!['dry-run'], isTrue);
 
     final machineConfig = parseCommandLine(
       ['--machine-config', 'foo.json'],

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -45,7 +45,7 @@ screens, yet allowing user to overwrite any of those during setup.
     },
     serverArgs: serverArgs,
     serverEnvironment: {
-      if (!isLiveRun(options) && options['reconfigure'] == true)
+      if (isDryRun() && options['reconfigure'] == true)
         'DRYRUN_RECONFIG': 'true',
     },
   );

--- a/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
+++ b/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
@@ -588,8 +588,8 @@ export PYTHON=$SNAP/usr/bin/python3.8
 export PY3OR2_PYTHON=$PYTHON
 # base directory for subiquity to locate resources
 export SUBIQUITY_ROOT=$SNAP/bin/subiquity
-# Needed for flutter
-export LIVE_RUN=1
+# The server should be always started in WSL because there's no systemd
+export SUBIQUITY_MODE=live
 
 BIN=$SNAP/usr/libexec/ubuntu_wsl_setup
 args=""

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
       GIO_MODULE_DIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gio/modules
-      LIVE_RUN: 1
+      SUBIQUITY_MODE: none # the server is already running
       LOG_LEVEL: debug
       SNAP_PYTHON: python3
 


### PR DESCRIPTION
| Name | Value | Description |
|---|---|---|
| SUBIQUITY_MODE | <li>`live`: Start Subiquity in live mode</li><li>`dry-run`: Start Subiquity in dry-run mode (default)</li><li>`none`: Do not start Subiquity</li> | Whether Subiquity server is automatically started in live or dry-run mode. |
| SUBIQUITY_PATH | For example: <li>`/home/user/dev/subiquity`</li> | Start Subiquity from the specified location. Defaults to the `subiquity_client/subiquity` submodule. |
| SUBIQUITY_SOCKET_PATH | For example: <li>`/tmp/subiquity.sock`</li> | Use the specified socket to communicate with Subiquity. Defaults to `/run/subiquity/socket` in live, and `.subiquity/socket` in dry-run mode. |
