### PR TITLE
Simplify await waitForWindowClosed() in WSL integration tests

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -189,8 +189,7 @@ Future<void> testApplyingChangesPage(
   expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
 
   if (expectClose) {
-    final windowClosed = waitForWindowClosed();
-    await expectLater(windowClosed, completion(isTrue));
+    expect(await waitForWindowClosed(), isTrue);
   }
 }
 


### PR DESCRIPTION
Unlike in other tests, on the applying changes page there's no button
press between querying the future and waiting for it to complete.