### PR TITLE
Another attempt to stabilize WSL integration tests

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -95,6 +95,7 @@ void main() {
     );
 
     await testApplyingChangesPage(tester, expectClose: true);
+    await tester.pumpAndSettle();
 
     await verifyConfigFile('reconfiguration/wsl.conf');
   });


### PR DESCRIPTION
By applying to 'reconifiguration' test the same operations as the other tests
    `await tester.pumpAndSettle();`
Before verifying goldens.

When WSL tests failed recently, it was due that test not completing. Let's see if the pattern applied will strength that test.