### PR TITLE
Sync IdentityData with Subiquity

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -327,10 +327,10 @@ class StorageResponseV2 with _$StorageResponseV2 {
 class IdentityData with _$IdentityData {
   @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
   const factory IdentityData({
-    @Default('') String? realname,
-    @Default('') String? username,
-    @Default('') String? cryptedPassword,
-    @Default('') String? hostname,
+    @Default('') String realname,
+    @Default('') String username,
+    @Default('') String cryptedPassword,
+    @Default('') String hostname,
   }) = _IdentityData;
 
   factory IdentityData.fromJson(Map<String, dynamic> json) =>

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -4658,10 +4658,10 @@ class _$IdentityDataTearOff {
   const _$IdentityDataTearOff();
 
   _IdentityData call(
-      {String? realname = '',
-      String? username = '',
-      String? cryptedPassword = '',
-      String? hostname = ''}) {
+      {String realname = '',
+      String username = '',
+      String cryptedPassword = '',
+      String hostname = ''}) {
     return _IdentityData(
       realname: realname,
       username: username,
@@ -4680,10 +4680,10 @@ const $IdentityData = _$IdentityDataTearOff();
 
 /// @nodoc
 mixin _$IdentityData {
-  String? get realname => throw _privateConstructorUsedError;
-  String? get username => throw _privateConstructorUsedError;
-  String? get cryptedPassword => throw _privateConstructorUsedError;
-  String? get hostname => throw _privateConstructorUsedError;
+  String get realname => throw _privateConstructorUsedError;
+  String get username => throw _privateConstructorUsedError;
+  String get cryptedPassword => throw _privateConstructorUsedError;
+  String get hostname => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -4697,10 +4697,10 @@ abstract class $IdentityDataCopyWith<$Res> {
           IdentityData value, $Res Function(IdentityData) then) =
       _$IdentityDataCopyWithImpl<$Res>;
   $Res call(
-      {String? realname,
-      String? username,
-      String? cryptedPassword,
-      String? hostname});
+      {String realname,
+      String username,
+      String cryptedPassword,
+      String hostname});
 }
 
 /// @nodoc
@@ -4722,19 +4722,19 @@ class _$IdentityDataCopyWithImpl<$Res> implements $IdentityDataCopyWith<$Res> {
       realname: realname == freezed
           ? _value.realname
           : realname // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       username: username == freezed
           ? _value.username
           : username // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       cryptedPassword: cryptedPassword == freezed
           ? _value.cryptedPassword
           : cryptedPassword // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       hostname: hostname == freezed
           ? _value.hostname
           : hostname // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
     ));
   }
 }
@@ -4747,10 +4747,10 @@ abstract class _$IdentityDataCopyWith<$Res>
       __$IdentityDataCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String? realname,
-      String? username,
-      String? cryptedPassword,
-      String? hostname});
+      {String realname,
+      String username,
+      String cryptedPassword,
+      String hostname});
 }
 
 /// @nodoc
@@ -4774,19 +4774,19 @@ class __$IdentityDataCopyWithImpl<$Res> extends _$IdentityDataCopyWithImpl<$Res>
       realname: realname == freezed
           ? _value.realname
           : realname // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       username: username == freezed
           ? _value.username
           : username // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       cryptedPassword: cryptedPassword == freezed
           ? _value.cryptedPassword
           : cryptedPassword // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       hostname: hostname == freezed
           ? _value.hostname
           : hostname // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
     ));
   }
 }
@@ -4806,16 +4806,16 @@ class _$_IdentityData implements _IdentityData {
 
   @JsonKey(defaultValue: '')
   @override
-  final String? realname;
+  final String realname;
   @JsonKey(defaultValue: '')
   @override
-  final String? username;
+  final String username;
   @JsonKey(defaultValue: '')
   @override
-  final String? cryptedPassword;
+  final String cryptedPassword;
   @JsonKey(defaultValue: '')
   @override
-  final String? hostname;
+  final String hostname;
 
   @override
   String toString() {
@@ -4861,22 +4861,22 @@ class _$_IdentityData implements _IdentityData {
 
 abstract class _IdentityData implements IdentityData {
   const factory _IdentityData(
-      {String? realname,
-      String? username,
-      String? cryptedPassword,
-      String? hostname}) = _$_IdentityData;
+      {String realname,
+      String username,
+      String cryptedPassword,
+      String hostname}) = _$_IdentityData;
 
   factory _IdentityData.fromJson(Map<String, dynamic> json) =
       _$_IdentityData.fromJson;
 
   @override
-  String? get realname => throw _privateConstructorUsedError;
+  String get realname => throw _privateConstructorUsedError;
   @override
-  String? get username => throw _privateConstructorUsedError;
+  String get username => throw _privateConstructorUsedError;
   @override
-  String? get cryptedPassword => throw _privateConstructorUsedError;
+  String get cryptedPassword => throw _privateConstructorUsedError;
   @override
-  String? get hostname => throw _privateConstructorUsedError;
+  String get hostname => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$IdentityDataCopyWith<_IdentityData> get copyWith =>

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -460,15 +460,9 @@ Future<void> verifyConfig({
 
   if (identity != null) {
     final actualIdentity = yaml['autoinstall']['identity'];
-    if (identity.hostname != null) {
-      expect(actualIdentity['hostname'], equals(identity.hostname));
-    }
-    if (identity.realname != null) {
-      expect(actualIdentity['realname'], equals(identity.realname));
-    }
-    if (identity.username != null) {
-      expect(actualIdentity['username'], equals(identity.username));
-    }
+    expect(actualIdentity['hostname'], equals(identity.hostname));
+    expect(actualIdentity['realname'], equals(identity.realname));
+    expect(actualIdentity['username'], equals(identity.username));
   }
 
   if (keyboard != null) {

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_model.dart
@@ -122,9 +122,9 @@ class WhoAreYouModel extends SafeChangeNotifier {
   /// Loads the identity data from the server, and resolves the system hostname.
   Future<void> loadIdentity() async {
     final identity = await _client.identity();
-    _realName.value ??= identity.realname?.orIfEmpty(null);
-    _hostname.value ??= identity.hostname?.orIfEmpty(null);
-    _username.value ??= identity.username?.orIfEmpty(null);
+    _realName.value ??= identity.realname.orIfEmpty(null);
+    _hostname.value ??= identity.hostname.orIfEmpty(null);
+    _username.value ??= identity.username.orIfEmpty(null);
     log.info('Loaded identity: ${identity.description}');
     _productName.value = await _readProductName();
     log.info('Read product name: ${_productName.value}');

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
@@ -81,9 +81,9 @@ void main() {
     final client = MockSubiquityClient();
 
     final model = WhoAreYouModel(client);
-    model.realName = identity.realname!;
-    model.username = identity.username!;
-    model.hostname = identity.hostname!;
+    model.realName = identity.realname;
+    model.username = identity.username;
+    model.hostname = identity.hostname;
     model.password = 'passwd';
 
     await model.saveIdentity(salt: 'test');

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_model.dart
@@ -86,8 +86,8 @@ class ProfileSetupModel extends SafeChangeNotifier {
   /// Loads the profile setup.
   Future<void> loadProfileSetup() async {
     final identity = await _client.identity();
-    _realname.value = identity.realname?.orIfEmpty(null);
-    _username.value = identity.username?.orIfEmpty(null);
+    _realname.value = identity.realname.orIfEmpty(null);
+    _username.value = identity.username.orIfEmpty(null);
   }
 
   /// Saves the profile setup.

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_model.dart
@@ -16,7 +16,7 @@ class SetupCompleteModel extends SafeChangeNotifier with SystemShutdown {
   final _identity = ValueNotifier(const IdentityData());
 
   /// The username for the profile.
-  String get username => _identity.value.username ?? '';
+  String get username => _identity.value.username;
 
   /// Initializes the model.
   Future<void> init() {


### PR DESCRIPTION
All the IdentityData fields are non-nullable i.e. none of them is
Optional in Subiquity. Making every field nullable only gives a false
sense of safety and clutters the UI code with unnecessary null-aware
operators and repeated imaginary defaults that are never used because
the values coming from Subiquity cannot be null.

Ref: https://github.com/canonical/ubuntu-desktop-installer/issues/412