### PR TITLE
Prevents UI to translate itself for languages lacking font support in WSL

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
@@ -1,10 +1,57 @@
 import 'dart:ui';
 
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 import '../../l10n.dart';
+
+const kDefaultLocale = Locale('en', 'US');
+// Languages we won't invest in shipping fonts for just yet.
+// They lack translations anyway, so fonts will not be missed at this point.
+// If users select one of those, we will submit it to Subiquity, but won't
+// update the UI.
+const _languagesLackingFontSupport = {
+  'am': 'Amharic',
+  'ar': 'Arabic',
+  'bn': 'Bangla',
+  'bo': 'Tibetan',
+  'dz': 'Dzongkha',
+  'fa': 'Persian',
+  'gu': 'Gujarati',
+  'he': 'Hebrew',
+  'hi': 'Hindi',
+  'ja': 'Japanese',
+  'ka': 'Georgian',
+  'km': 'Khmer',
+  'kn': 'Kannada',
+  'ko': 'Korean',
+  'lo': 'Lao',
+  'ml': 'Malayalam',
+  'mr': 'Marathi',
+  'my': 'Burmese',
+  'ne': 'Nepali',
+  'pa': 'Punjabi',
+  'si': 'Sinhala',
+  'ta': 'Tamil',
+  'te': 'Telugu',
+  'th': 'Thai',
+  'ug': 'Uyghur',
+  'vi': 'Vietnamese',
+  'zh': 'Chinese',
+};
+
+extension XDisplayName on LocalizedLanguage {
+  String displayName() {
+    final langCode = locale.languageCode;
+    final altName = _languagesLackingFontSupport[langCode];
+    if (altName != null) {
+      return altName;
+    }
+    return name;
+  }
+}
 
 /// View model for [SelectLanguagePage].
 class SelectLanguageModel extends ChangeNotifier {
@@ -26,13 +73,27 @@ class SelectLanguageModel extends ChangeNotifier {
 
   /// Loads available languages.
   Future<void> loadLanguages() async {
-    return loadLocalizedLanguages(supportedLocales)
-        .then((languages) => _languages = languages)
-        .then((_) => notifyListeners());
+    return loadLocalizedLanguages(supportedLocales).then((languages) {
+      _languages = languages;
+      _languages.sort((a, b) => removeDiacritics(a.displayName())
+          .compareTo(removeDiacritics(b.displayName())));
+    }).then((_) => notifyListeners());
   }
 
   /// Returns the locale for the given language [index].
   Locale locale(int index) => _languages[index].locale;
+
+  /// Returns the appropriate locale for the given language [index] considering
+  /// that the referred language might lack font support, for which case we
+  /// return the default locale to avoid issues in the UI.
+  Locale uiLocale(int index) {
+    final lang = _languages[index].locale.languageCode;
+    final altName = _languagesLackingFontSupport[lang];
+    if (altName != null) {
+      return kDefaultLocale;
+    }
+    return _languages[index].locale;
+  }
 
   /// Applies the given [locale].
   Future<void> applyLocale(Locale locale) {
@@ -44,7 +105,9 @@ class SelectLanguageModel extends ChangeNotifier {
   int get languageCount => _languages.length;
 
   /// Returns the name of the language at the given [index].
-  String language(int index) => _languages[index].name;
+  /// To avoid issues with the UI in WSL, the international name of
+  /// the language is returned in case it's blacklisted.
+  String language(int index) => _languages[index].displayName();
 
   /// Selects the given [locale].
   void selectLocale(Locale locale) {

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -77,7 +77,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
                 onTap: () {
                   model.selectedLanguageIndex = index;
                   final settings = Settings.of(context, listen: false);
-                  settings.applyLocale(model.locale(index));
+                  settings.applyLocale(model.uiLocale(index));
                 },
               ),
             );

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -81,25 +81,15 @@ void main() {
     final model = SelectLanguageModel(MockSubiquityClient());
     await model.loadLanguages();
     final languages = List.generate(model.languageCount, model.language);
-    var blacklisted = 'Uyghur';
-    var index = languages.indexOf(blacklisted);
-    var loc = model.uiLocale(index);
-    expect(loc, kDefaultLocale);
-    blacklisted = 'Sinhala';
-    index = languages.indexOf(blacklisted);
-    loc = model.uiLocale(index);
-    expect(loc, kDefaultLocale);
+    expect(model.uiLocale(languages.indexOf('Uyghur')), kDefaultLocale);
+    expect(model.uiLocale(languages.indexOf('Sinhala')), kDefaultLocale);
   });
 
   test('language wont return unsupported chars', () async {
     final model = SelectLanguageModel(MockSubiquityClient());
     await model.loadLanguages();
     final languages = List.generate(model.languageCount, model.language);
-    var blacklisted = '\u{0626}';
-    var index = languages.indexWhere((lang) => lang.contains(blacklisted));
-    expect(index, -1);
-    blacklisted = '\u{0DC3}';
-    index = languages.indexWhere((element) => element.contains(blacklisted));
-    expect(index, -1);
+    expect(languages.any((e) => e.contains('\u{0626}')), isFalse);
+    expect(languages.any((e) => e.contains('\u{0DC3}')), isFalse);
   });
 }

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -76,4 +76,30 @@ void main() {
     expect(model.selectedLanguageIndex, equals(1));
     expect(wasNotified, isTrue);
   });
+
+  test('uiLocale returns default for unsupported langs', () async {
+    final model = SelectLanguageModel(MockSubiquityClient());
+    await model.loadLanguages();
+    final languages = List.generate(model.languageCount, model.language);
+    var blacklisted = 'Uyghur';
+    var index = languages.indexOf(blacklisted);
+    var loc = model.uiLocale(index);
+    expect(loc, kDefaultLocale);
+    blacklisted = 'Sinhala';
+    index = languages.indexOf(blacklisted);
+    loc = model.uiLocale(index);
+    expect(loc, kDefaultLocale);
+  });
+
+  test('language wont return unsupported chars', () async {
+    final model = SelectLanguageModel(MockSubiquityClient());
+    await model.loadLanguages();
+    final languages = List.generate(model.languageCount, model.language);
+    var blacklisted = '\u{0626}';
+    var index = languages.indexWhere((lang) => lang.contains(blacklisted));
+    expect(index, -1);
+    blacklisted = '\u{0DC3}';
+    index = languages.indexWhere((element) => element.contains(blacklisted));
+    expect(index, -1);
+  });
 }

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -24,10 +24,13 @@ void main() {
     when(model.languageCount).thenReturn(3);
     when(model.language(0)).thenReturn('English');
     when(model.locale(0)).thenReturn(Locale('en_US'));
+    when(model.uiLocale(0)).thenReturn(Locale('en_US'));
     when(model.language(1)).thenReturn('French');
     when(model.locale(1)).thenReturn(Locale('fr_FR'));
+    when(model.uiLocale(1)).thenReturn(Locale('fr_FR'));
     when(model.language(2)).thenReturn('German');
     when(model.locale(2)).thenReturn(Locale('de_DE'));
+    when(model.uiLocale(2)).thenReturn(Locale('de_DE'));
     when(model.selectedLanguageIndex).thenReturn(1);
     when(model.getServerLocale()).thenAnswer((_) async => Locale('fr', 'FR'));
     return model;

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
@@ -58,6 +58,10 @@ class MockSelectLanguageModel extends _i1.Mock
       (super.noSuchMethod(Invocation.method(#locale, [index]),
           returnValue: _FakeLocale_0()) as _i2.Locale);
   @override
+  _i2.Locale uiLocale(int? index) =>
+      (super.noSuchMethod(Invocation.method(#uiLocale, [index]),
+          returnValue: _FakeLocale_0()) as _i2.Locale);
+  @override
   _i4.Future<void> applyLocale(_i2.Locale? locale) =>
       (super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
           returnValue: Future<void>.value(),


### PR DESCRIPTION
There are a couple of languges that require adding specific font packages to better support them for WSL. Unfortunately we didn't detect it earlier and the lack of such fonts is causing issues to users. Adding the required fonts will increase too much the image size, so the short term approach is to prevent the UI from translating itself into any of those languages. They will still show up in the "Select your language" page and selecting any of those will still be meaningfull for Subiquity, so they must be preserved.

With the following changes we go from this (notice the first line and last two):
![image](https://user-images.githubusercontent.com/11138291/168172248-2e89b58e-97a9-4ce9-9a5b-53ff49c853f0.png)

into this:
![image](https://user-images.githubusercontent.com/11138291/168172232-676c42d9-769d-44b7-81a5-ae6b340faba4.png)

This closes https://github.com/ubuntu/WSL/issues/172