### PR TITLE
subiquity_client: increase response logging length limit

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -10,7 +10,7 @@ import 'types.dart';
 /// @internal
 final log = Logger('subiquity_client');
 
-const _kMaxResponseLogLength = 120;
+const _kMaxResponseLogLength = 1200;
 
 String _formatResponseLog(String method, String response) {
   var formatted = response;


### PR DESCRIPTION
120 is way too short and results in unhelpful messages like this:

```
DEBUG subiquity_client: ==> status() {"state": "ERROR", "confirming_tty": "/dev/tty1", "error": {"state": "DONE", "base": "1648559745.870598793.install_fail"...
```

It's good to have some limits because some responses are huge, such
as the keyboard layout response. Increasing 10x is long enough to fit
typical storage v2 responses with one disk and a few partitions.