### PR TITLE
Defines SNAP_PYTHON for WSL.

### DIFF
--- a/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
+++ b/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
@@ -584,6 +584,7 @@ PYTHONPATH=$SNAP/lib/python3.8/site-packages:$PYTHONPATH
 PYTHONPATH=$SNAP/bin/subiquity/:$PYTHONPATH
 export PYTHONPATH
 export PYTHON=$SNAP/usr/bin/python3.8
+export SNAP_PYTHON=$PYTHON
 # ensure curtin points at PYTHON
 export PY3OR2_PYTHON=$PYTHON
 # base directory for subiquity to locate resources


### PR DESCRIPTION
WSL installation was crashing due Subiquity being launched with system's python3 due a7c86328b3031ba2a9a6d0f08210ff6703c7b221.