### PR TITLE
Upgrade to modularized flutter_html 3.0

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   filesize: ^2.0.0
   flutter:
     sdk: flutter
-  flutter_html: ^2.1.1
+  flutter_html: ^3.0.0-0
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.6.2

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_html: ^2.1.1
+  flutter_html: ^3.0.0-0
   get_it: ^7.2.0
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0


### PR DESCRIPTION
The new modularized version of `flutter_html` allows us to leave out
some unnecessary transitive dependencies, such as the `chewie` video
player and the `flutter_math_fork` math symbol renderer.

This reduces the size of the bundle by a couple of MB, and at the
same time gets rid of some annoying null-aware operator warnings
from `flutter_math_fork` that still hasn't been upgraded to Flutter 3:
```
ERROR: ../../../../../.pub-cache/hosted/pub.dartlang.org/flutter_math_fork-0.4.2+2/lib/src/widgets/selectable.dart:459:24: Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which excludes null.
ERROR:  - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('../../../../../.fvm/versions/stable/packages/flutter/lib/src/scheduler/binding.dart').
ERROR:       SchedulerBinding.instance!.addPostFrameCallback((_) {
ERROR:                        ^
```