### PR TITLE
WhoAreYouModel: respect existing values

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
@@ -106,9 +106,9 @@ class WhoAreYouModel extends ChangeNotifier {
   /// Loads the identity data from the server, and resolves the system hostname.
   Future<void> loadIdentity() async {
     final identity = await _client.identity();
-    _realName.value = identity.realname?.orIfEmpty(_realName.value);
-    _hostname.value = identity.hostname?.orIfEmpty(_hostname.value);
-    _username.value = identity.username?.orIfEmpty(_username.value);
+    _realName.value ??= identity.realname?.orIfEmpty(null);
+    _hostname.value ??= identity.hostname?.orIfEmpty(null);
+    _username.value ??= identity.username?.orIfEmpty(null);
     log.info('Loaded identity: ${identity.description}');
     _productName.value = await _readProductName();
     log.info('Read product name: ${_productName.value}');

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
@@ -106,9 +106,9 @@ class WhoAreYouModel extends ChangeNotifier {
   /// Loads the identity data from the server, and resolves the system hostname.
   Future<void> loadIdentity() async {
     final identity = await _client.identity();
-    _realName.value = identity.realname?.orIfEmpty(null);
-    _hostname.value = identity.hostname?.orIfEmpty(null);
-    _username.value = identity.username?.orIfEmpty(null);
+    _realName.value = identity.realname?.orIfEmpty(_realName.value);
+    _hostname.value = identity.hostname?.orIfEmpty(_hostname.value);
+    _username.value = identity.username?.orIfEmpty(_username.value);
     log.info('Loaded identity: ${identity.description}');
     _productName.value = await _readProductName();
     log.info('Read product name: ${_productName.value}');

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
@@ -184,4 +184,23 @@ void main() {
     testValid('real', 'host', 'user', 'passwd', 'passwd', isTrue);
     testValid('real', 'host', 'user', 'passwd', 'mismatch', isFalse);
   });
+
+  test('respect existing values', () async {
+    final client = MockSubiquityClient();
+    when(client.identity()).thenAnswer((_) async => IdentityData());
+
+    final model = WhoAreYouModel(client);
+    model.realName = 'User';
+    model.username = 'user';
+    model.hostname = 'ubuntu';
+
+    await IOOverrides.runZoned(() async {
+      await model.loadIdentity();
+    }, createFile: (path) => MockProductNameFile(''));
+    verify(client.identity()).called(1);
+
+    expect(model.realName, equals('User'));
+    expect(model.username, equals('user'));
+    expect(model.hostname, equals('ubuntu'));
+  });
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
@@ -187,7 +187,13 @@ void main() {
 
   test('respect existing values', () async {
     final client = MockSubiquityClient();
-    when(client.identity()).thenAnswer((_) async => IdentityData());
+    when(client.identity()).thenAnswer((_) async {
+      return IdentityData(
+        realname: 'Default',
+        username: 'default',
+        hostname: 'default',
+      );
+    });
 
     final model = WhoAreYouModel(client);
     model.realName = 'User';


### PR DESCRIPTION
It may happen in integration tests that UI values are entered before
receiving a response from subiquity. If/when that happens, don't reset
the values back to null.