### PR TITLE
Updates and other software: restore third-party drivers option

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
@@ -107,6 +107,8 @@
   "otherOptions": "Other options",
   "installThirdPartyTitle": "Install third-party software for graphics and Wi-Fi hardware, as well as additional media formats",
   "installThirdPartySubtitle": "This software is subject to license terms included with its documentation. Some are proprietary.",
+  "installDriversTitle": "Install third-party software for graphics and Wi-Fi hardware",
+  "installDriversSubtitle": "These drivers are subject to license terms included with their documentation. They are proprietary.",
   "onBatteryWarning": "<font color=\"{color}\">Warning</font>: The computer is not plugged in to a power source.",
   "@onBatteryWarning": {
     "type": "text",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -626,6 +626,18 @@ abstract class AppLocalizations {
   /// **'This software is subject to license terms included with its documentation. Some are proprietary.'**
   String get installThirdPartySubtitle;
 
+  /// No description provided for @installDriversTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Install third-party software for graphics and Wi-Fi hardware'**
+  String get installDriversTitle;
+
+  /// No description provided for @installDriversSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'These drivers are subject to license terms included with their documentation. They are proprietary.'**
+  String get installDriversSubtitle;
+
   /// No description provided for @onBatteryWarning.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -214,6 +214,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -214,6 +214,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -214,6 +214,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -214,6 +214,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -214,6 +214,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -214,6 +214,12 @@ class AppLocalizationsBo extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -214,6 +214,12 @@ class AppLocalizationsBs extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -214,6 +214,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -214,6 +214,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get installThirdPartySubtitle => 'Tento software je předmětem licenčních ujednání, obsažených v dokumentaci k němu. Některý je proprietární.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Upozornění</font>: Počítač není připojen k napájení ze zásuvky.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -214,6 +214,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -214,6 +214,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -214,6 +214,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get installThirdPartySubtitle => 'Diese Software unterliegt den Lizenzbedingungen, die in der Dokumentation enthalten sind. Ein Teil davon ist proprietär.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warnung</font>: Der Rechner ist nicht an eine Stromquelle angeschlossen.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -214,6 +214,12 @@ class AppLocalizationsDz extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get installThirdPartySubtitle => 'Tiuj programoj estas disponeblaj laŭ permesiloj inkluzivitaj en siaj dokumentaroj. Kelkaj el ili estas neliberaj.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Averto</font>: La komputilo ne estas konektita al energifonto.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get installThirdPartySubtitle => 'Estos programas están disponibles en virtud de los términos incluidos en su documentación. Algunos son privativos.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Atención</font>: el equipo no se ha enchufado a una fuente de energía.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -214,6 +214,12 @@ class AppLocalizationsEu extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -214,6 +214,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -214,6 +214,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get installThirdPartySubtitle => 'Näihin ohjelmistoihin kohdistuvat dokumentaation mukana olevat lisenssiehdot. Jotkin voivat olla suljetun lähdekoodin ohjelmistoja.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Varoitus</font>: Tietokonetta ei ole liitetty virtalähteeseen.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -214,6 +214,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get installThirdPartySubtitle => 'Ce logiciel est soumis à des termes de licence inclus dans sa documentation. Certains sont propriétaires.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\"> Avertissement </font> : L’ordinateur n’est pas branché à une source d’alimentation.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -214,6 +214,12 @@ class AppLocalizationsGa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -214,6 +214,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -214,6 +214,12 @@ class AppLocalizationsGu extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -214,6 +214,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get installThirdPartySubtitle => 'התכניות האלו כפופות לתנאי אישוי שנכללים בתיעוד שלהן. חלקן קנייניות.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">אזהרה</font>: המחשב לא מחובר למקור חשמל.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -214,6 +214,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -214,6 +214,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -214,6 +214,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get installThirdPartySubtitle => 'A szoftverre a dokumentációban szereplő licencfeltételek vonatkoznak. Egyesek védettek.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Figyelmeztetés</font>: A számítógép nincs csatlakoztatva áramforráshoz.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -214,6 +214,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get installThirdPartySubtitle => 'Perangkat lunak ini tunduk pada persyaratan lisensi disertakan dengan dokumentasinya. Beberapa adalah proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Peringatan</font>: Komputer tidak tertancam ke suatu sumber listrik.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -214,6 +214,12 @@ class AppLocalizationsIs extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -214,6 +214,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get installThirdPartySubtitle => 'Questo software è soggetto ai termini di licenza inclusi nella documentazione. Alcuni sono proprietari.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Attenzione</font>: Il computer non è connesso a una fonte di alimentazione.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -214,6 +214,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get installThirdPartySubtitle => 'このソフトウェアの使用には、それぞれのドキュメントに記載されているライセンス規約が適用されます。一部のソフトウェアはプロプライエタリです。';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">警告</font>: このコンピューターは電源に接続されていません。';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKm extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get installThirdPartySubtitle => '이 소프트웨어는 문서에 포함된 라이선스 조건의 적용을 받습니다. 일부는 독점입니다.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">경고</font>: 컴퓨터에 전원이 연결되어 있지 않습니다.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -214,6 +214,12 @@ class AppLocalizationsKu extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -214,6 +214,12 @@ class AppLocalizationsLo extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -214,6 +214,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get installThirdPartySubtitle => 'Šiai programinei įrangai taikomos licencijos sąlygos, kurias rasite jos dokumentacijoje. Kai kuri programinė įranga yra nuosavybinė.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Įspėjimas</font>: Šis kompiuteris daugiau nebėra prijungtas prie elektros maitinimo šaltinio.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -214,6 +214,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -214,6 +214,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -214,6 +214,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get installThirdPartySubtitle => 'ഈ സോഫ്റ്റ്‌വെയർ അതിന്റെ ഡോക്യുമെന്റേഷനിൽ ഉൾപ്പെടുത്തിയിട്ടുള്ള ലൈസൻസ് നിബന്ധനകൾക്ക് വിധേയമാണ്. ചിലത് ഉടമസ്ഥതയിലുള്ളതാണ്.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">മുന്നറിയിപ്പ്</font>: കമ്പ്യൂട്ടർ ഒരു വൈദ്യുത സ്രോതസ്സുമായി ബന്ധിപ്പിച്ചിട്ടില്ല.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -214,6 +214,12 @@ class AppLocalizationsMr extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -214,6 +214,12 @@ class AppLocalizationsMy extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -214,6 +214,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get installThirdPartySubtitle => 'Denne programvaren er underlagt lisensvilkårene som følger med dokumentasjonen. Noen er proprietære.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Advarsel</font>: Datamaskinen er ikke koblet til en strømkilde.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -214,6 +214,12 @@ class AppLocalizationsNe extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -214,6 +214,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -214,6 +214,12 @@ class AppLocalizationsNn extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -214,6 +214,12 @@ class AppLocalizationsOc extends AppLocalizations {
   String get installThirdPartySubtitle => 'Aqueste logicial es somés a de tèrmes de licéncia incluses dins sa documentacion. Certans son proprietaris.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Avertiment </font>: l’ordenador es pas brancat a una font d’alimentacion.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -214,6 +214,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -214,6 +214,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get installThirdPartySubtitle => 'To oprogramowanie podlega warunkom licencyjnym dołączonym do jego dokumentacji. Niektóre z nich są własnościowe.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Ostrzeżenie</font>: komputer nie jest podłączony do źródła zasilania.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -214,6 +214,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get installThirdPartySubtitle => 'Este software está sujeito aos termos de licença incluídos nas suas documentações. Alguns são proprietários.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Aviso</font>: O computador não está ligado a uma fonte de energia.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -214,6 +214,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -214,6 +214,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get installThirdPartySubtitle => 'На это программное обеспечение распространяются условиями лицензии, содержащиеся в документации. Часть из них является проприетарной.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Внимание</font>. Компьютер не подключен к источнику питания.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSe extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -214,6 +214,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get installThirdPartySubtitle => 'Denna programvara är föremål för licensvillkor som ingår i dess dokumentation. Vissa är proprietära.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Varning</font>: Datorn är inte ansluten till en strömkälla.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTg extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -214,6 +214,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get installThirdPartySubtitle => 'Bu yazılım, belgeleriyle birlikte verilen lisans koşullarına tabidir. Bazıları tescillidir.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Uyarı</font>: Bilgisayar güç kaynağına takılı değil.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -214,6 +214,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -214,6 +214,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -214,6 +214,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get installThirdPartySubtitle => 'This software is subject to license terms included with its documentation. Some are proprietary.';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">Warning</font>: The computer is not plugged in to a power source.';
   }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -214,6 +214,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get installThirdPartySubtitle => '本软件受其文档中包含的许可条款的约束中有些是专有的。';
 
   @override
+  String get installDriversTitle => 'Install third-party software for graphics and Wi-Fi hardware';
+
+  @override
+  String get installDriversSubtitle => 'These drivers are subject to license terms included with their documentation. They are proprietary.';
+
+  @override
   String onBatteryWarning(Object color) {
     return '<font color=\"$color\">警告</font>：电脑未插入电源。';
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -70,18 +70,17 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
             groupValue: model.installationMode,
             onChanged: model.setInstallationMode,
           ),
-          // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-          // Padding(
-          //   padding: kHeaderPadding.copyWith(bottom: kContentSpacing),
-          //   child: Text(lang.otherOptions),
-          // ),
-          // CheckButton(
-          //   title: Text(lang.installThirdPartyTitle),
-          //   subtitle: Text(lang.installThirdPartySubtitle),
-          //   contentPadding: kContentPadding,
-          //   value: model.installThirdParty,
-          //   onChanged: model.setInstallThirdParty,
-          // )
+          Padding(
+            padding: kHeaderPadding.copyWith(bottom: kContentSpacing),
+            child: Text(lang.otherOptions),
+          ),
+          CheckButton(
+            title: Text(lang.installDriversTitle),
+            subtitle: Text(lang.installDriversSubtitle),
+            contentPadding: kContentPadding,
+            value: model.installDrivers,
+            onChanged: model.setInstallDrivers,
+          ),
         ],
       ),
       footer: model.onBattery
@@ -97,9 +96,9 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
             final telemetry = getService<TelemetryService>();
             await telemetry.addMetrics({
               'Minimal': model.installationMode == InstallationMode.minimal,
-              'RestrictedAddons': model.installThirdParty,
+              // TODO: 'RestrictedAddons': model.installCodecs,
             });
-            await model.selectInstallationSource();
+            await model.save();
           },
         ),
       ],

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
@@ -22,13 +22,13 @@ import 'updates_other_software_page_test.mocks.dart';
 void main() {
   UpdateOtherSoftwareModel buildModel({
     InstallationMode? installationMode,
-    bool? installThirdParty,
+    bool? installDrivers,
     bool? onBattery,
   }) {
     final model = MockUpdateOtherSoftwareModel();
     when(model.installationMode)
         .thenReturn(installationMode ?? InstallationMode.normal);
-    when(model.installThirdParty).thenReturn(installThirdParty ?? false);
+    when(model.installDrivers).thenReturn(installDrivers ?? false);
     when(model.onBattery).thenReturn(onBattery ?? false);
     return model;
   }
@@ -79,25 +79,24 @@ void main() {
     verify(model.setInstallationMode(InstallationMode.minimal)).called(1);
   });
 
-  // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-  // testWidgets('install third-party software', (tester) async {
-  //   final model = buildModel(installThirdParty: true);
-  //   await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+  testWidgets('install drivers', (tester) async {
+    final model = buildModel(installDrivers: true);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-  //   final installThirdPartyTile = find.widgetWithText(
-  //     CheckButton,
-  //     tester.lang.installThirdPartyTitle,
-  //   );
-  //   expect(installThirdPartyTile, findsOneWidget);
+    final installDriversTile = find.widgetWithText(
+      CheckButton,
+      tester.lang.installDriversTitle,
+    );
+    expect(installDriversTile, findsOneWidget);
 
-  //   expect(tester.widget<CheckButton>(installThirdPartyTile).value, isTrue);
+    expect(tester.widget<CheckButton>(installDriversTile).value, isTrue);
 
-  //   when(model.installThirdParty).thenReturn(false);
+    when(model.installDrivers).thenReturn(false);
 
-  //   await tester.tap(installThirdPartyTile);
+    await tester.tap(installDriversTile);
 
-  //   verify(model.setInstallThirdParty(false)).called(1);
-  // });
+    verify(model.setInstallDrivers(false)).called(1);
+  });
 
   testWidgets('on battery', (tester) async {
     final model = buildModel(onBattery: true);
@@ -131,12 +130,15 @@ void main() {
     await tester.tap(continueButton);
     await tester.pumpAndSettle();
 
-    verify(model.selectInstallationSource()).called(1);
+    verify(model.save()).called(1);
     expect(find.text('Next page'), findsOneWidget);
   });
 
   testWidgets('creates a model', (tester) async {
-    registerMockService<SubiquityClient>(MockSubiquityClient());
+    final client = MockSubiquityClient();
+    when(client.getDrivers()).thenAnswer((_) async => const DriversResponse(
+        install: true, drivers: [], localOnly: false, searchDrivers: false));
+    registerMockService<SubiquityClient>(client);
 
     final power = MockPowerService();
     when(power.onBattery).thenReturn(false);

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
@@ -37,8 +37,8 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValue: _i2.InstallationMode.normal,
       ) as _i2.InstallationMode);
   @override
-  bool get installThirdParty => (super.noSuchMethod(
-        Invocation.getter(#installThirdParty),
+  bool get installDrivers => (super.noSuchMethod(
+        Invocation.getter(#installDrivers),
         returnValue: false,
       ) as bool);
   @override
@@ -65,17 +65,17 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void setInstallThirdParty(bool? installThirdParty) => super.noSuchMethod(
+  void setInstallDrivers(bool? installDrivers) => super.noSuchMethod(
         Invocation.method(
-          #setInstallThirdParty,
-          [installThirdParty],
+          #setInstallDrivers,
+          [installDrivers],
         ),
         returnValueForMissingStub: null,
       );
   @override
-  _i3.Future<void> selectInstallationSource() => (super.noSuchMethod(
+  _i3.Future<void> save() => (super.noSuchMethod(
         Invocation.method(
-          #selectInstallationSource,
+          #save,
           [],
         ),
         returnValue: _i3.Future<void>.value(),


### PR DESCRIPTION
There used to be a non-functional "install third-party software" checkbox that was commented out in #373. This PR brings the checkbox back so that it's connected to the "drivers" API of Subiquity. Another checkbox for codecs follows in a separate PR.

![image](https://user-images.githubusercontent.com/140617/202446564-2f6b2039-26c8-4777-a530-e523af74b39e.png)

Design: https://people.canonical.com/~platform/desktop/installer/6.%20Updates%20and%20Other%20Software/