### PR TITLE
Removes experimental systemd from the UI.

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/goldens/reconfiguration/wsl.conf
+++ b/packages/ubuntu_wsl_setup/integration_test/goldens/reconfiguration/wsl.conf
@@ -2,9 +2,6 @@
 enabled = false
 mountfstab = false
 
-[boot]
-command = /usr/libexec/wsl-systemd
-
 [interop]
 appendwindowspath = false
 enabled = false

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -90,7 +90,6 @@ void main() {
         interopAppendwindowspath: false,
         automountEnabled: false,
         automountMountfstab: false,
-        systemdEnabled: true,
       ),
     );
     await tester.pumpAndSettle();
@@ -201,10 +200,6 @@ Future<void> testConfigurationUIPage(
   await tester.toggleCheckbox(
     label: tester.lang.configurationUIInteropAppendWindowsPathSubtitle,
     value: config?.interopAppendwindowspath,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.configurationUISystemdSubtitle,
-    value: config?.systemdEnabled,
   );
   await tester.pumpAndSettle();
 

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
@@ -40,12 +40,6 @@ class ConfigurationUIModel extends ChangeNotifier {
     _conf.value = _conf.value.copyWith(automountMountfstab: value);
   }
 
-  /// Whether systemd experimental support is enabled.
-  bool get systemdEnabled => _conf.value.systemdEnabled ?? false;
-  set systemdEnabled(bool value) {
-    _conf.value = _conf.value.copyWith(systemdEnabled: value);
-  }
-
   /// Whether the current input is valid.
   bool get isValid => true;
 

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -89,18 +89,6 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
             value: model.interopAppendwindowspath,
             onChanged: (value) => model.interopAppendwindowspath = value!,
           ),
-          const SizedBox(height: kContentSpacing),
-          Padding(
-            padding: kHeaderPadding.copyWith(bottom: kContentSpacing),
-            child: Text(lang.configurationUISystemdHeader),
-          ),
-          CheckButton(
-            contentPadding: kContentPadding,
-            title: Text(lang.configurationUISystemdTitle),
-            subtitle: Text(lang.configurationUISystemdSubtitle),
-            value: model.systemdEnabled,
-            onChanged: (value) => model.systemdEnabled = value!,
-          ),
         ],
       ),
       actions: <WizardAction>[

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
@@ -34,7 +34,6 @@ void main() {
         .thenReturn(interopAppendwindowspath ?? false);
     when(model.automountEnabled).thenReturn(automountEnabled ?? true);
     when(model.automountMountfstab).thenReturn(automountMountfstab ?? true);
-    when(model.systemdEnabled).thenReturn(systemdEnabled ?? true);
     return model;
   }
 

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
@@ -59,14 +59,6 @@ class MockConfigurationUIModel extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#automountMountfstab, value),
           returnValueForMissingStub: null);
   @override
-  bool get systemdEnabled => (super
-          .noSuchMethod(Invocation.getter(#systemdEnabled), returnValue: false)
-      as bool);
-  @override
-  set systemdEnabled(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#systemdEnabled, value),
-          returnValueForMissingStub: null);
-  @override
   bool get isValid =>
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);


### PR DESCRIPTION
It's been decided to remove experimental systemd from this release.
Subiquity [PR 1259](https://github.com/canonical/subiquity/pull/1259) removes it from TUI. API remained unchanged.
For this reason, I kept the strings in the ARB files.