### PR TITLE
[WSL] Server side username validation

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/l10n/app_en.arb
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_en.arb
@@ -23,6 +23,10 @@
   "profileSetupPasswordMismatch": "The passwords do not match",
   "profileSetupUsernameRequired": "A username is required",
   "profileSetupUsernameInvalid": "The username is invalid",
+  "profileSetupUsernameInUse": "That user name already exists.",
+  "profileSetupUsernameSystemReserved": "That name is reserved for system usage.",
+  "profileSetupUsernameTooLong": "That name is too long.",
+  "profileSetupUsernameInvalidChars": "That name contains invalid characters.",
   "profileSetupPasswordRequired": "A password is required",
 
   "advancedSetupTitle": "Advanced setup",

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
@@ -349,6 +349,30 @@ abstract class AppLocalizations {
   /// **'The username is invalid'**
   String get profileSetupUsernameInvalid;
 
+  /// No description provided for @profileSetupUsernameInUse.
+  ///
+  /// In en, this message translates to:
+  /// **'That user name already exists.'**
+  String get profileSetupUsernameInUse;
+
+  /// No description provided for @profileSetupUsernameSystemReserved.
+  ///
+  /// In en, this message translates to:
+  /// **'That name is reserved for system usage.'**
+  String get profileSetupUsernameSystemReserved;
+
+  /// No description provided for @profileSetupUsernameTooLong.
+  ///
+  /// In en, this message translates to:
+  /// **'That name is too long.'**
+  String get profileSetupUsernameTooLong;
+
+  /// No description provided for @profileSetupUsernameInvalidChars.
+  ///
+  /// In en, this message translates to:
+  /// **'That name contains invalid characters.'**
+  String get profileSetupUsernameInvalidChars;
+
   /// No description provided for @profileSetupPasswordRequired.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
@@ -65,6 +65,18 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
@@ -65,6 +65,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
@@ -65,6 +65,18 @@ class AppLocalizationsBe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
@@ -65,6 +65,18 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
@@ -65,6 +65,18 @@ class AppLocalizationsBn extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
@@ -65,6 +65,18 @@ class AppLocalizationsBo extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
@@ -65,6 +65,18 @@ class AppLocalizationsBs extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
@@ -65,6 +65,18 @@ class AppLocalizationsCa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
@@ -65,6 +65,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Dané uživatelské jméno nelze použít (nepovolené znaky)';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Je zapotřebí vyplnit heslo';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
@@ -65,6 +65,18 @@ class AppLocalizationsCy extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
@@ -65,6 +65,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
@@ -65,6 +65,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Der Benutzername ist ungültig';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Ein Passwort ist erforderlich';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
@@ -65,6 +65,18 @@ class AppLocalizationsDz extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEo extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'La salutnomo ne validas';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Pasvorto bezoniĝas';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'El nombre de usuario no es válido';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Se necesita una contraseña';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEt extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
@@ -65,6 +65,18 @@ class AppLocalizationsEu extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
@@ -65,6 +65,18 @@ class AppLocalizationsFa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
@@ -65,6 +65,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
@@ -65,6 +65,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Ce nom d\'utilisateur est invalide';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Un mot de passe est requis';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
@@ -65,6 +65,18 @@ class AppLocalizationsGa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
@@ -65,6 +65,18 @@ class AppLocalizationsGl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
@@ -65,6 +65,18 @@ class AppLocalizationsGu extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
@@ -65,6 +65,18 @@ class AppLocalizationsHe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'שם המשתמש שגוי';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'דרושה סיסמה';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
@@ -65,6 +65,18 @@ class AppLocalizationsHi extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
@@ -65,6 +65,18 @@ class AppLocalizationsHr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
@@ -65,6 +65,18 @@ class AppLocalizationsHu extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'A felhasználónév érvénytelen';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Jelszó szükséges';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
@@ -65,6 +65,18 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
@@ -65,6 +65,18 @@ class AppLocalizationsIs extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
@@ -65,6 +65,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
@@ -65,6 +65,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'ユーザー名が無効です';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'パスワードが必要です';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKk extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKm extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKn extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupUsernameInvalid => '올바른 사용자 이름이 아닙니다';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => '암호가 필요합니다';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
@@ -65,6 +65,18 @@ class AppLocalizationsKu extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
@@ -65,6 +65,18 @@ class AppLocalizationsLo extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
@@ -65,6 +65,18 @@ class AppLocalizationsLt extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Naudotojo vardas yra netinkamas';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Reikia nurodyti slaptažodį';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
@@ -65,6 +65,18 @@ class AppLocalizationsLv extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
@@ -65,6 +65,18 @@ class AppLocalizationsMk extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
@@ -65,6 +65,18 @@ class AppLocalizationsMl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'ഉപയോക്തൃനാമം അസാധുവാണ്';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'ഒരു പാസ്‌വേഡ് ആവശ്യമാണ്';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
@@ -65,6 +65,18 @@ class AppLocalizationsMr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
@@ -65,6 +65,18 @@ class AppLocalizationsMy extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
@@ -65,6 +65,18 @@ class AppLocalizationsNb extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
@@ -65,6 +65,18 @@ class AppLocalizationsNe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'पासवर्ड आवश्यक छ';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
@@ -65,6 +65,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
@@ -65,6 +65,18 @@ class AppLocalizationsNn extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
@@ -65,6 +65,18 @@ class AppLocalizationsPa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
@@ -65,6 +65,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Nazwa użytkownika jest nieprawidłowa';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Wymagane jest podanie hasła';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
@@ -65,6 +65,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'O nome de usuário é inválido';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Senha é obrigatória';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
@@ -65,6 +65,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
@@ -65,6 +65,18 @@ class AppLocalizationsRu extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSi extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSk extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSq extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
@@ -65,6 +65,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Användarnamnet är ogiltigt';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Ett lösenord krävs';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTa extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTe extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTg extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTh extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTl extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
@@ -65,6 +65,18 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Kullanıcı adı geçersiz';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Parola gereklidir';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
@@ -65,6 +65,18 @@ class AppLocalizationsUg extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'The username is invalid';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'A password is required';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
@@ -65,6 +65,18 @@ class AppLocalizationsUk extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Ім’я користувача непридатне';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Пароль - обов’язково';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
@@ -65,6 +65,18 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileSetupUsernameInvalid => 'Tên người dùng không hợp lệ';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => 'Mật khẩu là bắt buộc';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
@@ -65,6 +65,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get profileSetupUsernameInvalid => '这个用户名是无效的';
 
   @override
+  String get profileSetupUsernameInUse => 'That user name already exists.';
+
+  @override
+  String get profileSetupUsernameSystemReserved => 'That name is reserved for system usage.';
+
+  @override
+  String get profileSetupUsernameTooLong => 'That name is too long.';
+
+  @override
+  String get profileSetupUsernameInvalidChars => 'That name contains invalid characters.';
+
+  @override
   String get profileSetupPasswordRequired => '密码是必须的';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/foundation.dart';
-import 'package:form_field_validator/form_field_validator.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
-import 'package:ubuntu_wizard/widgets.dart';
 
 /// The regular expression pattern for valid usernames:
 /// - must start with a lowercase letter
@@ -83,27 +81,6 @@ class ProfileSetupModel extends SafeChangeNotifier {
         RegExp(kValidUsernamePattern).hasMatch(username)) {
       _usernameValidation.value = await _client.validateUsername(username);
     }
-  }
-
-  final List<FieldValidator<String?>> _validators = [];
-  List<FieldValidator<String?>> get validators => _validators;
-
-  /// Initializes a list of [CallbackValidator]'s for each key-value pair of the
-  /// [errorValueToText] map, in which each value provided as the map key is a
-  /// possible value of [usernameValidation] for which the respective validator
-  /// will return invalid and the mapped value as the validator's error text.
-  void setUsernameValidators(Map<UsernameValidation, String> errorValueToText) {
-    if (_validators.isNotEmpty) {
-      return;
-    }
-    errorValueToText.forEach((key, value) {
-      _validators.add(
-        CallbackValidator(
-          (_) => usernameValidation != key,
-          errorText: value,
-        ),
-      );
-    });
   }
 
   /// Loads the profile setup.

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -42,19 +42,6 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
 
     final model = Provider.of<ProfileSetupModel>(context, listen: false);
     model.loadProfileSetup();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final lang = AppLocalizations.of(context);
-      model.setUsernameValidators(
-        {
-          UsernameValidation.ALREADY_IN_USE: lang.profileSetupUsernameInUse,
-          UsernameValidation.SYSTEM_RESERVED:
-              lang.profileSetupUsernameSystemReserved,
-          UsernameValidation.INVALID_CHARS:
-              lang.profileSetupUsernameInvalidChars,
-          UsernameValidation.TOO_LONG: lang.profileSetupUsernameTooLong,
-        },
-      );
-    });
   }
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -42,6 +42,19 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
 
     final model = Provider.of<ProfileSetupModel>(context, listen: false);
     model.loadProfileSetup();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final lang = AppLocalizations.of(context);
+      model.setUsernameValidators(
+        {
+          UsernameValidation.ALREADY_IN_USE: lang.profileSetupUsernameInUse,
+          UsernameValidation.SYSTEM_RESERVED:
+              lang.profileSetupUsernameSystemReserved,
+          UsernameValidation.INVALID_CHARS:
+              lang.profileSetupUsernameInvalidChars,
+          UsernameValidation.TOO_LONG: lang.profileSetupUsernameTooLong,
+        },
+      );
+    });
   }
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
@@ -41,6 +41,7 @@ class _UsernameFormField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
+    final model = context.read<ProfileSetupModel>();
     final username =
         context.select<ProfileSetupModel, String>((model) => model.username);
 
@@ -55,11 +56,13 @@ class _UsernameFormField extends StatelessWidget {
         PatternValidator(
           kValidUsernamePattern,
           errorText: lang.profileSetupUsernameInvalid,
-        )
+        ),
+        ...model.validators,
       ]),
-      onChanged: (value) {
+      onChanged: (value) async {
         final model = Provider.of<ProfileSetupModel>(context, listen: false);
         model.username = value;
+        await model.validate();
       },
     );
   }

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
@@ -30,6 +30,25 @@ class _RealNameFormField extends StatelessWidget {
   }
 }
 
+extension UsernameValidationL10n on UsernameValidation {
+  String localize(AppLocalizations lang) {
+    switch (this) {
+      case UsernameValidation.OK:
+        return '';
+      case UsernameValidation.ALREADY_IN_USE:
+        return lang.profileSetupUsernameInUse;
+      case UsernameValidation.SYSTEM_RESERVED:
+        return lang.profileSetupUsernameSystemReserved;
+      case UsernameValidation.INVALID_CHARS:
+        return lang.profileSetupUsernameInvalidChars;
+      case UsernameValidation.TOO_LONG:
+        return lang.profileSetupUsernameTooLong;
+      default:
+        throw UnimplementedError(toString());
+    }
+  }
+}
+
 class _UsernameFormField extends StatelessWidget {
   const _UsernameFormField({
     Key? key,
@@ -44,6 +63,8 @@ class _UsernameFormField extends StatelessWidget {
     final model = context.read<ProfileSetupModel>();
     final username =
         context.select<ProfileSetupModel, String>((model) => model.username);
+    final validation = context.select<ProfileSetupModel, UsernameValidation>(
+        (model) => model.usernameValidation);
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -57,7 +78,8 @@ class _UsernameFormField extends StatelessWidget {
           kValidUsernamePattern,
           errorText: lang.profileSetupUsernameInvalid,
         ),
-        ...model.validators,
+        CallbackValidator((_) => model.usernameOk,
+            errorText: validation.localize(lang)),
       ]),
       onChanged: (value) async {
         final model = Provider.of<ProfileSetupModel>(context, listen: false);

--- a/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_model_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:form_field_validator/form_field_validator.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -112,19 +111,12 @@ void main() {
     final model = ProfileSetupModel(client);
     expect(model.isValid, isFalse);
 
-    model.setUsernameValidators({
-      UsernameValidation.ALREADY_IN_USE: 'A',
-      UsernameValidation.SYSTEM_RESERVED: 'S',
-      UsernameValidation.TOO_LONG: 'T',
-    });
-
     void testValid(
       String realname,
       String username,
       String password,
       String confirmedPassword,
       Matcher matcher,
-      String errorText,
     ) async {
       model.realname = realname;
       model.username = username;
@@ -132,14 +124,11 @@ void main() {
       model.confirmedPassword = confirmedPassword;
       await model.validate();
       expect(model.isValid, matcher);
-
-      final validator = MultiValidator(model.validators);
-      expect(validator(username), errorText);
     }
 
-    testValid('User', kRoot, 'password', 'password', isFalse, 'A');
-    testValid('User', kPlugdev, 'password', 'password', isFalse, 'S');
-    testValid('User', kTooLong, 'password', 'password', isFalse, 'T');
+    testValid('User', kRoot, 'password', 'password', isFalse);
+    testValid('User', kPlugdev, 'password', 'password', isFalse);
+    testValid('User', kTooLong, 'password', 'password', isFalse);
   });
 
   test('validation', () {

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -38,6 +38,7 @@ void main() {
     when(model.passwordStrength)
         .thenReturn(passwordStrength ?? PasswordStrength.weak);
     when(model.showAdvancedOptions).thenReturn(showAdvancedOptions ?? false);
+    when(model.validators).thenReturn([]);
     return model;
   }
 

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -38,6 +38,8 @@ void main() {
     when(model.passwordStrength)
         .thenReturn(passwordStrength ?? PasswordStrength.weak);
     when(model.showAdvancedOptions).thenReturn(showAdvancedOptions ?? false);
+    when(model.usernameValidation).thenReturn(UsernameValidation.OK);
+    when(model.usernameOk).thenReturn(true);
     return model;
   }
 

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -38,7 +38,6 @@ void main() {
     when(model.passwordStrength)
         .thenReturn(passwordStrength ?? PasswordStrength.weak);
     when(model.showAdvancedOptions).thenReturn(showAdvancedOptions ?? false);
-    when(model.validators).thenReturn([]);
     return model;
   }
 

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
@@ -2,10 +2,12 @@
 // in ubuntu_wsl_setup/test/profile_setup_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
-import 'dart:ui' as _i5;
+import 'dart:async' as _i6;
+import 'dart:ui' as _i7;
 
+import 'package:form_field_validator/form_field_validator.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_wizard/utils.dart' as _i3;
 import 'package:ubuntu_wsl_setup/pages/profile_setup/profile_setup_model.dart'
     as _i2;
@@ -77,6 +79,19 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
           as bool);
   @override
+  _i4.UsernameValidation get usernameValidation =>
+      (super.noSuchMethod(Invocation.getter(#usernameValidation),
+          returnValue: _i4.UsernameValidation.OK) as _i4.UsernameValidation);
+  @override
+  bool get usernameOk =>
+      (super.noSuchMethod(Invocation.getter(#usernameOk), returnValue: false)
+          as bool);
+  @override
+  List<_i5.FieldValidator<String?>> get validators =>
+      (super.noSuchMethod(Invocation.getter(#validators),
+              returnValue: <_i5.FieldValidator<String?>>[])
+          as List<_i5.FieldValidator<String?>>);
+  @override
   bool get isDisposed =>
       (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
           as bool);
@@ -85,25 +100,36 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
-  _i4.Future<void> loadProfileSetup() =>
+  _i6.Future<void> validate() =>
+      (super.noSuchMethod(Invocation.method(#validate, []),
+          returnValue: Future<void>.value(),
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
+  @override
+  void setUsernameValidators(
+          Map<_i4.UsernameValidation, String>? errorValueToText) =>
+      super.noSuchMethod(
+          Invocation.method(#setUsernameValidators, [errorValueToText]),
+          returnValueForMissingStub: null);
+  @override
+  _i6.Future<void> loadProfileSetup() =>
       (super.noSuchMethod(Invocation.method(#loadProfileSetup, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i4.Future<void> saveProfileSetup({String? salt}) => (super.noSuchMethod(
+  _i6.Future<void> saveProfileSetup({String? salt}) => (super.noSuchMethod(
       Invocation.method(#saveProfileSetup, [], {#salt: salt}),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
   void notifyListeners() =>
       super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
   @override
-  void addListener(_i5.VoidCallback? listener) =>
+  void addListener(_i7.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
+  void removeListener(_i7.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override
@@ -120,7 +146,7 @@ class MockUrlLauncher extends _i1.Mock implements _i3.UrlLauncher {
   }
 
   @override
-  _i4.Future<bool> launchUrl(String? url) =>
+  _i6.Future<bool> launchUrl(String? url) =>
       (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
 }

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
@@ -2,10 +2,9 @@
 // in ubuntu_wsl_setup/test/profile_setup_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i6;
-import 'dart:ui' as _i7;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i6;
 
-import 'package:form_field_validator/form_field_validator.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_wizard/utils.dart' as _i3;
@@ -87,11 +86,6 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       (super.noSuchMethod(Invocation.getter(#usernameOk), returnValue: false)
           as bool);
   @override
-  List<_i5.FieldValidator<String?>> get validators =>
-      (super.noSuchMethod(Invocation.getter(#validators),
-              returnValue: <_i5.FieldValidator<String?>>[])
-          as List<_i5.FieldValidator<String?>>);
-  @override
   bool get isDisposed =>
       (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
           as bool);
@@ -100,36 +94,30 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
-  _i6.Future<void> validate() =>
+  _i5.Future<void> validate() =>
       (super.noSuchMethod(Invocation.method(#validate, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  void setUsernameValidators(
-          Map<_i4.UsernameValidation, String>? errorValueToText) =>
-      super.noSuchMethod(
-          Invocation.method(#setUsernameValidators, [errorValueToText]),
-          returnValueForMissingStub: null);
-  @override
-  _i6.Future<void> loadProfileSetup() =>
+  _i5.Future<void> loadProfileSetup() =>
       (super.noSuchMethod(Invocation.method(#loadProfileSetup, []),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
-  _i6.Future<void> saveProfileSetup({String? salt}) => (super.noSuchMethod(
+  _i5.Future<void> saveProfileSetup({String? salt}) => (super.noSuchMethod(
       Invocation.method(#saveProfileSetup, [], {#salt: salt}),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
   @override
   void notifyListeners() =>
       super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
   @override
-  void addListener(_i7.VoidCallback? listener) =>
+  void addListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i7.VoidCallback? listener) =>
+  void removeListener(_i6.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
   @override
@@ -146,7 +134,7 @@ class MockUrlLauncher extends _i1.Mock implements _i3.UrlLauncher {
   }
 
   @override
-  _i6.Future<bool> launchUrl(String? url) =>
+  _i5.Future<bool> launchUrl(String? url) =>
       (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
 }


### PR DESCRIPTION
With the merge of #852 we can validate usernames with the server. The intent behind it is centralize the logic to prevent users from selecting usernames reserved for the system. For WSL specifically, since the installer runs on the target, there is also the possibility of the username already exists.

So, with this PR we make use of that feature in the profile setup model.

Since WSL installer has fewer pages, I opted for pushing it first. Easier to test. Should the current approach be successfull I'll push the modifications I already experimented with for U-D-I. The end result can be seen below:

https://user-images.githubusercontent.com/11138291/169035544-deaa9eee-9478-4295-bfb1-1271463d5e4a.mp4


This closes https://github.com/ubuntu/WSL/issues/179