### PR TITLE
Fix slideshow interval

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -59,7 +59,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
           Stack(
             children: <Widget>[
               SlideShow(
-                interval: const Duration(hours: 1),
+                interval: const Duration(seconds: 50),
                 slides: SlidesContext.of(context)
                     .map((slide) => _SlidePage(slide: slide))
                     .toList(),


### PR DESCRIPTION
1 hour was probably meant to be 1 minute. :) Anyway, Ubiquity is using
50s so use the same. See `SLIDESHOW_OPTIONS = { timeout:50000 }` in:

https://bazaar.launchpad.net/~ubiquity-slideshow/ubiquity-slideshow-ubuntu/html/view/head:/slideshows/ubuntu/slides/index.html#L19