### PR TITLE
Sync keyboard detection steps with Subiquity

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -78,23 +78,23 @@ class AnyStep with _$AnyStep {
   @FreezedUnionValue('StepPressKey')
   @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
   const factory AnyStep.stepPressKey({
-    List<String>? symbols,
-    List<List<dynamic>>? keycodes,
+    required List<String> symbols,
+    required List<List<dynamic>> keycodes,
   }) = StepPressKey;
 
   @FreezedUnionValue('StepKeyPresent')
   @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
   const factory AnyStep.stepKeyPresent({
-    String? symbol,
-    String? yes,
-    String? no,
+    required String symbol,
+    required String yes,
+    required String no,
   }) = StepKeyPresent;
 
   @FreezedUnionValue('StepResult')
   @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
   const factory AnyStep.stepResult({
-    String? layout,
-    String? variant,
+    required String layout,
+    required String variant,
   }) = StepResult;
 
   factory AnyStep.fromJson(Map<String, dynamic> json) =>

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -73,13 +73,24 @@ class ApplicationStatus with _$ApplicationStatus {
       _$ApplicationStatusFromJson(json);
 }
 
+Map<int, String> _keycodesFromJson(List<dynamic> keycodes) {
+  return {
+    for (final keycode in keycodes) keycode[0] as int: keycode[1] as String,
+  };
+}
+
+List<dynamic> _keycodesToJson(Map<int, String> keycodes) {
+  return keycodes.entries.map((e) => [e.key, e.value]).toList();
+}
+
 @Freezed(unionKey: '\$type', unionValueCase: FreezedUnionCase.pascal)
 class AnyStep with _$AnyStep {
   @FreezedUnionValue('StepPressKey')
   @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
   const factory AnyStep.stepPressKey({
     required List<String> symbols,
-    required List<List<dynamic>> keycodes,
+    @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+        required Map<int, String> keycodes,
   }) = StepPressKey;
 
   @FreezedUnionValue('StepKeyPresent')

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -625,14 +625,15 @@ class _$AnyStepTearOff {
   const _$AnyStepTearOff();
 
   StepPressKey stepPressKey(
-      {List<String>? symbols, List<List<dynamic>>? keycodes}) {
+      {required List<String> symbols, required List<List<dynamic>> keycodes}) {
     return StepPressKey(
       symbols: symbols,
       keycodes: keycodes,
     );
   }
 
-  StepKeyPresent stepKeyPresent({String? symbol, String? yes, String? no}) {
+  StepKeyPresent stepKeyPresent(
+      {required String symbol, required String yes, required String no}) {
     return StepKeyPresent(
       symbol: symbol,
       yes: yes,
@@ -640,7 +641,7 @@ class _$AnyStepTearOff {
     );
   }
 
-  StepResult stepResult({String? layout, String? variant}) {
+  StepResult stepResult({required String layout, required String variant}) {
     return StepResult(
       layout: layout,
       variant: variant,
@@ -660,19 +661,19 @@ mixin _$AnyStep {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String>? symbols, List<List<dynamic>>? keycodes)
+            List<String> symbols, List<List<dynamic>> keycodes)
         stepPressKey,
-    required TResult Function(String? symbol, String? yes, String? no)
+    required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
-    required TResult Function(String? layout, String? variant) stepResult,
+    required TResult Function(String layout, String variant) stepResult,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String>? symbols, List<List<dynamic>>? keycodes)?
+    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
         stepPressKey,
-    TResult Function(String? symbol, String? yes, String? no)? stepKeyPresent,
-    TResult Function(String? layout, String? variant)? stepResult,
+    TResult Function(String symbol, String yes, String no)? stepKeyPresent,
+    TResult Function(String layout, String variant)? stepResult,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -714,7 +715,7 @@ abstract class $StepPressKeyCopyWith<$Res> {
   factory $StepPressKeyCopyWith(
           StepPressKey value, $Res Function(StepPressKey) then) =
       _$StepPressKeyCopyWithImpl<$Res>;
-  $Res call({List<String>? symbols, List<List<dynamic>>? keycodes});
+  $Res call({List<String> symbols, List<List<dynamic>> keycodes});
 }
 
 /// @nodoc
@@ -736,11 +737,11 @@ class _$StepPressKeyCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
       symbols: symbols == freezed
           ? _value.symbols
           : symbols // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
+              as List<String>,
       keycodes: keycodes == freezed
           ? _value.keycodes
           : keycodes // ignore: cast_nullable_to_non_nullable
-              as List<List<dynamic>>?,
+              as List<List<dynamic>>,
     ));
   }
 }
@@ -750,15 +751,15 @@ class _$StepPressKeyCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
 @FreezedUnionValue('StepPressKey')
 @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
 class _$StepPressKey implements StepPressKey {
-  const _$StepPressKey({this.symbols, this.keycodes});
+  const _$StepPressKey({required this.symbols, required this.keycodes});
 
   factory _$StepPressKey.fromJson(Map<String, dynamic> json) =>
       _$_$StepPressKeyFromJson(json);
 
   @override
-  final List<String>? symbols;
+  final List<String> symbols;
   @override
-  final List<List<dynamic>>? keycodes;
+  final List<List<dynamic>> keycodes;
 
   @override
   String toString() {
@@ -792,11 +793,11 @@ class _$StepPressKey implements StepPressKey {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String>? symbols, List<List<dynamic>>? keycodes)
+            List<String> symbols, List<List<dynamic>> keycodes)
         stepPressKey,
-    required TResult Function(String? symbol, String? yes, String? no)
+    required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
-    required TResult Function(String? layout, String? variant) stepResult,
+    required TResult Function(String layout, String variant) stepResult,
   }) {
     return stepPressKey(symbols, keycodes);
   }
@@ -804,10 +805,10 @@ class _$StepPressKey implements StepPressKey {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String>? symbols, List<List<dynamic>>? keycodes)?
+    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
         stepPressKey,
-    TResult Function(String? symbol, String? yes, String? no)? stepKeyPresent,
-    TResult Function(String? layout, String? variant)? stepResult,
+    TResult Function(String symbol, String yes, String no)? stepKeyPresent,
+    TResult Function(String layout, String variant)? stepResult,
     required TResult orElse(),
   }) {
     if (stepPressKey != null) {
@@ -848,13 +849,14 @@ class _$StepPressKey implements StepPressKey {
 
 abstract class StepPressKey implements AnyStep {
   const factory StepPressKey(
-      {List<String>? symbols, List<List<dynamic>>? keycodes}) = _$StepPressKey;
+      {required List<String> symbols,
+      required List<List<dynamic>> keycodes}) = _$StepPressKey;
 
   factory StepPressKey.fromJson(Map<String, dynamic> json) =
       _$StepPressKey.fromJson;
 
-  List<String>? get symbols => throw _privateConstructorUsedError;
-  List<List<dynamic>>? get keycodes => throw _privateConstructorUsedError;
+  List<String> get symbols => throw _privateConstructorUsedError;
+  List<List<dynamic>> get keycodes => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $StepPressKeyCopyWith<StepPressKey> get copyWith =>
       throw _privateConstructorUsedError;
@@ -865,7 +867,7 @@ abstract class $StepKeyPresentCopyWith<$Res> {
   factory $StepKeyPresentCopyWith(
           StepKeyPresent value, $Res Function(StepKeyPresent) then) =
       _$StepKeyPresentCopyWithImpl<$Res>;
-  $Res call({String? symbol, String? yes, String? no});
+  $Res call({String symbol, String yes, String no});
 }
 
 /// @nodoc
@@ -888,15 +890,15 @@ class _$StepKeyPresentCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
       symbol: symbol == freezed
           ? _value.symbol
           : symbol // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       yes: yes == freezed
           ? _value.yes
           : yes // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       no: no == freezed
           ? _value.no
           : no // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
     ));
   }
 }
@@ -906,17 +908,18 @@ class _$StepKeyPresentCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
 @FreezedUnionValue('StepKeyPresent')
 @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
 class _$StepKeyPresent implements StepKeyPresent {
-  const _$StepKeyPresent({this.symbol, this.yes, this.no});
+  const _$StepKeyPresent(
+      {required this.symbol, required this.yes, required this.no});
 
   factory _$StepKeyPresent.fromJson(Map<String, dynamic> json) =>
       _$_$StepKeyPresentFromJson(json);
 
   @override
-  final String? symbol;
+  final String symbol;
   @override
-  final String? yes;
+  final String yes;
   @override
-  final String? no;
+  final String no;
 
   @override
   String toString() {
@@ -951,11 +954,11 @@ class _$StepKeyPresent implements StepKeyPresent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String>? symbols, List<List<dynamic>>? keycodes)
+            List<String> symbols, List<List<dynamic>> keycodes)
         stepPressKey,
-    required TResult Function(String? symbol, String? yes, String? no)
+    required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
-    required TResult Function(String? layout, String? variant) stepResult,
+    required TResult Function(String layout, String variant) stepResult,
   }) {
     return stepKeyPresent(symbol, yes, no);
   }
@@ -963,10 +966,10 @@ class _$StepKeyPresent implements StepKeyPresent {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String>? symbols, List<List<dynamic>>? keycodes)?
+    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
         stepPressKey,
-    TResult Function(String? symbol, String? yes, String? no)? stepKeyPresent,
-    TResult Function(String? layout, String? variant)? stepResult,
+    TResult Function(String symbol, String yes, String no)? stepKeyPresent,
+    TResult Function(String layout, String variant)? stepResult,
     required TResult orElse(),
   }) {
     if (stepKeyPresent != null) {
@@ -1006,15 +1009,17 @@ class _$StepKeyPresent implements StepKeyPresent {
 }
 
 abstract class StepKeyPresent implements AnyStep {
-  const factory StepKeyPresent({String? symbol, String? yes, String? no}) =
-      _$StepKeyPresent;
+  const factory StepKeyPresent(
+      {required String symbol,
+      required String yes,
+      required String no}) = _$StepKeyPresent;
 
   factory StepKeyPresent.fromJson(Map<String, dynamic> json) =
       _$StepKeyPresent.fromJson;
 
-  String? get symbol => throw _privateConstructorUsedError;
-  String? get yes => throw _privateConstructorUsedError;
-  String? get no => throw _privateConstructorUsedError;
+  String get symbol => throw _privateConstructorUsedError;
+  String get yes => throw _privateConstructorUsedError;
+  String get no => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $StepKeyPresentCopyWith<StepKeyPresent> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1025,7 +1030,7 @@ abstract class $StepResultCopyWith<$Res> {
   factory $StepResultCopyWith(
           StepResult value, $Res Function(StepResult) then) =
       _$StepResultCopyWithImpl<$Res>;
-  $Res call({String? layout, String? variant});
+  $Res call({String layout, String variant});
 }
 
 /// @nodoc
@@ -1046,11 +1051,11 @@ class _$StepResultCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
       layout: layout == freezed
           ? _value.layout
           : layout // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       variant: variant == freezed
           ? _value.variant
           : variant // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
     ));
   }
 }
@@ -1060,15 +1065,15 @@ class _$StepResultCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
 @FreezedUnionValue('StepResult')
 @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
 class _$StepResult implements StepResult {
-  const _$StepResult({this.layout, this.variant});
+  const _$StepResult({required this.layout, required this.variant});
 
   factory _$StepResult.fromJson(Map<String, dynamic> json) =>
       _$_$StepResultFromJson(json);
 
   @override
-  final String? layout;
+  final String layout;
   @override
-  final String? variant;
+  final String variant;
 
   @override
   String toString() {
@@ -1100,11 +1105,11 @@ class _$StepResult implements StepResult {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String>? symbols, List<List<dynamic>>? keycodes)
+            List<String> symbols, List<List<dynamic>> keycodes)
         stepPressKey,
-    required TResult Function(String? symbol, String? yes, String? no)
+    required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
-    required TResult Function(String? layout, String? variant) stepResult,
+    required TResult Function(String layout, String variant) stepResult,
   }) {
     return stepResult(layout, variant);
   }
@@ -1112,10 +1117,10 @@ class _$StepResult implements StepResult {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String>? symbols, List<List<dynamic>>? keycodes)?
+    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
         stepPressKey,
-    TResult Function(String? symbol, String? yes, String? no)? stepKeyPresent,
-    TResult Function(String? layout, String? variant)? stepResult,
+    TResult Function(String symbol, String yes, String no)? stepKeyPresent,
+    TResult Function(String layout, String variant)? stepResult,
     required TResult orElse(),
   }) {
     if (stepResult != null) {
@@ -1155,13 +1160,14 @@ class _$StepResult implements StepResult {
 }
 
 abstract class StepResult implements AnyStep {
-  const factory StepResult({String? layout, String? variant}) = _$StepResult;
+  const factory StepResult({required String layout, required String variant}) =
+      _$StepResult;
 
   factory StepResult.fromJson(Map<String, dynamic> json) =
       _$StepResult.fromJson;
 
-  String? get layout => throw _privateConstructorUsedError;
-  String? get variant => throw _privateConstructorUsedError;
+  String get layout => throw _privateConstructorUsedError;
+  String get variant => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $StepResultCopyWith<StepResult> get copyWith =>
       throw _privateConstructorUsedError;

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -625,7 +625,9 @@ class _$AnyStepTearOff {
   const _$AnyStepTearOff();
 
   StepPressKey stepPressKey(
-      {required List<String> symbols, required List<List<dynamic>> keycodes}) {
+      {required List<String> symbols,
+      @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+          required Map<int, String> keycodes}) {
     return StepPressKey(
       symbols: symbols,
       keycodes: keycodes,
@@ -661,7 +663,9 @@ mixin _$AnyStep {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String> symbols, List<List<dynamic>> keycodes)
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)
         stepPressKey,
     required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
@@ -670,7 +674,10 @@ mixin _$AnyStep {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
+    TResult Function(
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)?
         stepPressKey,
     TResult Function(String symbol, String yes, String no)? stepKeyPresent,
     TResult Function(String layout, String variant)? stepResult,
@@ -715,7 +722,10 @@ abstract class $StepPressKeyCopyWith<$Res> {
   factory $StepPressKeyCopyWith(
           StepPressKey value, $Res Function(StepPressKey) then) =
       _$StepPressKeyCopyWithImpl<$Res>;
-  $Res call({List<String> symbols, List<List<dynamic>> keycodes});
+  $Res call(
+      {List<String> symbols,
+      @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+          Map<int, String> keycodes});
 }
 
 /// @nodoc
@@ -741,7 +751,7 @@ class _$StepPressKeyCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
       keycodes: keycodes == freezed
           ? _value.keycodes
           : keycodes // ignore: cast_nullable_to_non_nullable
-              as List<List<dynamic>>,
+              as Map<int, String>,
     ));
   }
 }
@@ -751,7 +761,10 @@ class _$StepPressKeyCopyWithImpl<$Res> extends _$AnyStepCopyWithImpl<$Res>
 @FreezedUnionValue('StepPressKey')
 @JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
 class _$StepPressKey implements StepPressKey {
-  const _$StepPressKey({required this.symbols, required this.keycodes});
+  const _$StepPressKey(
+      {required this.symbols,
+      @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+          required this.keycodes});
 
   factory _$StepPressKey.fromJson(Map<String, dynamic> json) =>
       _$_$StepPressKeyFromJson(json);
@@ -759,7 +772,8 @@ class _$StepPressKey implements StepPressKey {
   @override
   final List<String> symbols;
   @override
-  final List<List<dynamic>> keycodes;
+  @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+  final Map<int, String> keycodes;
 
   @override
   String toString() {
@@ -793,7 +807,9 @@ class _$StepPressKey implements StepPressKey {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String> symbols, List<List<dynamic>> keycodes)
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)
         stepPressKey,
     required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
@@ -805,7 +821,10 @@ class _$StepPressKey implements StepPressKey {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
+    TResult Function(
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)?
         stepPressKey,
     TResult Function(String symbol, String yes, String no)? stepKeyPresent,
     TResult Function(String layout, String variant)? stepResult,
@@ -850,13 +869,15 @@ class _$StepPressKey implements StepPressKey {
 abstract class StepPressKey implements AnyStep {
   const factory StepPressKey(
       {required List<String> symbols,
-      required List<List<dynamic>> keycodes}) = _$StepPressKey;
+      @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+          required Map<int, String> keycodes}) = _$StepPressKey;
 
   factory StepPressKey.fromJson(Map<String, dynamic> json) =
       _$StepPressKey.fromJson;
 
   List<String> get symbols => throw _privateConstructorUsedError;
-  List<List<dynamic>> get keycodes => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+  Map<int, String> get keycodes => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $StepPressKeyCopyWith<StepPressKey> get copyWith =>
       throw _privateConstructorUsedError;
@@ -954,7 +975,9 @@ class _$StepKeyPresent implements StepKeyPresent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String> symbols, List<List<dynamic>> keycodes)
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)
         stepPressKey,
     required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
@@ -966,7 +989,10 @@ class _$StepKeyPresent implements StepKeyPresent {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
+    TResult Function(
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)?
         stepPressKey,
     TResult Function(String symbol, String yes, String no)? stepKeyPresent,
     TResult Function(String layout, String variant)? stepResult,
@@ -1105,7 +1131,9 @@ class _$StepResult implements StepResult {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
-            List<String> symbols, List<List<dynamic>> keycodes)
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)
         stepPressKey,
     required TResult Function(String symbol, String yes, String no)
         stepKeyPresent,
@@ -1117,7 +1145,10 @@ class _$StepResult implements StepResult {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(List<String> symbols, List<List<dynamic>> keycodes)?
+    TResult Function(
+            List<String> symbols,
+            @JsonKey(fromJson: _keycodesFromJson, toJson: _keycodesToJson)
+                Map<int, String> keycodes)?
         stepPressKey,
     TResult Function(String symbol, String yes, String no)? stepKeyPresent,
     TResult Function(String layout, String variant)? stepResult,

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -128,9 +128,9 @@ const _$ApplicationStateEnumMap = {
 _$StepPressKey _$_$StepPressKeyFromJson(Map<String, dynamic> json) {
   return _$StepPressKey(
     symbols:
-        (json['symbols'] as List<dynamic>?)?.map((e) => e as String).toList(),
-    keycodes: (json['keycodes'] as List<dynamic>?)
-        ?.map((e) => e as List<dynamic>)
+        (json['symbols'] as List<dynamic>).map((e) => e as String).toList(),
+    keycodes: (json['keycodes'] as List<dynamic>)
+        .map((e) => e as List<dynamic>)
         .toList(),
   );
 }
@@ -143,9 +143,9 @@ Map<String, dynamic> _$_$StepPressKeyToJson(_$StepPressKey instance) =>
 
 _$StepKeyPresent _$_$StepKeyPresentFromJson(Map<String, dynamic> json) {
   return _$StepKeyPresent(
-    symbol: json['symbol'] as String?,
-    yes: json['yes'] as String?,
-    no: json['no'] as String?,
+    symbol: json['symbol'] as String,
+    yes: json['yes'] as String,
+    no: json['no'] as String,
   );
 }
 
@@ -158,8 +158,8 @@ Map<String, dynamic> _$_$StepKeyPresentToJson(_$StepKeyPresent instance) =>
 
 _$StepResult _$_$StepResultFromJson(Map<String, dynamic> json) {
   return _$StepResult(
-    layout: json['layout'] as String?,
-    variant: json['variant'] as String?,
+    layout: json['layout'] as String,
+    variant: json['variant'] as String,
   );
 }
 

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -129,16 +129,14 @@ _$StepPressKey _$_$StepPressKeyFromJson(Map<String, dynamic> json) {
   return _$StepPressKey(
     symbols:
         (json['symbols'] as List<dynamic>).map((e) => e as String).toList(),
-    keycodes: (json['keycodes'] as List<dynamic>)
-        .map((e) => e as List<dynamic>)
-        .toList(),
+    keycodes: _keycodesFromJson(json['keycodes'] as List),
   );
 }
 
 Map<String, dynamic> _$_$StepPressKeyToJson(_$StepPressKey instance) =>
     <String, dynamic>{
       'symbols': instance.symbols,
-      'keycodes': instance.keycodes,
+      'keycodes': _keycodesToJson(instance.keycodes),
     };
 
 _$StepKeyPresent _$_$StepKeyPresentFromJson(Map<String, dynamic> json) {

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -427,9 +427,6 @@ void main() {
       final stepPressKey = step0 as StepPressKey;
       expect(stepPressKey.symbols, isNotEmpty);
       expect(stepPressKey.keycodes, isNotEmpty);
-      expect(stepPressKey.keycodes.first, hasLength(2));
-      expect(stepPressKey.keycodes.first.first, isA<int>());
-      expect(stepPressKey.keycodes.first.last, isA<String>());
 
       // assumes that step 2 is a result step
       final step2 = await client.getKeyboardStep('2');

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -427,9 +427,9 @@ void main() {
       final stepPressKey = step0 as StepPressKey;
       expect(stepPressKey.symbols, isNotEmpty);
       expect(stepPressKey.keycodes, isNotEmpty);
-      expect(stepPressKey.keycodes!.first, hasLength(2));
-      expect(stepPressKey.keycodes!.first.first, isA<int>());
-      expect(stepPressKey.keycodes!.first.last, isA<String>());
+      expect(stepPressKey.keycodes.first, hasLength(2));
+      expect(stepPressKey.keycodes.first.first, isA<int>());
+      expect(stepPressKey.keycodes.first.last, isA<String>());
 
       // assumes that step 2 is a result step
       final step2 = await client.getKeyboardStep('2');

--- a/packages/subiquity_client/test/types_test.dart
+++ b/packages/subiquity_client/test/types_test.dart
@@ -283,10 +283,10 @@ void main() {
   test('keyboard layout key press step', () {
     const step = StepPressKey(
       symbols: ['z'],
-      keycodes: [
-        [21, '2'],
-        [44, '3']
-      ],
+      keycodes: {
+        21: '2',
+        44: '3',
+      },
     );
     final json = <String, dynamic>{
       'symbols': ['z'],

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_detector.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_detector.dart
@@ -39,24 +39,13 @@ class KeyboardLayoutDetector extends ValueNotifier<AnyStep?> {
     value = step;
   }
 
-  String? _findKeycodeStep(int keycode) {
-    final steps = _pressKeyStep?.keycodes ?? const [];
-    for (final step in steps) {
-      assert(step.length == 2);
-      if (keycode == step.first.toInt()) {
-        return step.last.toString();
-      }
-    }
-    return null;
-  }
-
   /// Initializes the detector.
   Future<void> init() => _getKeyboardStep();
 
   /// Delivers a key press from the user. The detector proceeds to the next step
   /// if possible.
   void press(int keycode) {
-    final step = _findKeycodeStep(keycode);
+    final step = _pressKeyStep?.keycodes[keycode];
     if (step != null) {
       _getKeyboardStep(step);
     }

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
@@ -9,7 +9,7 @@ void main() {
   test('init', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(null)).thenAnswer((_) async {
-      return AnyStep.stepPressKey(symbols: ['a', 'b', 'c']);
+      return AnyStep.stepPressKey(keycodes: [], symbols: ['a', 'b', 'c']);
     });
 
     final detector = KeyboardLayoutDetector(client);
@@ -31,7 +31,7 @@ void main() {
       );
     });
     when(client.getKeyboardStep('34')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: '56');
+      return AnyStep.stepKeyPresent(symbol: '56', yes: '', no: '');
     });
 
     final detector = KeyboardLayoutDetector(client);
@@ -59,7 +59,7 @@ void main() {
     late AnyStep result;
     final detector = KeyboardLayoutDetector(
       client,
-      value: AnyStep.stepKeyPresent(symbol: 'y', yes: '78'),
+      value: AnyStep.stepKeyPresent(symbol: 'y', yes: '78', no: ''),
       onResult: (value) => result = value,
     );
 
@@ -85,7 +85,7 @@ void main() {
     late AnyStep result;
     final detector = KeyboardLayoutDetector(
       client,
-      value: AnyStep.stepKeyPresent(symbol: 'n', no: '90'),
+      value: AnyStep.stepKeyPresent(symbol: 'n', yes: '', no: '90'),
       onResult: (value) => result = value,
     );
 

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
@@ -9,7 +9,7 @@ void main() {
   test('init', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(null)).thenAnswer((_) async {
-      return AnyStep.stepPressKey(keycodes: [], symbols: ['a', 'b', 'c']);
+      return AnyStep.stepPressKey(keycodes: {}, symbols: ['a', 'b', 'c']);
     });
 
     final detector = KeyboardLayoutDetector(client);
@@ -25,9 +25,7 @@ void main() {
     when(client.getKeyboardStep(null)).thenAnswer((_) async {
       return AnyStep.stepPressKey(
         symbols: ['a', 'b', 'c'],
-        keycodes: [
-          [12, '34']
-        ],
+        keycodes: {12: '34'},
       );
     });
     when(client.getKeyboardStep('34')).thenAnswer((_) async {

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
@@ -16,11 +16,7 @@ void main() {
   testWidgets('detect layout', (tester) async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(null)).thenAnswer((_) async {
-      return AnyStep.stepPressKey(symbols: [
-        'a'
-      ], keycodes: [
-        [30, '40']
-      ]);
+      return AnyStep.stepPressKey(symbols: ['a'], keycodes: {30: '40'});
     });
     when(client.getKeyboardStep('40')).thenAnswer((_) async {
       return AnyStep.stepKeyPresent(symbol: 'b', yes: '50', no: '');

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
@@ -23,10 +23,10 @@ void main() {
       ]);
     });
     when(client.getKeyboardStep('40')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: 'b', yes: '50');
+      return AnyStep.stepKeyPresent(symbol: 'b', yes: '50', no: '');
     });
     when(client.getKeyboardStep('50')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: 'c', no: '60');
+      return AnyStep.stepKeyPresent(symbol: 'c', yes: '', no: '60');
     });
     when(client.getKeyboardStep('60')).thenAnswer((_) async {
       return AnyStep.stepResult(layout: 'd', variant: 'e');

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
@@ -43,8 +43,8 @@ void main() {
 
   Widget buildPage(KeyboardLayoutModel model) {
     final client = MockSubiquityClient();
-    when(client.getKeyboardStep(any))
-        .thenAnswer((_) async => AnyStep.stepPressKey());
+    when(client.getKeyboardStep(any)).thenAnswer(
+        (_) async => AnyStep.stepPressKey(keycodes: [], symbols: []));
     registerMockService<SubiquityClient>(client);
 
     return ChangeNotifierProvider<KeyboardLayoutModel>.value(

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
@@ -44,7 +44,7 @@ void main() {
   Widget buildPage(KeyboardLayoutModel model) {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(any)).thenAnswer(
-        (_) async => AnyStep.stepPressKey(keycodes: [], symbols: []));
+        (_) async => AnyStep.stepPressKey(keycodes: {}, symbols: []));
     registerMockService<SubiquityClient>(client);
 
     return ChangeNotifierProvider<KeyboardLayoutModel>.value(


### PR DESCRIPTION
All the StepPressKey, StepKeyPresent, and StepResult fields are non-
nullable i.e. none of them is Optional in Subiquity. Making every field
nullable only gives a false sense of safety and clutters the UI code
with unnecessary null-aware operators and repeated imaginary defaults
that are never used because the values coming from Subiquity cannot be
null.

Ref: https://github.com/canonical/ubuntu-desktop-installer/issues/412