### PR TITLE
WSL: fix language list auto-scrolling

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -38,8 +38,6 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
       final settings = Settings.of(context, listen: false);
       model.selectLocale(settings.locale);
       model.getServerLocale().then((loc) {
-        if (loc == settings.locale) return;
-
         model.selectLocale(loc);
         settings.applyLocale(loc);
         _languageListScrollController.scrollToIndex(model.selectedLanguageIndex,


### PR DESCRIPTION
Auto-scrolling must be performed even if the server locale matches with
the UI locale. This issue was noticed because English no longer fits on
the screen by default.