### PR TITLE
Fix $SNAP path for WSL

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -95,7 +95,7 @@ abstract class SubiquityServer {
         if (serverMode == ServerMode.DRY_RUN) '--dry-run',
         ...?args,
       ];
-      await _startSubiquity(subiquityCmd, environment);
+      await _startSubiquity(serverMode, subiquityCmd, environment);
     }
 
     return _waitSubiquity(socketPath).then((_) {
@@ -104,8 +104,8 @@ abstract class SubiquityServer {
     });
   }
 
-  Future<void> _startSubiquity(
-      List<String> subiquityCmd, Map<String, String>? environment) async {
+  Future<void> _startSubiquity(ServerMode serverMode, List<String> subiquityCmd,
+      Map<String, String>? environment) async {
     final subiquityPath = await _getSubiquityPath();
     String? workingDirectory;
     // try using local subiquity

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -129,11 +129,13 @@ abstract class SubiquityServer {
       workingDirectory: workingDirectory,
       environment: {
         ..._pythonPath(subiquityPath),
-        // so subiquity doesn't think it's some other snap (e.g. flutter or vs code)
-        'SNAP': '.',
-        'SNAP_NAME': 'subiquity',
-        'SNAP_REVISION': '',
-        'SNAP_VERSION': '',
+        if (serverMode == ServerMode.DRY_RUN) ...{
+          // so subiquity doesn't think it's some other snap (e.g. flutter or vs code)
+          'SNAP': '.',
+          'SNAP_NAME': 'subiquity',
+          'SNAP_REVISION': '',
+          'SNAP_VERSION': '',
+        },
         ...?environment,
       },
     ).then((process) {


### PR DESCRIPTION
Since Subiquity server is started by this for WSL, the SNAP environment variable previously set by the preparation scripts was overwritten by the current directory which can even be a Windows directory.

And since the environment herein set was only meant for DRY_RUN, let's check for that before setting it up.