### PR TITLE
Attempt to stabilize WSL setup integration test

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -185,6 +185,7 @@ Future<void> testApplyingChangesPage(
   WidgetTester tester, {
   bool expectClose = false,
 }) async {
+  await tester.pumpUntil(find.byType(ApplyingChangesPage));
   expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
 
   if (expectClose) {


### PR DESCRIPTION
The test has started occasionally failing in the CI:

```
ERROR ubuntu_wsl_setup: Unhandled exception
	TestFailure: Expected: exactly one matching node in the widget tree
  Actual: _WidgetTypeFinder:<zero widgets with type "ApplyingChangesPage" (ignoring offstage widgets)>
   Which: means none were found but one was expected
```

Try the same approach as in #767 - let the widget tester pump until the
page (hopefully) becomes available.