### PR TITLE
Use SafeChangeNotifier for all view models

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -86,7 +86,7 @@ enum PartitionLocation {
 }
 
 /// View model for [AllocateDiskSpacePage].
-class AllocateDiskSpaceModel extends ChangeNotifier {
+class AllocateDiskSpaceModel extends SafeChangeNotifier {
   /// Creates a new model with the given disk storage service.
   AllocateDiskSpaceModel(this._service);
 

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_model.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 /// View model for [ChooseSecurityKeyPage].
-class ChooseSecurityKeyModel extends ChangeNotifier {
+class ChooseSecurityKeyModel extends SafeChangeNotifier {
   /// Creates the model with the given client.
   ChooseSecurityKeyModel(this._client) {
     Listenable.merge([

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_model.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 
 enum SecureBootMode { turnOff, dontInstall }
 
-class ConfigureSecureBootModel extends ChangeNotifier {
+class ConfigureSecureBootModel extends SafeChangeNotifier {
   ConfigureSecureBootModel({
     required SecureBootMode secureBootMode,
   }) : _mode = secureBootMode;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p;
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -10,7 +11,7 @@ import '../../services.dart';
 export 'package:subiquity_client/subiquity_client.dart' show ApplicationState;
 
 /// View model for [InstallationSlidesPage].
-class InstallationSlidesModel extends ChangeNotifier with SystemShutdown {
+class InstallationSlidesModel extends SafeChangeNotifier with SystemShutdown {
   /// Creates an instance with the given client.
   InstallationSlidesModel(this.client, this._journal);
 

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -32,7 +32,7 @@ enum AdvancedFeature {
 }
 
 /// View model for [InstallationTypePage].
-class InstallationTypeModel extends ChangeNotifier {
+class InstallationTypeModel extends SafeChangeNotifier {
   /// Creates a new model with the given client and service.
   InstallationTypeModel(
       this._client, this._diskService, this._telemetryService);

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -11,7 +11,7 @@ import '../../services.dart';
 final log = Logger('keyboard_layout');
 
 /// Implements the business logic of the Keyboard Layout page.
-class KeyboardLayoutModel extends ChangeNotifier {
+class KeyboardLayoutModel extends SafeChangeNotifier {
   /// Creates a model with the specified [client] and [keyboardService].
   KeyboardLayoutModel({
     required SubiquityClient client,

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -7,7 +7,7 @@ import '../../services.dart';
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 
 /// View model for [SelectGuidedStoragePage].
-class SelectGuidedStorageModel extends ChangeNotifier {
+class SelectGuidedStorageModel extends SafeChangeNotifier {
   /// Creates a new model with the given service.
   SelectGuidedStorageModel(this._service);
 

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -1,6 +1,7 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal
@@ -22,7 +23,7 @@ enum Option {
 }
 
 /// Implements the business logic of the Try Or Install page.
-class TryOrInstallModel extends ChangeNotifier {
+class TryOrInstallModel extends SafeChangeNotifier {
   /// The currently selected option.
   Option get option => _option;
   Option _option = Option.none;

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
@@ -10,7 +10,7 @@ import '../../l10n.dart';
 final log = Logger('welcome');
 
 /// Implements the business logic of the welcome page.
-class WelcomeModel extends ChangeNotifier {
+class WelcomeModel extends SafeChangeNotifier {
   /// Creates a model with the specified [client].
   WelcomeModel(this._client);
 

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_model.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
@@ -7,7 +7,7 @@ import '../../services.dart';
 
 final log = Logger('where_are_you');
 
-class WhereAreYouModel extends ChangeNotifier {
+class WhereAreYouModel extends SafeChangeNotifier {
   WhereAreYouModel(
       {required SubiquityClient client, required GeoService service})
       : _client = client,

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -33,7 +34,7 @@ enum LoginStrategy {
 }
 
 /// [WhoAreYouPage]'s view model.
-class WhoAreYouModel extends ChangeNotifier {
+class WhoAreYouModel extends SafeChangeNotifier {
   /// Creates the model with the given client.
   WhoAreYouModel(this._client) {
     Listenable.merge([

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 import '../../services.dart';
@@ -6,7 +6,7 @@ import '../../services.dart';
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 
 /// View model for [WriteChangesToDiskPage].
-class WriteChangesToDiskModel extends ChangeNotifier {
+class WriteChangesToDiskModel extends SafeChangeNotifier {
   /// Creates a model with the given client and service.
   WriteChangesToDiskModel(this._client, this._service);
 

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
@@ -69,6 +69,10 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
           .noSuchMethod(Invocation.getter(#canReformatDisk), returnValue: false)
       as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -136,16 +140,16 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
   void removeListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
 }
 

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.mocks.dart
@@ -49,6 +49,10 @@ class MockChooseSecurityKeyModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -63,6 +67,10 @@ class MockChooseSecurityKeyModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -73,8 +81,4 @@ class MockChooseSecurityKeyModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -35,6 +35,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
       returnValue: _FakeLocale_0()) as _i2.Locale);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -47,6 +51,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
       super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
           returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i2.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -57,8 +65,4 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.mocks.dart
@@ -52,6 +52,10 @@ class MockConfigureSecureBootModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isConfirmationKeyValid),
           returnValue: false) as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -68,6 +72,10 @@ class MockConfigureSecureBootModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#setConfirmKey, [key]),
           returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i3.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -78,8 +86,4 @@ class MockConfigureSecureBootModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -66,6 +66,10 @@ class MockInstallationSlidesModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#journal),
           returnValue: Stream<String>.empty()) as _i4.Stream<String>);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -84,6 +88,10 @@ class MockInstallationSlidesModel extends _i1.Mock
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -94,10 +102,6 @@ class MockInstallationSlidesModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#shutdown, [], {#immediate: immediate}),

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -60,6 +60,10 @@ class MockInstallationTypeModel extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#encryption, encryption),
           returnValueForMissingStub: null);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -72,6 +76,10 @@ class MockInstallationTypeModel extends _i1.Mock
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -82,8 +90,4 @@ class MockInstallationTypeModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
@@ -59,6 +59,10 @@ class MockKeyboardLayoutModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -96,6 +100,10 @@ class MockKeyboardLayoutModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -106,10 +114,6 @@ class MockKeyboardLayoutModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }
 
 /// A class which mocks [KeyboardService].

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
@@ -38,6 +38,10 @@ class MockSelectGuidedStorageModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#selectedIndex), returnValue: 0)
           as int);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -61,6 +65,10 @@ class MockSelectGuidedStorageModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -71,8 +79,4 @@ class MockSelectGuidedStorageModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.mocks.dart
@@ -37,6 +37,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
       returnValue: _FakeLocale_0()) as _i2.Locale);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -49,6 +53,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
       super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
           returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i2.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -59,10 +67,6 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }
 
 /// A class which mocks [UrlLauncher].

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.mocks.dart
@@ -41,6 +41,10 @@ class MockWhereAreYouModel extends _i1.Mock implements _i2.WhereAreYouModel {
       (super.noSuchMethod(Invocation.getter(#timezones),
           returnValue: <_i3.GeoLocation>[]) as Iterable<_i3.GeoLocation>);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -73,6 +77,10 @@ class MockWhereAreYouModel extends _i1.Mock implements _i2.WhereAreYouModel {
                   Future<Iterable<_i3.GeoLocation>>.value(<_i3.GeoLocation>[]))
           as _i4.Future<Iterable<_i3.GeoLocation>>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -83,8 +91,4 @@ class MockWhereAreYouModel extends _i1.Mock implements _i2.WhereAreYouModel {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
@@ -93,6 +93,10 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
       super.noSuchMethod(Invocation.setter(#showPassword, value),
           returnValueForMissingStub: null);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -107,6 +111,10 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -117,8 +125,4 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
@@ -72,6 +72,10 @@ class MockWriteChangesToDiskModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i4.Disk>[])
           as List<_i4.Disk>);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -89,6 +93,10 @@ class MockWriteChangesToDiskModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -99,8 +107,4 @@ class MockWriteChangesToDiskModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wizard/lib/settings.dart
+++ b/packages/ubuntu_wizard/lib/settings.dart
@@ -2,9 +2,10 @@ import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:provider/provider.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 
 /// Provides access to application-wide settings.
-class Settings extends ChangeNotifier {
+class Settings extends SafeChangeNotifier {
   /// Creates an app settings instance using the given GSettings as a backend
   /// for storing the settings.
   Settings(this._gsettings);

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_model.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 /// Implements the business logic of the WSL Advanced Setup page.
-class AdvancedSetupModel extends ChangeNotifier {
+class AdvancedSetupModel extends SafeChangeNotifier {
   /// Creates an advanced setup model.
   AdvancedSetupModel(this._client) {
     _conf.addListener(notifyListeners);

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 import '../../installing_state.dart';
@@ -9,7 +10,7 @@ import '../../installing_state.dart';
 ///
 /// See also:
 ///  * [ApplyingChangesPage]
-class ApplyingChangesModel extends ChangeNotifier {
+class ApplyingChangesModel extends SafeChangeNotifier {
   /// Creates a model for the 'applying changes' page.
   ApplyingChangesModel(this._monitor);
 

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_model.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 /// Implements the business logic of the WSL Configuration UI page.
 ///
 /// See also:
 ///  * [ConfigurationUIPage]
-class ConfigurationUIModel extends ChangeNotifier {
+class ConfigurationUIModel extends SafeChangeNotifier {
   /// Creates a advanced setup model.
   ConfigurationUIModel(this._client) {
     _conf.addListener(notifyListeners);

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -8,7 +9,7 @@ import 'package:ubuntu_wizard/utils.dart';
 const kValidUsernamePattern = r'^[a-z][a-z0-9-_]*$';
 
 /// View model for [ProfileSetupPage].
-class ProfileSetupModel extends ChangeNotifier {
+class ProfileSetupModel extends SafeChangeNotifier {
   /// Creates a profile setup model.
   ProfileSetupModel(this._client) {
     Listenable.merge([

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:diacritic/diacritic.dart';
-import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -54,7 +54,7 @@ extension XDisplayName on LocalizedLanguage {
 }
 
 /// View model for [SelectLanguagePage].
-class SelectLanguageModel extends ChangeNotifier {
+class SelectLanguageModel extends SafeChangeNotifier {
   /// Creates a model with the specified client.
   SelectLanguageModel(this._client);
 

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 /// Implements the business logic of the WSL Setup complete page.
-class SetupCompleteModel extends ChangeNotifier with SystemShutdown {
+class SetupCompleteModel extends SafeChangeNotifier with SystemShutdown {
   /// Creates a setup complete model.
   SetupCompleteModel(this.client) {
     _identity.addListener(notifyListeners);

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter_html: ^2.1.1
   get_it: ^7.2.0
   provider: ^6.0.0
+  safe_change_notifier: ^0.1.0
   scroll_to_index: ^2.0.0
   ubuntu_localizations:
     git:

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.mocks.dart
@@ -65,6 +65,10 @@ class MockAdvancedSetupModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -79,6 +83,10 @@ class MockAdvancedSetupModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -89,8 +97,4 @@ class MockAdvancedSetupModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wsl_setup/test/app_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.mocks.dart
@@ -35,6 +35,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
       returnValue: _FakeLocale_0()) as _i2.Locale);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -47,6 +51,10 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
       super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
           returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i2.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -57,8 +65,4 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
@@ -28,6 +28,10 @@ class MockApplyingChangesModel extends _i1.Mock
   }
 
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -39,15 +43,15 @@ class MockApplyingChangesModel extends _i1.Mock
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i3.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
   void removeListener(_i3.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
@@ -65,6 +65,10 @@ class MockConfigurationUIModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -79,6 +83,10 @@ class MockConfigurationUIModel extends _i1.Mock
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -89,8 +97,4 @@ class MockConfigurationUIModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
@@ -77,6 +77,10 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -91,6 +95,10 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -101,10 +109,6 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }
 
 /// A class which mocks [UrlLauncher].

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
@@ -45,6 +45,10 @@ class MockSelectLanguageModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#languageCount), returnValue: 0)
           as int);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -80,6 +84,10 @@ class MockSelectLanguageModel extends _i1.Mock
               returnValue: Future<_i2.Locale>.value(_FakeLocale_0()))
           as _i4.Future<_i2.Locale>);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i2.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -90,10 +98,6 @@ class MockSelectLanguageModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }
 
 /// A class which mocks [Settings].
@@ -111,6 +115,10 @@ class MockSettings extends _i1.Mock implements _i5.Settings {
   _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
       returnValue: _FakeLocale_0()) as _i2.Locale);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -123,6 +131,10 @@ class MockSettings extends _i1.Mock implements _i5.Settings {
       super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
           returnValueForMissingStub: null);
   @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
   void addListener(_i2.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
@@ -133,8 +145,4 @@ class MockSettings extends _i1.Mock implements _i5.Settings {
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
@@ -40,6 +40,10 @@ class MockSetupCompleteModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#username), returnValue: '')
           as String);
   @override
+  bool get isDisposed =>
+      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
+          as bool);
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
@@ -47,6 +51,10 @@ class MockSetupCompleteModel extends _i1.Mock
   _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+  @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
   @override
   void addListener(_i5.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
@@ -58,10 +66,6 @@ class MockSetupCompleteModel extends _i1.Mock
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
-  @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
   @override
   _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),


### PR DESCRIPTION
[SafeChangeNotifier](https://pub.dev/packages/safe_change_notifier) was developed to protect from the common issue that
view models may get disposed while waiting for an async operation to
complete. Unlike the built-in ChangeNotifier that throws assertion
errors, SafeChangeNotifier handles the situation gracefully by simply
not notifying the listeners if called after disposal.

This change is motivated by an attempt to fix the recently disabled
`use_build_context_synchronously` lint failures.

P.S. SafeChangeNotifier is not a new dependency but is already used in the "connect the internet" module. :)