### PR TITLE
Split wizard actions into two phases - activation & execution 

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -98,7 +98,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onActivated: () async {
+          onNext: () async {
             await model.setStorage();
             Wizard.of(context).next();
           },

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -98,10 +98,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onNext: () async {
-            await model.setStorage();
-            Wizard.of(context).next();
-          },
+          onNext: model.setStorage,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -84,7 +84,7 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
           context,
           enabled: context
               .select<ChooseSecurityKeyModel, bool>((model) => model.isValid),
-          onActivated: () async {
+          onNext: () async {
             final model =
                 Provider.of<ChooseSecurityKeyModel>(context, listen: false);
             await model.saveSecurityKey();

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -84,13 +84,7 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
           context,
           enabled: context
               .select<ChooseSecurityKeyModel, bool>((model) => model.isValid),
-          onNext: () async {
-            final model =
-                Provider.of<ChooseSecurityKeyModel>(context, listen: false);
-            await model.saveSecurityKey();
-
-            Wizard.of(context).next();
-          },
+          onNext: context.read<ChooseSecurityKeyModel>().saveSecurityKey,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
@@ -69,7 +69,6 @@ class _ConfigureSecureBootPageState extends State<ConfigureSecureBootPage> {
         WizardAction.next(
           context,
           enabled: model.isFormValid,
-          onActivated: Wizard.of(context).next,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -110,6 +110,8 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
             // suspend network activity when proceeding on the next page
             model.cleanup();
             await Wizard.of(context).next();
+          },
+          onBack: () async {
             // resume network activity if/when returning back to this page
             model.init();
           },

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -106,7 +106,7 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
           context,
           enabled: model.isEnabled && !model.isConnecting && model.isConnected,
           visible: !model.isEnabled || !model.canConnect,
-          onActivated: () async {
+          onNext: () async {
             // suspend network activity when proceeding on the next page
             model.cleanup();
             await Wizard.of(context).next();

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -106,15 +106,10 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
           context,
           enabled: model.isEnabled && !model.isConnecting && model.isConnected,
           visible: !model.isEnabled || !model.canConnect,
-          onNext: () async {
-            // suspend network activity when proceeding on the next page
-            model.cleanup();
-            await Wizard.of(context).next();
-          },
-          onBack: () async {
-            // resume network activity if/when returning back to this page
-            model.init();
-          },
+          // suspend network activity when proceeding on the next page
+          onNext: model.cleanup,
+          // resume network activity if/when returning back to this page
+          onBack: model.init,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -138,11 +138,8 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
-          onNext: () async {
-            await model.save();
-
-            Wizard.of(context).next(arguments: model.installationType);
-          },
+          arguments: model.installationType,
+          onNext: model.save,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -138,7 +138,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
-          onActivated: () async {
+          onNext: () async {
             await model.save();
 
             Wizard.of(context).next(arguments: model.installationType);

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -151,10 +151,7 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onNext: () async {
-            await model.applyKeyboardSettings();
-            Wizard.of(context).next();
-          },
+          onNext: model.applyKeyboardSettings,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -151,7 +151,7 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onActivated: () async {
+          onNext: () async {
             await model.applyKeyboardSettings();
             Wizard.of(context).next();
           },

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -123,13 +123,14 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
           onNext: () async {
             await model.saveGuidedStorage();
             await Wizard.of(context).next();
-
+          },
+          onBack: () async {
             // If the user returns back to select another disk, the previously
             // configured guided storage must be reset to avoid multiple disks
             // being configured for guided partitioning.
             await model.resetGuidedStorage();
           },
-        )
+        ),
       ],
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -120,16 +120,11 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
         WizardAction.next(
           context,
           label: lang.selectGuidedStorageInstallNow,
-          onNext: () async {
-            await model.saveGuidedStorage();
-            await Wizard.of(context).next();
-          },
-          onBack: () async {
-            // If the user returns back to select another disk, the previously
-            // configured guided storage must be reset to avoid multiple disks
-            // being configured for guided partitioning.
-            await model.resetGuidedStorage();
-          },
+          onNext: model.saveGuidedStorage,
+          // If the user returns back to select another disk, the previously
+          // configured guided storage must be reset to avoid multiple disks
+          // being configured for guided partitioning.
+          onBack: model.resetGuidedStorage,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -117,9 +117,10 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
       ),
       actions: <WizardAction>[
         WizardAction.back(context),
-        WizardAction(
+        WizardAction.next(
+          context,
           label: lang.selectGuidedStorageInstallNow,
-          onActivated: () async {
+          onNext: () async {
             await model.saveGuidedStorage();
             await Wizard.of(context).next();
 

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -78,7 +78,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
         WizardAction.next(
           context,
           enabled: model.option != Option.none,
-          onActivated: () => Wizard.of(context).next(arguments: model.option),
+          arguments: model.option,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -51,7 +51,7 @@ class TurnOffBitLockerPage extends StatelessWidget {
           context,
           label: lang.restartIntoWindows,
           highlighted: true,
-          onActivated: () async {
+          onDone: () async {
             await Wizard.of(context).done();
             model.reboot(immediate: true);
           },

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -47,7 +47,8 @@ class TurnOffBitLockerPage extends StatelessWidget {
       ),
       actions: [
         WizardAction.back(context),
-        WizardAction(
+        WizardAction.done(
+          context,
           label: lang.restartIntoWindows,
           highlighted: true,
           onActivated: () async {

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -51,10 +51,7 @@ class TurnOffBitLockerPage extends StatelessWidget {
           context,
           label: lang.restartIntoWindows,
           highlighted: true,
-          onDone: () async {
-            await Wizard.of(context).done();
-            model.reboot(immediate: true);
-          },
+          onDone: () => model.reboot(immediate: true),
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -55,7 +55,7 @@ class TurnOffRSTPage extends StatelessWidget {
             context,
             label: lang.restartButtonText,
             highlighted: true,
-            onActivated: () async {
+            onDone: () async {
               await Wizard.of(context).done();
               model.reboot(immediate: true);
             },

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -51,7 +51,8 @@ class TurnOffRSTPage extends StatelessWidget {
         ),
         actions: <WizardAction>[
           WizardAction.back(context),
-          WizardAction(
+          WizardAction.done(
+            context,
             label: lang.restartButtonText,
             highlighted: true,
             onActivated: () async {

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -55,10 +55,7 @@ class TurnOffRSTPage extends StatelessWidget {
             context,
             label: lang.restartButtonText,
             highlighted: true,
-            onDone: () async {
-              await Wizard.of(context).done();
-              model.reboot(immediate: true);
-            },
+            onDone: () => model.reboot(immediate: true),
           ),
         ],
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -99,7 +99,6 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
                 enabled: model.installationMode == InstallationMode.minimal);
             telemetry.setRestrictedAddons(enabled: model.installThirdParty);
             await model.selectInstallationSource();
-            Wizard.of(context).next();
           },
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -93,7 +93,7 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
-          onActivated: () async {
+          onNext: () async {
             final telemetry = getService<TelemetryService>();
             telemetry.setMinimal(
                 enabled: model.installationMode == InstallationMode.minimal);

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -102,7 +102,6 @@ class _WelcomePageState extends State<WelcomePage> {
             final locale = model.locale(model.selectedLanguageIndex);
             model.applyLocale(locale);
             getService<TelemetryService>().setLanguage(locale.languageCode);
-            Wizard.of(context).next();
           },
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -98,7 +98,7 @@ class _WelcomePageState extends State<WelcomePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
-          onActivated: () {
+          onNext: () {
             final locale = model.locale(model.selectedLanguageIndex);
             model.applyLocale(locale);
             getService<TelemetryService>().setLanguage(locale.languageCode);

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -124,7 +124,7 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
         ),
         WizardAction.next(
           context,
-          onActivated: () async {
+          onNext: () async {
             await model.save();
             await Wizard.of(context).next();
           },

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -124,10 +124,7 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
         ),
         WizardAction.next(
           context,
-          onNext: () async {
-            await model.save();
-            await Wizard.of(context).next();
-          },
+          onNext: model.save,
         )
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -102,7 +102,7 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
           context,
           enabled:
               context.select<WhoAreYouModel, bool>((model) => model.isValid),
-          onActivated: () async {
+          onNext: () async {
             final model = Provider.of<WhoAreYouModel>(context, listen: false);
             await model.saveIdentity();
 

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -102,12 +102,7 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
           context,
           enabled:
               context.select<WhoAreYouModel, bool>((model) => model.isValid),
-          onNext: () async {
-            final model = Provider.of<WhoAreYouModel>(context, listen: false);
-            await model.saveIdentity();
-
-            Wizard.of(context).next();
-          },
+          onNext: context.read<WhoAreYouModel>().saveIdentity,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -97,11 +97,7 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
           context,
           highlighted: true,
           label: lang.startInstallingButtonText,
-          onNext: () async {
-            await model.startInstallation();
-
-            Wizard.of(context).next();
-          },
+          onNext: model.startInstallation,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -93,10 +93,11 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
       ]),
       actions: <WizardAction>[
         WizardAction.back(context),
-        WizardAction(
+        WizardAction.next(
+          context,
           highlighted: true,
           label: lang.startInstallingButtonText,
-          onActivated: () async {
+          onNext: () async {
             await model.startInstallation();
 
             Wizard.of(context).next();

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -60,6 +60,31 @@ class WizardAction {
     );
   }
 
+  /// An action that finishes the wizard.
+  factory WizardAction.done(
+    BuildContext context, {
+    String? label,
+    bool? visible,
+    bool? enabled,
+    bool? highlighted,
+    Object? result,
+    VoidCallback? onActivated,
+  }) {
+    return WizardAction(
+      label: label,
+      visible: visible,
+      enabled: enabled,
+      highlighted: highlighted,
+      onActivated: () {
+        if (onActivated != null) {
+          onActivated();
+        } else {
+          Wizard.of(context).next(arguments: result);
+        }
+      },
+    );
+  }
+
   /// Text label of the back button.
   final String? label;
 

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -22,15 +22,15 @@ class WizardAction {
     BuildContext context, {
     bool? visible,
     bool? enabled,
-    VoidCallback? onActivated,
+    VoidCallback? onBack,
   }) {
     return WizardAction(
       label: UbuntuLocalizations.of(context).backAction,
       visible: visible,
       enabled: enabled ?? Wizard.of(context).hasPrevious,
       onActivated: () {
-        if (onActivated != null) {
-          onActivated();
+        if (onBack != null) {
+          onBack();
         } else {
           Wizard.of(context).back();
         }
@@ -44,15 +44,15 @@ class WizardAction {
     bool? visible,
     bool? enabled,
     Object? arguments,
-    VoidCallback? onActivated,
+    VoidCallback? onNext,
   }) {
     return WizardAction(
       label: UbuntuLocalizations.of(context).continueAction,
       visible: visible,
       enabled: enabled,
       onActivated: () {
-        if (onActivated != null) {
-          onActivated();
+        if (onNext != null) {
+          onNext();
         } else {
           Wizard.of(context).next(arguments: arguments);
         }
@@ -68,7 +68,7 @@ class WizardAction {
     bool? enabled,
     bool? highlighted,
     Object? result,
-    VoidCallback? onActivated,
+    VoidCallback? onDone,
   }) {
     return WizardAction(
       label: label,
@@ -76,8 +76,8 @@ class WizardAction {
       enabled: enabled,
       highlighted: highlighted,
       onActivated: () {
-        if (onActivated != null) {
-          onActivated();
+        if (onDone != null) {
+          onDone();
         } else {
           Wizard.of(context).next(arguments: result);
         }

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -47,17 +47,19 @@ class WizardAction {
     bool? highlighted,
     Object? arguments,
     VoidCallback? onNext,
+    VoidCallback? onBack,
   }) {
     return WizardAction(
       label: label ?? UbuntuLocalizations.of(context).continueAction,
       visible: visible,
       enabled: enabled,
       highlighted: highlighted,
-      onActivated: () {
+      onActivated: () async {
         if (onNext != null) {
           onNext();
         } else {
-          Wizard.of(context).next(arguments: arguments);
+          await Wizard.of(context).next(arguments: arguments);
+          onBack?.call();
         }
       },
     );

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -41,15 +41,18 @@ class WizardAction {
   /// A _Continue_ action that advances to the next page.
   factory WizardAction.next(
     BuildContext context, {
+    String? label,
     bool? visible,
     bool? enabled,
+    bool? highlighted,
     Object? arguments,
     VoidCallback? onNext,
   }) {
     return WizardAction(
-      label: UbuntuLocalizations.of(context).continueAction,
+      label: label ?? UbuntuLocalizations.of(context).continueAction,
       visible: visible,
       enabled: enabled,
+      highlighted: highlighted,
       onActivated: () {
         if (onNext != null) {
           onNext();

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -43,6 +43,7 @@ class WizardAction {
     BuildContext context, {
     bool? visible,
     bool? enabled,
+    Object? arguments,
     VoidCallback? onActivated,
   }) {
     return WizardAction(
@@ -53,7 +54,7 @@ class WizardAction {
         if (onActivated != null) {
           onActivated();
         } else {
-          Wizard.of(context).next();
+          Wizard.of(context).next(arguments: arguments);
         }
       },
     );

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -10,7 +10,7 @@ export 'wizard_action.dart';
 ///
 /// Provides the appropriate layout and the common building blocks for
 /// installation wizard pages.
-class WizardPage extends StatelessWidget {
+class WizardPage extends StatefulWidget {
   /// Creates the wizard page.
   const WizardPage({
     Key? key,
@@ -55,45 +55,51 @@ class WizardPage extends StatelessWidget {
   final List<WizardAction> actions;
 
   @override
+  State<WizardPage> createState() => _WizardPageState();
+}
+
+class _WizardPageState extends State<WizardPage> {
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: title, automaticallyImplyLeading: false),
+      appBar: AppBar(title: widget.title, automaticallyImplyLeading: false),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           Padding(
-            padding: headerPadding,
-            child: header != null
+            padding: widget.headerPadding,
+            child: widget.header != null
                 ? Align(
                     alignment: Alignment.centerLeft,
-                    child: header,
+                    child: widget.header,
                   )
                 : null,
           ),
-          if (header != null) const SizedBox(height: kContentSpacing),
+          if (widget.header != null) const SizedBox(height: kContentSpacing),
           Expanded(
-            child: Padding(padding: contentPadding, child: content),
+            child:
+                Padding(padding: widget.contentPadding, child: widget.content),
           ),
           const SizedBox(height: kContentSpacing),
         ],
       ),
       bottomNavigationBar: Padding(
-        padding: footerPadding,
+        padding: widget.footerPadding,
         child: Row(
-          mainAxisAlignment: footer != null
+          mainAxisAlignment: widget.footer != null
               ? MainAxisAlignment.spaceBetween
               : MainAxisAlignment.end,
           children: <Widget>[
-            if (footer != null) Expanded(child: footer!),
+            if (widget.footer != null) Expanded(child: widget.footer!),
             const SizedBox(width: kContentSpacing),
             ButtonBar(
               buttonPadding: EdgeInsets.zero,
               children: <Widget>[
-                for (final action in actions)
+                for (final action in widget.actions)
                   if (action.visible ?? true)
                     Padding(
                       padding: const EdgeInsets.only(left: kButtonBarSpacing),
-                      child: _createButton(action),
+                      child: _createButton(context, action),
                     ),
               ],
             ),
@@ -103,8 +109,13 @@ class WizardPage extends StatelessWidget {
     );
   }
 
-  Widget _createButton(WizardAction action) {
-    final maybeActivate = action.enabled ?? true ? action.onActivated : null;
+  Widget _createButton(BuildContext context, WizardAction action) {
+    final maybeActivate = action.enabled ?? true
+        ? () async {
+            await action.onActivated?.call();
+            if (mounted) action.execute?.call();
+          }
+        : null;
     return action.highlighted == true
         ? ElevatedButton(onPressed: maybeActivate, child: Text(action.label!))
         : OutlinedButton(onPressed: maybeActivate, child: Text(action.label!));

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -81,10 +81,7 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
           highlighted: true,
           label: lang.setupButton,
           enabled: model.isValid,
-          onNext: () {
-            model.saveAdvancedSetup();
-            Wizard.of(context).next();
-          },
+          onNext: model.saveAdvancedSetup,
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -76,11 +76,12 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
       }),
       actions: <WizardAction>[
         WizardAction.back(context),
-        WizardAction(
+        WizardAction.next(
+          context,
           highlighted: true,
           label: lang.setupButton,
           enabled: model.isValid,
-          onActivated: () {
+          onNext: () {
             model.saveAdvancedSetup();
             Wizard.of(context).next();
           },

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -98,10 +98,7 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
           highlighted: true,
           label: lang.saveButton,
           enabled: model.isValid,
-          onNext: () {
-            model.saveConfiguration();
-            Wizard.of(context).next();
-          },
+          onNext: model.saveConfiguration,
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -93,11 +93,12 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
       ),
       actions: <WizardAction>[
         WizardAction.back(context),
-        WizardAction(
+        WizardAction.next(
+          context,
           highlighted: true,
           label: lang.saveButton,
           enabled: model.isValid,
-          onActivated: () {
+          onNext: () {
             model.saveConfiguration();
             Wizard.of(context).next();
           },

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -100,7 +100,7 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onActivated: () {
+          onNext: () {
             model.saveProfileSetup();
             Wizard.of(context).next(arguments: model.showAdvancedOptions);
           },

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -100,10 +100,8 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onNext: () {
-            model.saveProfileSetup();
-            Wizard.of(context).next(arguments: model.showAdvancedOptions);
-          },
+          arguments: model.showAdvancedOptions,
+          onNext: model.saveProfileSetup,
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -88,7 +88,6 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
           context,
           onNext: () {
             model.applyLocale(model.locale(model.selectedLanguageIndex));
-            Wizard.of(context).next();
           },
         ),
       ],

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -86,7 +86,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
-          onActivated: () {
+          onNext: () {
             model.applyLocale(model.locale(model.selectedLanguageIndex));
             Wizard.of(context).next();
           },

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -66,7 +66,7 @@ class _SetupCompletePageState extends State<SetupCompletePage> {
         WizardAction.done(
           context,
           label: lang.finishButton,
-          onActivated: () => model.reboot(immediate: false),
+          onDone: () => model.reboot(immediate: false),
         ),
       ],
     );

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -63,7 +63,8 @@ class _SetupCompletePageState extends State<SetupCompletePage> {
         ],
       ),
       actions: <WizardAction>[
-        WizardAction(
+        WizardAction.done(
+          context,
           label: lang.finishButton,
           onActivated: () => model.reboot(immediate: false),
         ),


### PR DESCRIPTION
The activation step allows pages to perform asynchronous tasks such as
sending information to Subiquity. The execution step gets only called if
the context is still valid after the asynchronous activation step. This
ensures that e.g. `Wizard.of(context).next()` is not incorrectly called
after navigating back.

This is a partial fix to issues exposed by the recently enabled
`use_build_context_synchronously` lint.