### PR TITLE
Remove gdk_set_allowed_backends("x11")

### DIFF
--- a/packages/ubuntu_desktop_installer/linux/main.cc
+++ b/packages/ubuntu_desktop_installer/linux/main.cc
@@ -1,10 +1,6 @@
 #include "my_application.h"
 
 int main(int argc, char** argv) {
-  // Only X11 is currently supported.
-  // Wayland support is being developed: https://github.com/flutter/flutter/issues/57932.
-  gdk_set_allowed_backends("x11");
-
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }


### PR DESCRIPTION
Fixes the installer to respect dark system theme on the latest Jammy.

https://github.com/flutter/flutter/commit/b200baebd7680f5361d199ae0b406781014a918b