### PR TITLE
Update subiquity

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 8c13139961b9decc23a57f2f515f5248a21e1b06
+    source-commit: b49f5b1505d6597a5c64e3220bb45a291d9a78f7
     build-packages:
       - shared-mime-info
       - zlib1g-dev


### PR DESCRIPTION
The first Subiquity update after enabling [integration tests in the CI](https://github.com/canonical/ubuntu-desktop-installer/pull/730).