### PR TITLE
Prevents window getting unclosable on server exit

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -47,7 +47,9 @@ screens, yet allowing user to overwrite any of those during setup.
         variant.value = value;
         if (value == Variant.WSL_SETUP) {
           subiquityMonitor.onStatusChanged.listen((status) {
-            setWindowClosable(status?.state?.isInstalling == false);
+            final closable =
+                status == null || status.state?.isInstalling == false;
+            setWindowClosable(closable);
           });
         }
       });

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -47,9 +47,7 @@ screens, yet allowing user to overwrite any of those during setup.
         variant.value = value;
         if (value == Variant.WSL_SETUP) {
           subiquityMonitor.onStatusChanged.listen((status) {
-            final closable =
-                status == null || status.state?.isInstalling == false;
-            setWindowClosable(closable);
+            setWindowClosable(status?.state?.isInstalling != true);
           });
         }
       });


### PR DESCRIPTION
Hello! I'm not quite sure how, but latest Windows builds revealed a race condition on the window getting non-closable after Subiquity server exiting. Checking Subiquity status monitor current state for null and allowing the window to be closed in that situation prevents the window from getting unclosable after the server reporting DONE (or ERROR) and exiting.

Closes https://github.com/ubuntu/WSL/issues/201