### PR TITLE
Fix button alignment

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -95,7 +95,6 @@ class WizardPage extends StatelessWidget {
                       padding: const EdgeInsets.only(left: kButtonBarSpacing),
                       child: _createButton(action),
                     ),
-                const SizedBox(width: kButtonBarSpacing),
               ],
             ),
           ],


### PR DESCRIPTION
Remove extra spacing after the last button.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/160565787-b103c605-11dc-412d-b5b3-8f5d7f5ef837.png) | ![image](https://user-images.githubusercontent.com/140617/160565804-367e051a-c7ad-4cdc-aba3-d12590abdf03.png) |