### PR TITLE
Removes ProxyAssetBundle dependency on /proc/self/exe symbolic link.

### DIFF
--- a/packages/ubuntu_wizard/lib/src/utils/proxy_asset_bundle.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/proxy_asset_bundle.dart
@@ -7,9 +7,6 @@ typedef StructuredDataParser<T> = Future<T> Function(String value);
 
 /// Attempts to locate assets in the app asset bundle, or if not found, falls
 /// back to the specified package's asset bundle.
-///
-/// NOTE: This class works on Linux only. Assets are assumed to be ordinary
-/// files that are resolved relative to `/proc/self/exe`.
 class ProxyAssetBundle extends AssetBundle {
   ProxyAssetBundle(this.source, {required this.package});
 
@@ -33,7 +30,7 @@ class ProxyAssetBundle extends AssetBundle {
 
   Future<String> _findAsset(String assetName, {required String package}) async {
     // <app>/data/flutter_assets/
-    final exePath = await File('/proc/self/exe').resolveSymbolicLinks();
+    final exePath = Platform.resolvedExecutable;
     final bundlePath = p.join(p.dirname(exePath), 'data', 'flutter_assets');
 
     // <bundle>/assets/foo.png

--- a/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
+++ b/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
@@ -6,14 +6,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:path/path.dart' as p;
 
 import 'proxy_asset_bundle_test.mocks.dart';
 
-const appPath = '/path/to/app';
-const assetName = 'assets/foo.txt';
-const bundlePath = '$appPath/data/flutter_assets';
-const appAssetPath = '$bundlePath/$assetName';
-const pkgAssetPath = '$bundlePath/packages/qux/$assetName';
+final appPath = p.dirname(Platform.resolvedExecutable);
+final assetName = p.join('assets', 'foo.txt');
+final bundlePath = p.join(appPath, 'data', 'flutter_assets');
+final appAssetPath = p.join(bundlePath, assetName);
+final pkgAssetPath = p.join(bundlePath, 'packages', 'qux', assetName);
 
 @GenerateMocks([], customMocks: [
   MockSpec<AssetBundle>(
@@ -133,11 +134,7 @@ class MockFileCreator {
   final Set<String> paths;
   File call(String path) {
     final file = MockFile(path);
-    if (path == '/proc/self/exe') {
-      when(file.resolveSymbolicLinks()).thenAnswer((_) async => '$appPath/exe');
-    } else {
-      when(file.exists()).thenAnswer((_) async => paths.contains(path));
-    }
+    when(file.exists()).thenAnswer((_) async => paths.contains(path));
     return file;
   }
 }


### PR DESCRIPTION
Hello! While doing my research I stumbled accross this class with a big note saying that it only works on Linux due dependency on `/proc/self/exe` symlink. It turns out Dart offers a suitable API for the resolved path of the app executable: `Platform.resolvedExecutable`. If I understood correctly the intent here, the following set of modifications makes this class portable. To prove the concept, I took a screenshot of the same codebase running Linux (over WSL) and Windows versions (compiled in release mode).

![portable_proxyassetbundle](https://user-images.githubusercontent.com/11138291/169602478-1ba8a607-576a-45c0-a5d1-7e30e76a9cbe.png)
