### PR TITLE
Integration test: wait for installation slides

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -415,6 +415,7 @@ Future<void> testWhoAreYouPage(
 }
 
 Future<void> testInstallationSlidesPage(WidgetTester tester) async {
+  await tester.pumpUntil(find.byType(InstallationSlidesPage));
   expect(find.byType(InstallationSlidesPage), findsOneWidget);
 }
 


### PR DESCRIPTION
The installation slides are not immediately available after pressing
"Continue" on the previous screen. Let the widget tester pump until
the slides are available.