### PR TITLE
Temporarily mark "drivers" as configured

### DIFF
--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -61,6 +61,7 @@ Future<void> runWizardApp(
     // Use the default values for a number of endpoints
     // for which a UI page isn't implemented yet.
     subiquityClient.markConfigured([
+      'drivers',
       'mirror',
       'proxy',
       'network',


### PR DESCRIPTION
The "drivers" controller doesn't get automatically marked as configured
if available drivers are detected. Explicitly mark it configured until
we have UI (#733) for it, to ensure that the installer doesn't get stuck
on systems where available drivers are detected.