### PR TITLE
Sort out the mixture of effective_dart and flutter_lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:effective_dart/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   exclude:
@@ -11,6 +11,6 @@ linter:
   rules:
     constant_identifier_names: false
     lines_longer_than_80_chars: false
-    # prefer_const_constructors: true
+    prefer_const_constructors: false # TODO: enable
     public_member_api_docs: false
     sort_pub_dependencies: true

--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -25,6 +25,8 @@ class SubiquityException implements Exception {
   final String method;
   final int statusCode;
   final String message;
+
+  @override
   String toString() => '$method returned error $statusCode\n$message';
 }
 

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.1
-  effective_dart: ^1.3.1
+  flutter_lints: ^1.0.0
   freezed: ^0.14.1
   json_serializable: ^4.1.1
   mockito: ^5.0.14

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -7,7 +7,6 @@ import 'package:test/test.dart';
 void main() {
   late SubiquityServer _testServer;
   late SubiquityClient _client;
-  var _socketPath;
 
   test('initialization', () async {
     final client = SubiquityClient();
@@ -21,7 +20,7 @@ void main() {
     setUpAll(() async {
       _testServer = SubiquityServer();
       _client = SubiquityClient();
-      _socketPath = await _testServer.start(ServerMode.DRY_RUN, args: [
+      final socketPath = await _testServer.start(ServerMode.DRY_RUN, args: [
         '--machine-config',
         'examples/simple.json',
         '--source-catalog',
@@ -29,7 +28,7 @@ void main() {
         '--bootloader',
         'uefi',
       ]);
-      _client.open(_socketPath);
+      _client.open(socketPath);
     });
 
     tearDownAll(() async {
@@ -441,8 +440,8 @@ void main() {
     setUpAll(() async {
       _testServer = SubiquityServer.wsl();
       _client = SubiquityClient();
-      _socketPath = await _testServer.start(ServerMode.DRY_RUN);
-      _client.open(_socketPath);
+      final socketPath = await _testServer.start(ServerMode.DRY_RUN);
+      _client.open(socketPath);
     });
 
     tearDownAll(() async {

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -26,6 +26,7 @@ class PartitionFormat {
   /// The type of the partition format (e.g. 'ext4').
   final String type;
 
+  @override
   String toString() => type;
 
   static const btrfs = PartitionFormat._('btrfs');

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -12,7 +12,7 @@ import 'storage_columns.dart';
 import 'storage_table.dart';
 
 class PartitionBar extends StatelessWidget {
-  PartitionBar({Key? key}) : super(key: key);
+  const PartitionBar({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
@@ -9,6 +9,9 @@ import 'configure_secure_boot_model.dart';
 import 'configure_secure_boot_widgets.dart';
 
 class ConfigureSecureBootPage extends StatefulWidget {
+  @visibleForTesting
+  const ConfigureSecureBootPage({Key? key}) : super(key: key);
+
   @override
   _ConfigureSecureBootPageState createState() =>
       _ConfigureSecureBootPageState();

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
@@ -98,6 +98,7 @@ class ConnectToInternetModel extends SafeChangeNotifier
     }
   }
 
+  @override
   Future<void> cleanup() async {
     for (final model in _connectModels.values) {
       await model.cleanup();

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
@@ -95,6 +95,8 @@ abstract class NetworkModel<T extends NetworkDevice>
 
   bool? _wasEnabled;
   bool? _hadActiveConnection;
+
+  @override
   Stream get onAvailabilityChanged => _onAvailable.stream;
   final _onAvailable = StreamController();
 

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_model.dart
@@ -297,7 +297,7 @@ class WifiDevice extends NetworkDevice {
     _setLastScan(wireless?.lastScan ?? -1);
     _setScanning(false);
     if (_completer?.isCompleted == false) {
-      _completer!.complete(device);
+      _completer!.complete();
     }
     _completer = null;
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -94,6 +94,7 @@ class InstallationSlidesModel extends ChangeNotifier with SystemShutdown {
   }
 
   /// Requests an immediate system reboot.
+  @override
   Future<void> reboot({bool immediate = true}) {
     return super.reboot(immediate: immediate);
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -47,7 +47,7 @@ class TryOrInstallModel extends ChangeNotifier {
             .readAsLinesSync()
             .firstWhere((line) => line.trim().isNotEmpty);
         return url.replaceAll(r'${LANG}', locale.languageCode);
-        // ignore: avoid_catches_without_on_clauses
+        // ignore: empty_catches
       } catch (e) {}
     }
     try {

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -11,6 +11,9 @@ import '../../services.dart';
 import 'turn_off_bitlocker_model.dart';
 
 class TurnOffBitLockerPage extends StatelessWidget {
+  @visibleForTesting
+  const TurnOffBitLockerPage({Key? key}) : super(key: key);
+
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();
     return Provider(

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -12,6 +12,9 @@ import '../../services.dart';
 import 'updates_other_software_model.dart';
 
 class UpdatesOtherSoftwarePage extends StatefulWidget {
+  @visibleForTesting
+  const UpdatesOtherSoftwarePage({Key? key}) : super(key: key);
+
   @override
   _UpdatesOtherSoftwarePageState createState() =>
       _UpdatesOtherSoftwarePageState();

--- a/packages/ubuntu_desktop_installer/lib/slides/slide_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/slides/slide_widgets.dart
@@ -16,7 +16,7 @@ class Slide {
 /// Provides access to the slides in the current context.
 class SlidesContext extends InheritedWidget {
   /// Creates an inherited slide widget with the specified slides.
-  SlidesContext({
+  const SlidesContext({
     Key? key,
     required this.slides,
     required Widget child,

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -53,8 +53,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.5
-  effective_dart: ^1.3.1
   fake_async: ^1.2.0
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
@@ -59,7 +59,7 @@ void main() {
     return MaterialApp(
       home: StorageTable(
         columns: columns,
-        storages: [sda, sdb, sdc, sdd],
+        storages: const [sda, sdb, sdc, sdd],
         canSelect: canSelect,
         isSelected: isSelected,
         onSelected: onSelected,

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.dart
@@ -342,7 +342,7 @@ void main() {
   });
 
   test('enable', () async {
-    when(service.setWirelessEnabled(true)).thenAnswer((_) async => null);
+    when(service.setWirelessEnabled(true)).thenAnswer((_) async {});
 
     model.enable();
     verify(service.setWirelessEnabled(true)).called(1);

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_widgets_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_widgets_test.dart
@@ -13,7 +13,7 @@ void main() {
     await tester.pumpWidget(
       tester.buildApp(
         (_) => DetectKeyboardLayoutView(
-          pressKey: ['x', 'y', 'z'],
+          pressKey: const ['x', 'y', 'z'],
           onKeyPress: (code) => keyPress = code,
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_model_test.dart
@@ -55,7 +55,7 @@ void main() {
 
   test('set locale', () {
     final client = MockSubiquityClient();
-    when(client.setLocale('fr_CA.UTF-8')).thenAnswer((_) async => null);
+    when(client.setLocale('fr_CA.UTF-8')).thenAnswer((_) async {});
 
     final model = WelcomeModel(client);
     model.applyLocale(Locale('fr', 'CA'));

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_model_test.dart
@@ -34,8 +34,8 @@ void main() {
     final location = GeoLocation(timezone: 'Europe/Oslo');
 
     final client = MockSubiquityClient();
-    when(client.setTimezone('geoip')).thenAnswer((_) async => null);
-    when(client.setTimezone(location.timezone)).thenAnswer((_) async => null);
+    when(client.setTimezone('geoip')).thenAnswer((_) async {});
+    when(client.setTimezone(location.timezone)).thenAnswer((_) async {});
     final service = MockGeoService();
 
     final model = WhereAreYouModel(client: client, service: service);

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
@@ -90,7 +90,7 @@ void main() {
 
     final model = buildModel();
     when(model.searchLocation('b')).thenAnswer((_) async => locations);
-    when(model.selectLocation(GeoLocation())).thenReturn((_) {});
+    when(model.selectLocation(GeoLocation())).thenAnswer((_) {});
 
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -120,7 +120,7 @@ void main() {
 
     final model = buildModel();
     when(model.searchTimezone('b')).thenAnswer((_) async => timezones);
-    when(model.selectTimezone(GeoLocation())).thenReturn((_) {});
+    when(model.selectTimezone(GeoLocation())).thenAnswer((_) {});
 
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   build_runner: ^2.1.1
-  effective_dart: ^1.3.1
   flutter:
     sdk: flutter
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   gsettings: ^0.2.0

--- a/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/product_info_extractor.dart
@@ -37,10 +37,12 @@ class ProductInfoExtractor {
 
     try {
       _cachedProductInfo ??= _extractIsoInfo(_fileSystem.file(isoPath));
+      // ignore: empty_catches
     } on Exception {}
 
     try {
       _cachedProductInfo ??= _extractLocalInfo(_fileSystem.file(localPath));
+      // ignore: empty_catches
     } on Exception {}
 
     _cachedProductInfo ??= ProductInfo(name: 'Ubuntu');

--- a/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
@@ -63,7 +63,7 @@ class FlavorData {
 /// Provides access to the flavor data in the current context.
 class Flavor extends InheritedWidget {
   /// Creates an inherited flavor widget with the specified flavor data.
-  Flavor({
+  const Flavor({
     Key? key,
     required this.data,
     required Widget child,

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.5
-  effective_dart: ^1.3.2
   flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter

--- a/packages/ubuntu_wizard/test/form_layout_test.dart
+++ b/packages/ubuntu_wizard/test/form_layout_test.dart
@@ -14,7 +14,7 @@ void main() {
         child: FormLayout(
           rowSpacing: 10,
           columnSpacing: 20,
-          rows: [
+          rows: const [
             [
               SizedBox(key: Key('r0c0'), width: 100, height: 10),
               SizedBox(key: Key('r0c1'), width: 200, height: 10),

--- a/packages/ubuntu_wizard/test/product_info_extractor_test.dart
+++ b/packages/ubuntu_wizard/test/product_info_extractor_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
 
     test('should return product info when iso file exists', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -31,7 +31,7 @@ void main() {
 
     test('should return product info from disk when iso file doesnt exists',
         () async {
-      final localPath = '/etc/os-release';
+      const localPath = '/etc/os-release';
 
       await fileSystem.file(localPath).create(recursive: true).then((f) {
         f.writeAsString('''
@@ -68,7 +68,7 @@ UBUNTU_CODENAME=hirsute
     });
 
     test('should return product info with LTS when iso file exists', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -84,7 +84,7 @@ UBUNTU_CODENAME=hirsute
 
     test('should return product info LTS from disk when iso file doesnt exists',
         () async {
-      final localPath = '/etc/os-release';
+      const localPath = '/etc/os-release';
 
       await fileSystem.file(localPath).create(recursive: true).then((f) {
         f.writeAsString('''
@@ -112,7 +112,7 @@ UBUNTU_CODENAME=focal
     });
 
     test('should return product info for kubuntu', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -127,7 +127,7 @@ UBUNTU_CODENAME=focal
     });
 
     test('should return product info for kubuntu', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -142,7 +142,7 @@ UBUNTU_CODENAME=focal
     });
 
     test('should return product info for ubuntu mate', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -157,7 +157,7 @@ UBUNTU_CODENAME=focal
     });
 
     test('should cache product info', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
@@ -179,7 +179,7 @@ UBUNTU_CODENAME=focal
     });
 
     test('should reset cache when paramter is passed', () async {
-      final isoPath = '/cdrom/.disk/info';
+      const isoPath = '/cdrom/.disk/info';
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(

--- a/packages/ubuntu_wizard/test/settings_test.dart
+++ b/packages/ubuntu_wizard/test/settings_test.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_wizard/settings.dart';
 void main() {
   test('set gtk-theme via gsettings', () {
     final gsettings = MockGSettings();
-    when(gsettings.set(any, any)).thenAnswer((_) async => null);
+    when(gsettings.set(any, any)).thenAnswer((_) async {});
 
     final settings = Settings(gsettings);
 

--- a/packages/ubuntu_wizard/test/system_shutdown_test.dart
+++ b/packages/ubuntu_wizard/test/system_shutdown_test.dart
@@ -10,6 +10,7 @@ typedef SystemShutdownTester = Future<void> Function(SystemShutdown system);
 class TestSystemShutdown with SystemShutdown {
   TestSystemShutdown(this.client);
 
+  @override
   final SubiquityClient client;
 }
 

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -32,9 +32,9 @@ void main() {
           header: const Text('header'),
           content: const Text('content'),
           footer: const Text('footer'),
-          actions: <WizardAction>[
-            const WizardAction(label: 'back'),
-            const WizardAction(label: 'next'),
+          actions: const <WizardAction>[
+            WizardAction(label: 'back'),
+            WizardAction(label: 'next'),
           ],
         ),
       ),
@@ -64,8 +64,8 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: <WizardAction>[
-            const WizardAction(label: 'action', highlighted: false),
+          actions: const <WizardAction>[
+            WizardAction(label: 'action', highlighted: false),
           ],
         ),
       ),
@@ -76,8 +76,8 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: <WizardAction>[
-            const WizardAction(label: 'action', highlighted: true),
+          actions: const <WizardAction>[
+            WizardAction(label: 'action', highlighted: true),
           ],
         ),
       ),
@@ -114,7 +114,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: <WizardAction>[
+          actions: const <WizardAction>[
             WizardAction(label: 'action', visible: false),
           ],
         ),

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -55,11 +55,11 @@ class UbuntuWslReconfigureWizard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Wizard(
       initialRoute: initialRoute ?? Routes.advancedSetup,
-      routes: <String, WizardRoute>{
-        Routes.advancedSetup: const WizardRoute(
+      routes: const <String, WizardRoute>{
+        Routes.advancedSetup: WizardRoute(
           builder: AdvancedSetupPage.create,
         ),
-        Routes.configurationUI: const WizardRoute(
+        Routes.configurationUI: WizardRoute(
           builder: ConfigurationUIPage.create,
         ),
       },

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.1
   diacritic: ^0.1.3
-  effective_dart: ^1.3.2
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/udev/pubspec.yaml
+++ b/packages/udev/pubspec.yaml
@@ -10,6 +10,6 @@ dependencies:
   ffi: ^1.0.0
 
 dev_dependencies:
-  effective_dart: ^1.3.1
   ffigen: ^2.4.2
+  flutter_lints: ^1.0.0
   test: ^1.17.7

--- a/packages/udev/test/udev_test.dart
+++ b/packages/udev/test/udev_test.dart
@@ -118,12 +118,14 @@ class FakeLibudev implements Libudev {
   Pointer<udev>? _udev;
   Pointer<udev_device>? _udev_device;
 
+  @override
   Pointer<udev> udev_new() {
     calls.add('udev_new');
     arguments.add([]);
     return _udev ??= 'udev'.toNativeUtf8().cast();
   }
 
+  @override
   Pointer<udev> udev_unref(Pointer<udev> udev) {
     calls.add('udev_unref');
     arguments.add([udev]);
@@ -131,6 +133,7 @@ class FakeLibudev implements Libudev {
     return nullptr;
   }
 
+  @override
   Pointer<udev_device> udev_device_unref(Pointer<udev_device> udev_device) {
     calls.add('udev_device_unref');
     arguments.add([udev_device]);
@@ -138,6 +141,7 @@ class FakeLibudev implements Libudev {
     return nullptr;
   }
 
+  @override
   Pointer<udev_device> udev_device_new_from_subsystem_sysname(
     Pointer<udev> udev,
     Pointer<Int8> subsystem,
@@ -152,6 +156,7 @@ class FakeLibudev implements Libudev {
     return _udev_device ??= 'udev_device'.toNativeUtf8().cast();
   }
 
+  @override
   Pointer<udev_device> udev_device_new_from_syspath(
     Pointer<udev> udev,
     Pointer<Int8> syspath,
@@ -161,6 +166,7 @@ class FakeLibudev implements Libudev {
     return _udev_device ??= 'udev_device'.toNativeUtf8().cast();
   }
 
+  @override
   Pointer<Int8> udev_device_get_property_value(
     Pointer<udev_device> udev_device,
     Pointer<Int8> key,


### PR DESCRIPTION
Finish the move from the deprecated effective_dart rules to the
recommended flutter_lints by removing any remaining references to the
former.

NOTE: The `prefer_const_constructors` rule was explicitly disabled in
the process because the fix gets so noisy that it's better to fix it
separately.