### PR TITLE
Prepare tests for Disk API changes

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -89,7 +89,7 @@ void main() {
 
   testWidgets('manual partitioning', (tester) async {
     final storage = [
-      Disk(
+      testDisk(
         path: '/dev/sda',
         partitions: [
           Partition(size: toBytes(6, DataUnit.gigabytes), mount: '/'),

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -18,7 +18,7 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaml/yaml.dart';
 
-import '../test/widget_tester_extensions.dart';
+import '../test/test_utils.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -10,7 +10,7 @@ import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_types
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'allocate_disk_space_page_test.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 
@@ -18,9 +18,9 @@ void main() {
   setUpAll(() => UbuntuTester.context = AlertDialog);
 
   testWidgets('create partition', (tester) async {
-    final testDisk = Disk();
-    final testGap = Gap(offset: 0, size: 1000000);
-    final model = buildModel(selectedDisk: testDisk);
+    final disk = testDisk();
+    final gap = Gap(offset: 0, size: 1000000);
+    final model = buildModel(selectedDisk: disk);
 
     registerMockService<UdevService>(MockUdevService());
 
@@ -32,7 +32,7 @@ void main() {
     );
 
     final result = showCreatePartitionDialog(
-        tester.element(find.byType(AllocateDiskSpacePage)), testDisk, testGap);
+        tester.element(find.byType(AllocateDiskSpacePage)), disk, gap);
     await tester.pumpAndSettle();
 
     await tester.tap(find.byType(DropdownButton<DataUnit>));
@@ -61,8 +61,8 @@ void main() {
     await result;
 
     verify(model.addPartition(
-      testDisk,
-      testGap,
+      disk,
+      gap,
       size: 123,
       format: PartitionFormat.btrfs,
       mount: '/tst',
@@ -73,7 +73,7 @@ void main() {
     tester.binding.window.devicePixelRatioTestValue = 1;
     tester.binding.window.physicalSizeTestValue = Size(960, 680);
 
-    final testDisk = Disk(partitions: [
+    final disk = testDisk(partitions: [
       Partition(
         number: 1,
         format: 'ext4',
@@ -83,7 +83,7 @@ void main() {
       ),
       Gap(offset: 123, size: 1000000),
     ]);
-    final model = buildModel(selectedDisk: testDisk);
+    final model = buildModel(selectedDisk: disk);
 
     registerMockService<UdevService>(MockUdevService());
 
@@ -96,8 +96,8 @@ void main() {
 
     final result = showEditPartitionDialog(
         tester.element(find.byType(AllocateDiskSpacePage)),
-        testDisk,
-        testDisk.partitions!.whereType<Partition>().first);
+        disk,
+        disk.partitions!.whereType<Partition>().first);
     await tester.pumpAndSettle();
 
     await tester.tap(find.byType(DropdownButton<PartitionFormat>));
@@ -120,8 +120,8 @@ void main() {
     await result;
 
     verify(model.editPartition(
-      testDisk,
-      testDisk.partitions!.whereType<Partition>().first,
+      disk,
+      disk.partitions!.whereType<Partition>().first,
       format: PartitionFormat.btrfs,
       wipe: false,
       mount: '/tst',

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -11,14 +11,14 @@ import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_types.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'allocate_disk_space_model_test.mocks.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 
 final selection = StreamController.broadcast();
 
-const testDisks = <Disk>[
-  Disk(
+final testDisks = <Disk>[
+  testDisk(
     path: '/dev/sda',
     size: 12,
     partitions: [
@@ -37,7 +37,7 @@ const testDisks = <Disk>[
       )
     ],
   ),
-  Disk(
+  testDisk(
     path: '/dev/sdb',
     size: 23,
     partitions: [
@@ -264,7 +264,7 @@ void main() {
   });
 
   testWidgets('confirm new partition table', (tester) async {
-    const disk = Disk(ptable: 'gpt', path: '/dev/sda');
+    final disk = testDisk(ptable: 'gpt', path: '/dev/sda');
     final model = buildModel(
       disks: [disk],
       selectedDisk: disk,

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_selector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_selector_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_selector.dart';
+
+import '../test_utils.dart';
 
 void main() {
   testWidgets('initial selection', (tester) async {
@@ -12,7 +13,7 @@ void main() {
             title: '',
             storages: [
               for (var i = 0; i < 3; i++)
-                Disk(model: 'model$i', vendor: 'vendor$i'),
+                testDisk(model: 'model$i', vendor: 'vendor$i'),
             ],
             selected: 1,
             onSelected: (_) {},
@@ -37,7 +38,7 @@ void main() {
             title: '',
             storages: [
               for (var i = 0; i < 3; i++)
-                Disk(model: 'model$i', vendor: 'vendor$i'),
+                testDisk(model: 'model$i', vendor: 'vendor$i'),
             ],
             onSelected: (v) => selected = v,
           ),

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
@@ -4,9 +4,11 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_columns.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_table.dart';
 
+import '../test_utils.dart';
+
 void main() {
-  const sda = Disk(path: '/dev/sda', size: 11);
-  const sdb = Disk(
+  final sda = testDisk(path: '/dev/sda', size: 11);
+  final sdb = testDisk(
     path: '/dev/sdb',
     size: 22,
     partitions: [
@@ -14,7 +16,7 @@ void main() {
       Gap(offset: 2211, size: 2222),
     ],
   );
-  const sdc = Disk(
+  final sdc = testDisk(
     path: '/dev/sdc',
     size: 33,
     partitions: [
@@ -23,7 +25,7 @@ void main() {
       Gap(offset: 3322, size: 3333),
     ],
   );
-  const sdd = Disk(
+  final sdd = testDisk(
     path: '/dev/sdd',
     size: 44,
     partitions: [
@@ -59,7 +61,7 @@ void main() {
     return MaterialApp(
       home: StorageTable(
         columns: columns,
-        storages: const [sda, sdb, sdc, sdd],
+        storages: [sda, sdb, sdc, sdd],
         canSelect: canSelect,
         isSelected: isSelected,
         onSelected: onSelected,

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_desktop_installer/pages/choose_security_key/choose_securi
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'choose_security_key_page_test.mocks.dart';
 
 @GenerateMocks([ChooseSecurityKeyModel])

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.dart
@@ -7,7 +7,7 @@ import 'package:ubuntu_desktop_installer/pages/choose_your_look_page.dart';
 import 'package:ubuntu_wizard/settings.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'choose_your_look_page_test.mocks.dart';
 
 @GenerateMocks([Settings])

--- a/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/configure_secure_boot/configure_s
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'configure_secure_boot_page_test.mocks.dart';
 
 @GenerateMocks([ConfigureSecureBootModel])

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
@@ -19,7 +19,7 @@ import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'connect_to_internet_page_test.mocks.dart';
 
 @GenerateMocks([

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_view_test.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/connect_to_internet/ethernet_mode
 import 'package:ubuntu_desktop_installer/pages/connect_to_internet/ethernet_view.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'ethernet_view_test.mocks.dart';
 
 @GenerateMocks([EthernetModel, EthernetDevice])

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/connect_to_internet/wifi_model.da
 import 'package:ubuntu_desktop_installer/pages/connect_to_internet/wifi_view.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'wifi_view_test.mocks.dart';
 
 @GenerateMocks([AccessPoint, WifiModel, WifiDevice])

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_desktop_installer/pages/installation_complete/installatio
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'installation_complete_page_test.mocks.dart';
 
 @GenerateMocks([InstallationCompleteModel])

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -13,7 +13,7 @@ import 'package:ubuntu_desktop_installer/slides.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'installation_slides_page_test.mocks.dart';
 
 @GenerateMocks([InstallationSlidesModel, JournalService])

--- a/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_desktop_installer/slides/slide_widgets.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'slides_test.mocks.dart';
 
 @GenerateMocks([UrlLauncher])

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
@@ -7,7 +7,7 @@ import 'package:ubuntu_desktop_installer/pages/installation_type/installation_ty
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_page.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
 
 void main() {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_desktop_installer/pages/installation_type/installation_ty
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
+import '../test_utils.dart';
 import 'installation_type_model_test.mocks.dart';
 
 @GenerateMocks([DiskStorageService, TelemetryService])
@@ -23,8 +24,8 @@ void main() {
       version: '22.04 LTS',
       type: 'linux',
     );
-    const existingOS = [
-      Disk(partitions: [
+    final existingOS = [
+      testDisk(partitions: [
         Partition(os: ubuntu2110),
         Partition(os: ubuntu2204),
       ]),

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -11,7 +11,7 @@ import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
 
 @GenerateMocks([InstallationTypeModel])

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_dialogs_test.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_w
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 
 void main() {
   setUpAll(() => UbuntuTester.context = DetectKeyboardLayoutView);

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
@@ -12,7 +12,7 @@ import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_w
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'keyboard_layout_page_test.mocks.dart';
 
 @GenerateMocks([KeyboardLayoutModel])

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_widgets_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_widgets_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 
 void main() {
   setUpAll(() => UbuntuTester.context = DetectKeyboardLayoutView);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
@@ -4,11 +4,12 @@ import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
+import '../test_utils.dart';
 import 'select_guided_storage_model_test.mocks.dart';
 
 @GenerateMocks([DiskStorageService])
 void main() {
-  const testStorages = <Disk>[Disk(id: 'a'), Disk(id: 'b')];
+  final testStorages = <Disk>[testDisk(id: 'a'), testDisk(id: 'b')];
 
   test('load guided storage', () async {
     final service = MockDiskStorageService();

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -8,15 +8,15 @@ import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guid
 import 'package:ubuntu_desktop_installer/pages/select_guided_storage/select_guided_storage_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
 
 @GenerateMocks([SelectGuidedStorageModel])
 void main() {
-  const testStorages = <Disk>[
-    Disk(path: '/dev/sda', size: 12, model: 'SDA', vendor: 'ATA'),
-    Disk(path: '/dev/sdb', size: 23, model: 'SDB', vendor: 'ATA'),
+  final testStorages = <Disk>[
+    testDisk(path: '/dev/sda', size: 12, model: 'SDA', vendor: 'ATA'),
+    testDisk(path: '/dev/sdb', size: 23, model: 'SDB', vendor: 'ATA'),
   ];
 
   SelectGuidedStorageModel buildModel({

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -4,8 +4,10 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 
+import '../test_utils.dart';
+
 void main() {
-  const testDisks = <Disk>[Disk(id: 'a'), Disk(id: 'b')];
+  final testDisks = <Disk>[testDisk(id: 'a'), testDisk(id: 'b')];
 
   late SubiquityClient client;
 
@@ -117,7 +119,7 @@ void main() {
   });
 
   test('add/edit/remove partition', () async {
-    final disk = Disk(id: 'tst');
+    final disk = testDisk(id: 'tst');
     final gap = Gap(offset: 2, size: 3);
     final partition = Partition(number: 1);
     final service = DiskStorageService(client);
@@ -145,7 +147,7 @@ void main() {
   });
 
   test('add boot partition', () async {
-    final disk = Disk(id: 'tst');
+    final disk = testDisk(id: 'tst');
     final service = DiskStorageService(client);
 
     when(client.addBootPartitionV2(disk))
@@ -157,7 +159,7 @@ void main() {
   });
 
   test('reformat disk', () async {
-    final disk = Disk(id: 'tst');
+    final disk = testDisk(id: 'tst');
     final service = DiskStorageService(client);
 
     when(client.reformatDiskV2(disk))

--- a/packages/ubuntu_desktop_installer/test/test_utils.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
@@ -64,4 +65,36 @@ extension UbuntuTester on WidgetTester {
       ),
     );
   }
+}
+
+Disk testDisk({
+  String? id,
+  String? label,
+  String? path,
+  String? type,
+  int? size,
+  List<String>? usageLabels,
+  List<DiskObject>? partitions,
+  bool? okForGuided,
+  String? ptable,
+  bool? preserve,
+  bool? bootDevice,
+  String? model,
+  String? vendor,
+}) {
+  return Disk(
+    id: id,
+    label: label,
+    path: path,
+    type: type,
+    size: size,
+    usageLabels: usageLabels,
+    partitions: partitions,
+    okForGuided: okForGuided,
+    ptable: ptable,
+    preserve: preserve,
+    bootDevice: bootDevice,
+    model: model,
+    vendor: vendor,
+  );
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'turn_off_bitlocker_page_test.mocks.dart';
 
 @GenerateMocks([TurnOffBitLockerModel, UrlLauncher])

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'turn_off_rst_page_test.mocks.dart';
 
 @GenerateMocks([TurnOffRSTModel, UrlLauncher])

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
@@ -12,7 +12,7 @@ import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'updates_other_software_model_test.mocks.dart';
 import 'updates_other_software_page_test.mocks.dart';
 

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_desktop_installer/pages/where_are_you/where_are_you_page.
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'where_are_you_model_test.mocks.dart';
 import 'where_are_you_page_test.mocks.dart';
 

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
@@ -10,7 +10,7 @@ import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_model.dar
 import 'package:ubuntu_desktop_installer/pages/who_are_you/who_are_you_page.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'who_are_you_page_test.mocks.dart';
 
 @GenerateMocks([WhoAreYouModel])

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -5,17 +5,18 @@ import 'package:ubuntu_desktop_installer/pages/write_changes_to_disk/write_chang
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
+import '../test_utils.dart';
 import 'write_changes_to_disk_model_test.mocks.dart';
 
 @GenerateMocks([DiskStorageService])
 void main() {
-  const testDisks = <Disk>[
-    Disk(
+  final testDisks = <Disk>[
+    testDisk(
       id: 'a',
       preserve: false,
       partitions: [Partition(number: 1, preserve: false)],
     ),
-    Disk(
+    testDisk(
       id: 'b',
       preserve: true,
       partitions: [
@@ -23,7 +24,7 @@ void main() {
         Partition(number: 2, grubDevice: true),
       ],
     ),
-    Disk(
+    testDisk(
       id: 'c',
       preserve: false,
       partitions: [
@@ -33,13 +34,13 @@ void main() {
     ),
   ];
 
-  const nonPreservedDisks = <Disk>[
-    Disk(
+  final nonPreservedDisks = <Disk>[
+    testDisk(
       id: 'a',
       preserve: false,
       partitions: [Partition(number: 1, preserve: false)],
     ),
-    Disk(
+    testDisk(
       id: 'c',
       preserve: false,
       partitions: [Partition(number: 3, preserve: false)],

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -9,12 +9,12 @@ import 'package:ubuntu_desktop_installer/pages/write_changes_to_disk/write_chang
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
 
-import '../widget_tester_extensions.dart';
+import '../test_utils.dart';
 import 'write_changes_to_disk_model_test.mocks.dart';
 import 'write_changes_to_disk_page_test.mocks.dart';
 
-const testDisks = <Disk>[
-  Disk(
+final testDisks = <Disk>[
+  testDisk(
     path: '/dev/sda',
     size: 12,
     preserve: false,
@@ -35,7 +35,7 @@ const testDisks = <Disk>[
       )
     ],
   ),
-  Disk(
+  testDisk(
     path: '/dev/sdb',
     size: 23,
     preserve: false,


### PR DESCRIPTION
This helps to take the next step, which is to make the majority of Disk
arguments required and non-nullable to match the Subiquity API. With a
centralized helper method we can stick some dummy defaults in one place
instead of repeating them all over the place.

Ref: #412