### PR TITLE
Temporarily disables the profile page hyperlink.

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -48,13 +48,19 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<ProfileSetupModel>(context);
+    final textColor = Theme.of(context).textTheme.bodyText2!.color;
     return WizardPage(
       contentPadding: EdgeInsets.zero,
       title: Text(lang.profileSetupTitle),
-      header: Html(
-        data: lang.profileSetupHeader,
-        style: {'body': Style(margin: EdgeInsets.zero)},
-        onLinkTap: (url, _, __, ___) => launchUrl(url!),
+      header: AbsorbPointer(
+        child: Html(
+          data: lang.profileSetupHeader,
+          style: {
+            'body': Style(margin: EdgeInsets.zero),
+            'a': Style(textDecoration: TextDecoration.none, color: textColor),
+          },
+          onLinkTap: (url, _, __, ___) => launchUrl(url!),
+        ),
       ),
       content: LayoutBuilder(builder: (context, constraints) {
         final fieldPadding = EdgeInsets.symmetric(

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -210,7 +210,7 @@ void main() {
     verify(model.saveProfileSetup()).called(1);
   });
 
-  testWidgets('click link', (tester) async {
+  testWidgets('click link currently disabled', (tester) async {
     const url = 'https://aka.ms/wslusers';
     final urlLauncher = MockUrlLauncher();
     when(urlLauncher.launchUrl(url)).thenAnswer((_) async => true);
@@ -219,8 +219,8 @@ void main() {
     await tester.pumpWidget(buildApp(tester, buildModel()));
 
     expect(find.byType(Html), findsOneWidget);
-    await tester.tap(find.byType(Html));
-    verify(urlLauncher.launchUrl(url)).called(1);
+    await tester.tap(find.byType(Html), warnIfMissed: false);
+    verifyNever(urlLauncher.launchUrl(url));
   });
 
   testWidgets('creates a model', (tester) async {


### PR DESCRIPTION
That hyperlink renders and reacts correclty but there are no browsers available at the context where user would click the link, so it fails to launch the webpage. I took an approach that favors easily roll back in part to avoid translators to spend time reworking he strings, but also because we expect to make it work soon.

Here is how it looks like with the proposed changes:

![image](https://user-images.githubusercontent.com/11138291/166558551-2d846728-6a0d-4db9-85ef-f0b234a5307f.png)


This closes https://github.com/ubuntu/WSL/issues/173.