### PR TITLE
subiquity_client: use a symlink when the socket path is too long

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -40,10 +40,20 @@ abstract class SubiquityServer {
   // to be resolved based on the location of the `subiquity_client` package.
   Future<String> _getSocketPath(ServerMode mode) async {
     if (mode == ServerMode.DRY_RUN) {
-      // Use a relative path to avoid hitting AF_UNIX path length limit because
+      // Use a relative path or a symlink if necessary to avoid hitting AF_UNIX path length limit because
       // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
       // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
-      return p.relative(p.join(await _getSubiquityPath(), '.subiquity/socket'));
+      final path =
+          p.relative(p.join(await _getSubiquityPath(), '.subiquity/socket'));
+      if (path.length > 107) {
+        final tempDir = Directory.systemTemp.createTempSync('subiquity');
+        final symlink = Link(p.join(tempDir.path, 'socket'));
+        if (!symlink.existsSync()) {
+          symlink.createSync(p.absolute(path));
+        }
+        return symlink.path;
+      }
+      return path;
     }
     return '/run/subiquity/socket';
   }


### PR DESCRIPTION
This is a continuation of #610 and #665. Using a relative path is not
enough. For flavors, the path to subiquity's socket grows even longer,
because it's located in Pub cache and includes a full sha1 in its name.

`$HOME/.pub-cache/git/ubuntu-desktop-installer-<sha1>/packages/subiquity_client/subiquity/.subiquity/socket`