### PR TITLE
Adapt to url_launcher 6.1 changes

### DIFF
--- a/packages/ubuntu_wizard/lib/src/utils/url_launcher.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/url_launcher.dart
@@ -1,5 +1,5 @@
 import 'package:ubuntu_logger/ubuntu_logger.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../services.dart';
 
@@ -11,11 +11,11 @@ Future<bool> launchUrl(String url) {
 
 class UrlLauncher {
   Future<bool> launchUrl(String url) async {
-    if (!await canLaunch(url)) {
+    if (!await canLaunchUrlString(url)) {
       log.error('Unable to launch $url');
       return false;
     }
     log.debug('Launching $url');
-    return launch(url);
+    return launchUrlString(url);
   }
 }

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
-  url_launcher: ^6.0.20
+  url_launcher: ^6.1.0
   wizard_router: ^0.7.0
   yaru: ^0.2.0
 

--- a/packages/ubuntu_wizard/test/url_launcher_test.dart
+++ b/packages/ubuntu_wizard/test/url_launcher_test.dart
@@ -3,6 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/src/utils/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' show WebViewConfiguration;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 // ignore_for_file: prefer_mixin
@@ -47,6 +48,11 @@ void main() {
   });
 }
 
+const expectedUseWebView = true;
+const expectedWebViewConfiguration = WebViewConfiguration();
+const expectedUniversalLinksOnly = false;
+const expectedWebOnlyWindowName = null;
+
 void createPlatformMock(
   String url, {
   required bool canLaunch,
@@ -56,13 +62,13 @@ void createPlatformMock(
   when(mock.canLaunch(url)).thenAnswer((_) async => canLaunch);
   when(mock.launch(
     url,
-    useSafariVC: true,
-    useWebView: false,
-    enableJavaScript: false,
-    enableDomStorage: false,
-    universalLinksOnly: false,
-    headers: {},
-    webOnlyWindowName: null,
+    useSafariVC: expectedUseWebView,
+    useWebView: expectedUseWebView,
+    enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
+    enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
+    universalLinksOnly: expectedUniversalLinksOnly,
+    headers: expectedWebViewConfiguration.headers,
+    webOnlyWindowName: expectedWebOnlyWindowName,
   )).thenAnswer((_) async => result);
   UrlLauncherPlatform.instance = mock;
 }
@@ -79,24 +85,24 @@ void verifyPlatformMock({
   if (canLaunch) {
     verify(mock.launch(
       url,
-      useSafariVC: true,
-      useWebView: false,
-      enableJavaScript: false,
-      enableDomStorage: false,
-      universalLinksOnly: false,
-      headers: {},
-      webOnlyWindowName: null,
+      useSafariVC: expectedUseWebView,
+      useWebView: expectedUseWebView,
+      enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
+      enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
+      universalLinksOnly: expectedUniversalLinksOnly,
+      headers: expectedWebViewConfiguration.headers,
+      webOnlyWindowName: expectedWebOnlyWindowName,
     )).called(1);
   } else {
     verifyNever(mock.launch(
       url,
-      useSafariVC: true,
-      useWebView: false,
-      enableJavaScript: false,
-      enableDomStorage: false,
-      universalLinksOnly: false,
-      headers: {},
-      webOnlyWindowName: null,
+      useSafariVC: expectedUseWebView,
+      useWebView: expectedUseWebView,
+      enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
+      enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
+      universalLinksOnly: expectedUniversalLinksOnly,
+      headers: expectedWebViewConfiguration.headers,
+      webOnlyWindowName: expectedWebOnlyWindowName,
     ));
   }
 }


### PR DESCRIPTION
Unblocks the CI:
```
ubuntu_wizard:
Analyzing ubuntu_wizard...                                      

   info • 'canLaunch' is deprecated and shouldn't be used. Use canLaunchUrl instead • lib/src/utils/url_launcher.dart:14:16 • deprecated_member_use
   info • 'launch' is deprecated and shouldn't be used. Use launchUrl instead • lib/src/utils/url_launcher.dart:19:12 • deprecated_member_use

2 issues found. (ran in 4.7s)
```