### PR TITLE
Attempts to stabilize UDI integration test

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -337,7 +337,7 @@ Future<void> testTurnOffBitLockerPage(WidgetTester tester) async {
 
   final windowClosed = waitForWindowClosed();
   await tester.tapHighlightedButton(tester.lang.restartIntoWindows);
-  expect(windowClosed, completion(isTrue));
+  await expectLater(windowClosed, completion(isTrue));
 }
 
 Future<void> testWhereAreYouPage(
@@ -426,7 +426,7 @@ Future<void> testInstallationCompletePage(WidgetTester tester) async {
 
   final windowClosed = waitForWindowClosed();
   await tester.tapButton(label: tester.lang.shutdown);
-  expect(windowClosed, completion(isTrue));
+  await expectLater(windowClosed, completion(isTrue));
 }
 
 Future<void> expectPage(

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -120,10 +120,11 @@ Future<bool> waitForWindowClosed() {
   final methodChannel = MethodChannel('ubuntu_wizard');
 
   methodChannel.setMockMethodCallHandler((call) async {
-    expect(call.method, equals('closeWindow'));
-    await _testCloseWindow();
-    completer.complete(true);
-    methodChannel.setMockMethodCallHandler(null);
+    if (call.method == 'closeWindow') {
+      await _testCloseWindow();
+      completer.complete(true);
+      methodChannel.setMockMethodCallHandler(null);
+    }
   });
 
   return completer.future;


### PR DESCRIPTION
We had failures due `expect(someFuture, completion(isTrue))`. Await expectLater should fix.
Expectation of the `closeWindow` method call turned into an if clause