### PR TITLE
Upgrade scroll_to_index

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   nm: ^0.4.3
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
-  scroll_to_index: ^2.0.0
+  scroll_to_index: ^3.0.0
   subiquity_client:
     path: ../subiquity_client
   ubuntu_localizations:

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   get_it: ^7.2.0
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
-  scroll_to_index: ^2.0.0
+  scroll_to_index: ^3.0.0
   ubuntu_localizations:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git


### PR DESCRIPTION
The latest scroll_to_index version 3.0.0 has adapted to the non-nullable
WidgetsBinding.instance API change in Flutter 3.0: https://github.com/quire-io/scroll-to-index/pull/93

There are still others left, but this gets rid of one of the following types of warnings:

```
../../../../../.pub-cache/hosted/pub.dartlang.org/scroll_to_index-2.1.1/lib/scroll_to_index.dart:358:57: Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which
excludes null.
 - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('../../../../../.fvm/versions/stable/packages/flutter/lib/src/scheduler/binding.dart').
  Future _waitForWidgetStateBuild() => SchedulerBinding.instance!.endOfFrame;
                                                        ^
```