### PR TITLE
WSL: show "applying changes..." at the end of reconfiguration

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -93,7 +93,8 @@ void main() {
         automountMountfstab: false,
       ),
     );
-    await tester.pumpAndSettle();
+
+    await testApplyingChangesPage(tester, expectClose: true);
 
     await verifyConfigFile('reconfiguration/wsl.conf');
   });
@@ -180,8 +181,16 @@ Future<void> testAdvancedSetupPage(
   await tester.tapButton(label: tester.lang.setupButton, highlighted: true);
 }
 
-Future<void> testApplyingChangesPage(WidgetTester tester) async {
+Future<void> testApplyingChangesPage(
+  WidgetTester tester, {
+  bool expectClose = false,
+}) async {
   expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
+
+  if (expectClose) {
+    final windowClosed = waitForWindowClosed();
+    expect(windowClosed, completion(isTrue));
+  }
 }
 
 Future<void> testConfigurationUIPage(
@@ -208,9 +217,7 @@ Future<void> testConfigurationUIPage(
   );
   await tester.pumpAndSettle();
 
-  final windowClosed = waitForWindowClosed();
   await tester.tapButton(label: tester.lang.saveButton, highlighted: true);
-  expect(windowClosed, completion(isTrue));
 }
 
 Future<void> testSetupCompletePage(

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/services.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n/app_localizations.dart';
@@ -37,7 +38,13 @@ class _ApplyingChangesPageState extends State<ApplyingChangesPage> {
   void initState() {
     super.initState();
     final model = Provider.of<ApplyingChangesModel>(context, listen: false);
-    model.init(onDoneTransition: Wizard.of(context).next);
+    model.init(onDoneTransition: () {
+      if (Wizard.of(context).hasNext) {
+        Wizard.of(context).next();
+      } else {
+        closeWindow();
+      }
+    });
   }
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_wizard/utils.dart';
 
 /// Implements the business logic of the WSL Configuration UI page.
 ///
@@ -52,8 +51,6 @@ class ConfigurationUIModel extends ChangeNotifier {
 
   /// Saves the UI configuration.
   Future<void> saveConfiguration() async {
-    return _client
-        .setWslConfigurationAdvanced(_conf.value)
-        .then((_) => closeWindow());
+    return _client.setWslConfigurationAdvanced(_conf.value);
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -97,7 +97,10 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
           highlighted: true,
           label: lang.saveButton,
           enabled: model.isValid,
-          onActivated: model.saveConfiguration,
+          onActivated: () {
+            model.saveConfiguration();
+            Wizard.of(context).next();
+          },
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -62,6 +62,9 @@ class UbuntuWslReconfigureWizard extends StatelessWidget {
         Routes.configurationUI: WizardRoute(
           builder: ConfigurationUIPage.create,
         ),
+        Routes.applyingChanges: WizardRoute(
+          builder: ApplyingChangesPage.create,
+        ),
       },
     );
   }

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -29,8 +28,6 @@ void main() {
   });
 
   test('save UI configuration', () async {
-    TestWidgetsFlutterBinding.ensureInitialized();
-
     final client = MockSubiquityClient();
 
     final model = ConfigurationUIModel(client);
@@ -46,16 +43,8 @@ void main() {
       automountMountfstab: false,
     );
 
-    var windowClosed = false;
-    final methodChannel = MethodChannel('ubuntu_wizard');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('closeWindow'));
-      windowClosed = true;
-    });
-
     await model.saveConfiguration();
     verify(client.setWslConfigurationAdvanced(conf)).called(1);
-    expect(windowClosed, isTrue);
   });
 
   test('notify changes', () {


### PR DESCRIPTION
Same as #786 but for reconfiguration mode.

This solves the issue found by the integration tests that Subiquity
would get killed before it was done with writing the config.