### PR TITLE
Replaces `String socketPath`  by an Endpoint

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:dartx/dartx.dart';
-import 'package:subiquity_client/src/server.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'endpoint.dart';
 import 'types.dart';
 
 /// @internal
@@ -47,7 +47,7 @@ class SubiquityClient {
   Future<bool> get isOpen => _isOpen.future;
 
   void open(Endpoint endpoint) {
-    log.info('Opening socket address ${endpoint.address}');
+    log.info('Opening socket to $endpoint');
     _endpoint = endpoint;
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
       return Socket.startConnect(endpoint.address, endpoint.port);
@@ -56,7 +56,7 @@ class SubiquityClient {
   }
 
   Future<void> close() async {
-    log.info('Closing socket address ${_endpoint.address}');
+    log.info('Closing socket to $_endpoint');
     _client.close();
   }
 

--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:dartx/dartx.dart';
-import 'package:path/path.dart' as p;
+import 'package:subiquity_client/src/server.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'types.dart';
 
@@ -41,23 +41,22 @@ class SubiquityException implements Exception {
 
 class SubiquityClient {
   final _client = HttpClient();
-  late String _socketPath;
+  late Endpoint _endpoint;
   final _isOpen = Completer<bool>();
 
   Future<bool> get isOpen => _isOpen.future;
 
-  void open(String socketPath) {
-    log.info('Opening socket ${p.absolute(socketPath)}');
-    _socketPath = socketPath;
+  void open(Endpoint endpoint) {
+    log.info('Opening socket address ${endpoint.address}');
+    _endpoint = endpoint;
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
-      var address = InternetAddress(socketPath, type: InternetAddressType.unix);
-      return Socket.startConnect(address, 0);
+      return Socket.startConnect(endpoint.address, endpoint.port);
     };
     _isOpen.complete(true);
   }
 
   Future<void> close() async {
-    log.info('Closing socket ${p.absolute(_socketPath)}');
+    log.info('Closing socket address ${_endpoint.address}');
     _client.close();
   }
 

--- a/packages/subiquity_client/lib/src/endpoint.dart
+++ b/packages/subiquity_client/lib/src/endpoint.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+/// Vocabulary type that combines an [InternetAddress] and a [port] number
+class Endpoint {
+  final InternetAddress address;
+  final int port;
+
+  /// Creates an Unix domain socket endpoint.
+  factory Endpoint.unix(String socketPath) => Endpoint(
+        InternetAddress(socketPath, type: InternetAddressType.unix),
+        port: 0,
+      );
+
+  /// Creates a localhost TCP endpoint on port number [port].
+  factory Endpoint.localhost(int port) => Endpoint(
+        InternetAddress('127.0.0.1', type: InternetAddressType.IPv4),
+        port: port,
+      );
+
+  Endpoint(this.address, {required this.port});
+
+  @override
+  String toString() =>
+      'Endpoint(${address.address} ${port != 0 ? ', port: $port' : ''})';
+}

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -6,29 +6,12 @@ import 'package:path/path.dart' as p;
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 
+import 'endpoint.dart';
+
 enum ServerMode { LIVE, DRY_RUN }
 
 /// @internal
 final log = Logger('subiquity_server');
-
-/// Vocabulary type that combines an [InternetAddress] and a [port] number
-class Endpoint {
-  final InternetAddress address;
-  final int port;
-
-  /// Creates an Unix domain socket endpoint.
-  factory Endpoint.unix(String socketPath) => Endpoint(
-        InternetAddress(socketPath, type: InternetAddressType.unix),
-        port: 0,
-      );
-
-  /// Creates a localhost TCP endpoint on port number [port].
-  factory Endpoint.localhost(int port) => Endpoint(
-        InternetAddress("127.0.0.1", type: InternetAddressType.IPv4),
-        port: port,
-      );
-  Endpoint(this.address, {required this.port});
-}
 
 abstract class SubiquityServer {
   Process? _serverProcess;

--- a/packages/subiquity_client/lib/src/status_monitor.dart
+++ b/packages/subiquity_client/lib/src/status_monitor.dart
@@ -20,10 +20,9 @@ class SubiquityStatusMonitor {
   StreamController<ApplicationStatus?>? _statusController;
 
   /// Starts monitoring the status using the provided [socketPath].
-  Future<bool> start(String socketPath) async {
+  Future<bool> start(InternetAddress address, {int port = 0}) async {
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
-      var address = InternetAddress(socketPath, type: InternetAddressType.unix);
-      return Socket.startConnect(address, 0);
+      return Socket.startConnect(address, port);
     };
     return _fetchStatus().then(_updateStatus).then((_) {
       _listen();

--- a/packages/subiquity_client/lib/subiquity_client.dart
+++ b/packages/subiquity_client/lib/subiquity_client.dart
@@ -1,5 +1,6 @@
 library subiquity_client;
 
 export 'src/client.dart' hide log;
+export 'src/endpoint.dart';
 export 'src/status_monitor.dart' hide log;
 export 'src/types.dart';

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -1,3 +1,4 @@
 library subiquity_server;
 
+export 'src/endpoint.dart';
 export 'src/server.dart' hide log;

--- a/packages/subiquity_client/test/status_monitor_test.dart
+++ b/packages/subiquity_client/test/status_monitor_test.dart
@@ -34,13 +34,17 @@ final isDone = testStatus(ApplicationState.DONE);
 
 @GenerateMocks([HttpClient, HttpClientRequest, HttpClientResponse])
 void main() {
+  final addr = InternetAddress(
+    '/tmp/subiquity.sock',
+    type: InternetAddressType.unix,
+  );
   group('start', () {
     test('before listen', () async {
       final client = createMockClient();
       final monitor = SubiquityStatusMonitor(client);
 
       // start first
-      await monitor.start('/tmp/subiquity.sock');
+      await monitor.start(addr);
       expect(monitor.status, equals(isWaiting));
       verify(client.openUrl('GET', noStatus)).called(1);
 
@@ -61,7 +65,7 @@ void main() {
       monitor.onStatusChanged.listen(statuses.add);
 
       // then start
-      await monitor.start('/tmp/subiquity.sock');
+      await monitor.start(addr);
       expect(monitor.status, equals(isWaiting));
       verify(client.openUrl('GET', noStatus)).called(1);
 
@@ -78,7 +82,7 @@ void main() {
     final client = createMockClient();
     final monitor = SubiquityStatusMonitor(client);
 
-    await monitor.start('/tmp/subiquity.sock');
+    await monitor.start(addr);
     expect(monitor.status, equals(isWaiting));
     await expectLater(monitor.onStatusChanged, emits(isRunning));
     verify(client.openUrl('GET', any)).called(isPositive);
@@ -100,7 +104,7 @@ void main() {
 
     final monitor = SubiquityStatusMonitor(client);
 
-    await monitor.start('/tmp/subiquity.sock');
+    await monitor.start(addr);
     expect(monitor.status, equals(isWaiting));
     await expectLater(
         monitor.onStatusChanged, emitsInOrder([isRunning, isNull]));

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -11,7 +11,8 @@ void main() {
   test('initialization', () async {
     client = SubiquityClient();
     final isOpen = client.isOpen;
-    Future.delayed(Duration(milliseconds: 1)).then((_) => client.open(''));
+    final address = Endpoint.unix('');
+    Future.delayed(Duration(milliseconds: 1)).then((_) => client.open(address));
     await expectLater(isOpen, completes);
     expect(await isOpen, isTrue);
   });

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -8,7 +8,8 @@ import 'package:dbus/dbus.dart' as _i2;
 import 'package:gsettings/src/gsettings.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/src/client.dart' as _i7;
-import 'package:subiquity_client/src/server.dart' as _i4;
+import 'package:subiquity_client/src/endpoint.dart' as _i4;
+import 'package:subiquity_client/src/server.dart' as _i8;
 import 'package:subiquity_client/src/types.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -367,13 +368,13 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
 /// A class which mocks [SubiquityServer].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityServer extends _i1.Mock implements _i4.SubiquityServer {
+class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   MockSubiquityServer() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<_i4.Endpoint> start(_i4.ServerMode? serverMode,
+  _i6.Future<_i4.Endpoint> start(_i8.ServerMode? serverMode,
           {List<String>? args, Map<String, String>? environment}) =>
       (super.noSuchMethod(
               Invocation.method(#start, [serverMode],

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -2,13 +2,13 @@
 // in ubuntu_test/src/generated.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i5;
+import 'dart:async' as _i6;
 
 import 'package:dbus/dbus.dart' as _i2;
-import 'package:gsettings/src/gsettings.dart' as _i4;
+import 'package:gsettings/src/gsettings.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/src/client.dart' as _i6;
-import 'package:subiquity_client/src/server.dart' as _i7;
+import 'package:subiquity_client/src/client.dart' as _i7;
+import 'package:subiquity_client/src/server.dart' as _i4;
 import 'package:subiquity_client/src/types.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -51,10 +51,12 @@ class _FakeWSLConfigurationAdvanced_10 extends _i1.Fake
 
 class _FakeAnyStep_11 extends _i1.Fake implements _i3.AnyStep {}
 
+class _FakeEndpoint_12 extends _i1.Fake implements _i4.Endpoint {}
+
 /// A class which mocks [GSettings].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGSettings extends _i1.Mock implements _i4.GSettings {
+class MockGSettings extends _i1.Mock implements _i5.GSettings {
   MockGSettings() {
     _i1.throwOnMissingStub(this);
   }
@@ -64,321 +66,322 @@ class MockGSettings extends _i1.Mock implements _i4.GSettings {
       (super.noSuchMethod(Invocation.getter(#schemaName), returnValue: '')
           as String);
   @override
-  _i5.Stream<List<String>> get keysChanged => (super.noSuchMethod(
+  _i6.Stream<List<String>> get keysChanged => (super.noSuchMethod(
       Invocation.getter(#keysChanged),
-      returnValue: Stream<List<String>>.empty()) as _i5.Stream<List<String>>);
+      returnValue: Stream<List<String>>.empty()) as _i6.Stream<List<String>>);
   @override
-  _i5.Future<List<String>> list() =>
+  _i6.Future<List<String>> list() =>
       (super.noSuchMethod(Invocation.method(#list, []),
               returnValue: Future<List<String>>.value(<String>[]))
-          as _i5.Future<List<String>>);
+          as _i6.Future<List<String>>);
   @override
-  _i5.Future<_i2.DBusValue> get(String? name) =>
+  _i6.Future<_i2.DBusValue> get(String? name) =>
       (super.noSuchMethod(Invocation.method(#get, [name]),
               returnValue: Future<_i2.DBusValue>.value(_FakeDBusValue_0()))
-          as _i5.Future<_i2.DBusValue>);
+          as _i6.Future<_i2.DBusValue>);
   @override
-  _i5.Future<_i2.DBusValue> getDefault(String? name) =>
+  _i6.Future<_i2.DBusValue> getDefault(String? name) =>
       (super.noSuchMethod(Invocation.method(#getDefault, [name]),
               returnValue: Future<_i2.DBusValue>.value(_FakeDBusValue_0()))
-          as _i5.Future<_i2.DBusValue>);
+          as _i6.Future<_i2.DBusValue>);
   @override
-  _i5.Future<bool> isSet(String? name) =>
+  _i6.Future<bool> isSet(String? name) =>
       (super.noSuchMethod(Invocation.method(#isSet, [name]),
-          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i5.Future<void> set(String? name, _i2.DBusValue? value) =>
+  _i6.Future<void> set(String? name, _i2.DBusValue? value) =>
       (super.noSuchMethod(Invocation.method(#set, [name, value]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<void> unset(String? name) =>
+  _i6.Future<void> unset(String? name) =>
       (super.noSuchMethod(Invocation.method(#unset, [name]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<void> setAll(Map<String, _i2.DBusValue?>? values) =>
+  _i6.Future<void> setAll(Map<String, _i2.DBusValue?>? values) =>
       (super.noSuchMethod(Invocation.method(#setAll, [values]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
+  _i6.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
 }
 
 /// A class which mocks [SubiquityClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityClient extends _i1.Mock implements _i6.SubiquityClient {
+class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   MockSubiquityClient() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<bool> get isOpen => (super.noSuchMethod(Invocation.getter(#isOpen),
-      returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+  _i6.Future<bool> get isOpen => (super.noSuchMethod(Invocation.getter(#isOpen),
+      returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  void open(String? socketPath) =>
-      super.noSuchMethod(Invocation.method(#open, [socketPath]),
+  void open(_i4.Endpoint? endpoint) =>
+      super.noSuchMethod(Invocation.method(#open, [endpoint]),
           returnValueForMissingStub: null);
   @override
-  _i5.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
+  _i6.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i6.Variant> variant() =>
+  _i6.Future<_i7.Variant> variant() =>
       (super.noSuchMethod(Invocation.method(#variant, []),
-              returnValue: Future<_i6.Variant>.value(_i6.Variant.SERVER))
-          as _i5.Future<_i6.Variant>);
+              returnValue: Future<_i7.Variant>.value(_i7.Variant.SERVER))
+          as _i6.Future<_i7.Variant>);
   @override
-  _i5.Future<void> setVariant(_i6.Variant? variant) =>
+  _i6.Future<void> setVariant(_i7.Variant? variant) =>
       (super.noSuchMethod(Invocation.method(#setVariant, [variant]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.SourceSelectionAndSetting> source() =>
+  _i6.Future<_i3.SourceSelectionAndSetting> source() =>
       (super.noSuchMethod(Invocation.method(#source, []),
               returnValue: Future<_i3.SourceSelectionAndSetting>.value(
                   _FakeSourceSelectionAndSetting_1()))
-          as _i5.Future<_i3.SourceSelectionAndSetting>);
+          as _i6.Future<_i3.SourceSelectionAndSetting>);
   @override
-  _i5.Future<void> setSource(String? sourceId) =>
+  _i6.Future<void> setSource(String? sourceId) =>
       (super.noSuchMethod(Invocation.method(#setSource, [sourceId]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<String> locale() =>
+  _i6.Future<String> locale() =>
       (super.noSuchMethod(Invocation.method(#locale, []),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
+          returnValue: Future<String>.value('')) as _i6.Future<String>);
   @override
-  _i5.Future<void> setLocale(String? locale) =>
+  _i6.Future<void> setLocale(String? locale) =>
       (super.noSuchMethod(Invocation.method(#setLocale, [locale]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.KeyboardSetup> keyboard() => (super.noSuchMethod(
+  _i6.Future<_i3.KeyboardSetup> keyboard() => (super.noSuchMethod(
           Invocation.method(#keyboard, []),
           returnValue: Future<_i3.KeyboardSetup>.value(_FakeKeyboardSetup_2()))
-      as _i5.Future<_i3.KeyboardSetup>);
+      as _i6.Future<_i3.KeyboardSetup>);
   @override
-  _i5.Future<void> setKeyboard(_i3.KeyboardSetting? setting) =>
+  _i6.Future<void> setKeyboard(_i3.KeyboardSetting? setting) =>
       (super.noSuchMethod(Invocation.method(#setKeyboard, [setting]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<String> proxy() =>
+  _i6.Future<String> proxy() =>
       (super.noSuchMethod(Invocation.method(#proxy, []),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
+          returnValue: Future<String>.value('')) as _i6.Future<String>);
   @override
-  _i5.Future<void> setProxy(String? proxy) =>
+  _i6.Future<void> setProxy(String? proxy) =>
       (super.noSuchMethod(Invocation.method(#setProxy, [proxy]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<String> mirror() =>
+  _i6.Future<String> mirror() =>
       (super.noSuchMethod(Invocation.method(#mirror, []),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
+          returnValue: Future<String>.value('')) as _i6.Future<String>);
   @override
-  _i5.Future<void> setMirror(String? mirror) =>
+  _i6.Future<void> setMirror(String? mirror) =>
       (super.noSuchMethod(Invocation.method(#setMirror, [mirror]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<bool> freeOnly() =>
+  _i6.Future<bool> freeOnly() =>
       (super.noSuchMethod(Invocation.method(#freeOnly, []),
-          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i5.Future<void> setFreeOnly(bool? enable) =>
+  _i6.Future<void> setFreeOnly(bool? enable) =>
       (super.noSuchMethod(Invocation.method(#setFreeOnly, [enable]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.IdentityData> identity() => (super.noSuchMethod(
+  _i6.Future<_i3.IdentityData> identity() => (super.noSuchMethod(
           Invocation.method(#identity, []),
           returnValue: Future<_i3.IdentityData>.value(_FakeIdentityData_3()))
-      as _i5.Future<_i3.IdentityData>);
+      as _i6.Future<_i3.IdentityData>);
   @override
-  _i5.Future<void> setIdentity(_i3.IdentityData? identity) =>
+  _i6.Future<void> setIdentity(_i3.IdentityData? identity) =>
       (super.noSuchMethod(Invocation.method(#setIdentity, [identity]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.UsernameValidation> validateUsername(String? username) =>
+  _i6.Future<_i3.UsernameValidation> validateUsername(String? username) =>
       (super.noSuchMethod(Invocation.method(#validateUsername, [username]),
               returnValue: Future<_i3.UsernameValidation>.value(
                   _i3.UsernameValidation.OK))
-          as _i5.Future<_i3.UsernameValidation>);
+          as _i6.Future<_i3.UsernameValidation>);
   @override
-  _i5.Future<_i3.TimeZoneInfo> timezone() => (super.noSuchMethod(
+  _i6.Future<_i3.TimeZoneInfo> timezone() => (super.noSuchMethod(
           Invocation.method(#timezone, []),
           returnValue: Future<_i3.TimeZoneInfo>.value(_FakeTimeZoneInfo_4()))
-      as _i5.Future<_i3.TimeZoneInfo>);
+      as _i6.Future<_i3.TimeZoneInfo>);
   @override
-  _i5.Future<void> setTimezone(String? timezone) =>
+  _i6.Future<void> setTimezone(String? timezone) =>
       (super.noSuchMethod(Invocation.method(#setTimezone, [timezone]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.SSHData> ssh() =>
+  _i6.Future<_i3.SSHData> ssh() =>
       (super.noSuchMethod(Invocation.method(#ssh, []),
               returnValue: Future<_i3.SSHData>.value(_FakeSSHData_5()))
-          as _i5.Future<_i3.SSHData>);
+          as _i6.Future<_i3.SSHData>);
   @override
-  _i5.Future<void> setSsh(_i3.SSHData? ssh) =>
+  _i6.Future<void> setSsh(_i3.SSHData? ssh) =>
       (super.noSuchMethod(Invocation.method(#setSsh, [ssh]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.ApplicationStatus> status({_i3.ApplicationState? current}) =>
+  _i6.Future<_i3.ApplicationStatus> status({_i3.ApplicationState? current}) =>
       (super.noSuchMethod(Invocation.method(#status, [], {#current: current}),
               returnValue: Future<_i3.ApplicationStatus>.value(
                   _FakeApplicationStatus_6()))
-          as _i5.Future<_i3.ApplicationStatus>);
+          as _i6.Future<_i3.ApplicationStatus>);
   @override
-  _i5.Future<void> markConfigured(List<String>? endpointNames) =>
+  _i6.Future<void> markConfigured(List<String>? endpointNames) =>
       (super.noSuchMethod(Invocation.method(#markConfigured, [endpointNames]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<void> confirm(String? tty) =>
+  _i6.Future<void> confirm(String? tty) =>
       (super.noSuchMethod(Invocation.method(#confirm, [tty]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<bool> hasRst() =>
+  _i6.Future<bool> hasRst() =>
       (super.noSuchMethod(Invocation.method(#hasRst, []),
-          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i5.Future<bool> hasBitLocker() =>
+  _i6.Future<bool> hasBitLocker() =>
       (super.noSuchMethod(Invocation.method(#hasBitLocker, []),
-          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i5.Future<_i3.GuidedStorageResponse> getGuidedStorage({bool? wait = true}) =>
+  _i6.Future<_i3.GuidedStorageResponse> getGuidedStorage({bool? wait = true}) =>
       (super.noSuchMethod(
               Invocation.method(#getGuidedStorage, [], {#wait: wait}),
               returnValue: Future<_i3.GuidedStorageResponse>.value(
                   _FakeGuidedStorageResponse_7()))
-          as _i5.Future<_i3.GuidedStorageResponse>);
+          as _i6.Future<_i3.GuidedStorageResponse>);
   @override
-  _i5.Future<_i3.StorageResponseV2> setGuidedStorageV2(
+  _i6.Future<_i3.StorageResponseV2> setGuidedStorageV2(
           _i3.GuidedChoice? choice) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorageV2, [choice]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> getStorageV2() => (super.noSuchMethod(
+  _i6.Future<_i3.StorageResponseV2> getStorageV2() => (super.noSuchMethod(
           Invocation.method(#getStorageV2, []),
           returnValue:
               Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
-      as _i5.Future<_i3.StorageResponseV2>);
+      as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> setStorageV2() => (super.noSuchMethod(
+  _i6.Future<_i3.StorageResponseV2> setStorageV2() => (super.noSuchMethod(
           Invocation.method(#setStorageV2, []),
           returnValue:
               Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
-      as _i5.Future<_i3.StorageResponseV2>);
+      as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> resetStorageV2() => (super.noSuchMethod(
+  _i6.Future<_i3.StorageResponseV2> resetStorageV2() => (super.noSuchMethod(
           Invocation.method(#resetStorageV2, []),
           returnValue:
               Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
-      as _i5.Future<_i3.StorageResponseV2>);
+      as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> addPartitionV2(
+  _i6.Future<_i3.StorageResponseV2> addPartitionV2(
           _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#addPartitionV2, [disk, gap, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> editPartitionV2(
+  _i6.Future<_i3.StorageResponseV2> editPartitionV2(
           _i3.Disk? disk, _i3.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#editPartitionV2, [disk, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> deletePartitionV2(
+  _i6.Future<_i3.StorageResponseV2> deletePartitionV2(
           _i3.Disk? disk, _i3.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#deletePartitionV2, [disk, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> addBootPartitionV2(_i3.Disk? disk) =>
+  _i6.Future<_i3.StorageResponseV2> addBootPartitionV2(_i3.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartitionV2, [disk]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<_i3.StorageResponseV2> reformatDiskV2(_i3.Disk? disk) =>
+  _i6.Future<_i3.StorageResponseV2> reformatDiskV2(_i3.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDiskV2, [disk]),
               returnValue: Future<_i3.StorageResponseV2>.value(
                   _FakeStorageResponseV2_8()))
-          as _i5.Future<_i3.StorageResponseV2>);
+          as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i5.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
+  _i6.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
       Invocation.method(#reboot, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+  _i6.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
       Invocation.method(#shutdown, [], {#immediate: immediate}),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.WSLConfigurationBase> wslConfigurationBase() =>
+  _i6.Future<_i3.WSLConfigurationBase> wslConfigurationBase() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationBase, []),
               returnValue: Future<_i3.WSLConfigurationBase>.value(
                   _FakeWSLConfigurationBase_9()))
-          as _i5.Future<_i3.WSLConfigurationBase>);
+          as _i6.Future<_i3.WSLConfigurationBase>);
   @override
-  _i5.Future<void> setWslConfigurationBase(_i3.WSLConfigurationBase? conf) =>
+  _i6.Future<void> setWslConfigurationBase(_i3.WSLConfigurationBase? conf) =>
       (super.noSuchMethod(Invocation.method(#setWslConfigurationBase, [conf]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.WSLConfigurationAdvanced> wslConfigurationAdvanced() =>
+  _i6.Future<_i3.WSLConfigurationAdvanced> wslConfigurationAdvanced() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationAdvanced, []),
               returnValue: Future<_i3.WSLConfigurationAdvanced>.value(
                   _FakeWSLConfigurationAdvanced_10()))
-          as _i5.Future<_i3.WSLConfigurationAdvanced>);
+          as _i6.Future<_i3.WSLConfigurationAdvanced>);
   @override
-  _i5.Future<void> setWslConfigurationAdvanced(
+  _i6.Future<void> setWslConfigurationAdvanced(
           _i3.WSLConfigurationAdvanced? conf) =>
       (super.noSuchMethod(
           Invocation.method(#setWslConfigurationAdvanced, [conf]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
   @override
-  _i5.Future<_i3.AnyStep> getKeyboardStep([String? step = r'0']) =>
+  _i6.Future<_i3.AnyStep> getKeyboardStep([String? step = r'0']) =>
       (super.noSuchMethod(Invocation.method(#getKeyboardStep, [step]),
               returnValue: Future<_i3.AnyStep>.value(_FakeAnyStep_11()))
-          as _i5.Future<_i3.AnyStep>);
+          as _i6.Future<_i3.AnyStep>);
 }
 
 /// A class which mocks [SubiquityServer].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityServer extends _i1.Mock implements _i7.SubiquityServer {
+class MockSubiquityServer extends _i1.Mock implements _i4.SubiquityServer {
   MockSubiquityServer() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<String> start(_i7.ServerMode? serverMode,
+  _i6.Future<_i4.Endpoint> start(_i4.ServerMode? serverMode,
           {List<String>? args, Map<String, String>? environment}) =>
       (super.noSuchMethod(
-          Invocation.method(
-              #start, [serverMode], {#args: args, #environment: environment}),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
+              Invocation.method(#start, [serverMode],
+                  {#args: args, #environment: environment}),
+              returnValue: Future<_i4.Endpoint>.value(_FakeEndpoint_12()))
+          as _i6.Future<_i4.Endpoint>);
   @override
-  _i5.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
+  _i6.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
 }

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -101,7 +101,7 @@ Future<void> _verifyGoldenFile(String fileName, String goldenName) async {
 /// Waits for the subiquity server to be ready for integration testing.
 Future<void> waitForSubiquityServer() async {
   final startup = Completer();
-  callback(String socketPath) => startup.complete();
+  callback(Endpoint endpoint) => startup.complete();
 
   SubiquityServer.startupCallback = callback;
   addTearDown(() => SubiquityServer.startupCallback = null);

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -49,9 +49,9 @@ Future<void> runWizardApp(
 
   subiquityServer
       .start(serverMode, args: serverArgs, environment: serverEnvironment)
-      .then((socketPath) {
-    subiquityClient.open(socketPath);
-    subiquityMonitor?.start(socketPath);
+      .then((endpoint) {
+    subiquityClient.open(endpoint);
+    subiquityMonitor?.start(endpoint.address, port: endpoint.port);
 
     onInitSubiquity?.call(subiquityClient);
 

--- a/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
@@ -93,8 +93,8 @@ class MockSubiquityStatusMonitor extends _i1.Mock
               returnValue: Stream<_i6.ApplicationStatus?>.empty())
           as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(String? socketPath) =>
-      (super.noSuchMethod(Invocation.method(#start, [socketPath]),
+  _i4.Future<bool> start(_i3.InternetAddress? address, {int? port = 0}) =>
+      (super.noSuchMethod(Invocation.method(#start, [address], {#port: port}),
           returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
   @override
   _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),

--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
@@ -93,8 +93,8 @@ class MockSubiquityStatusMonitor extends _i1.Mock
               returnValue: Stream<_i6.ApplicationStatus?>.empty())
           as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(String? socketPath) =>
-      (super.noSuchMethod(Invocation.method(#start, [socketPath]),
+  _i4.Future<bool> start(_i3.InternetAddress? address, {int? port = 0}) =>
+      (super.noSuchMethod(Invocation.method(#start, [address], {#port: port}),
           returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
   @override
   _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),


### PR DESCRIPTION
Hello! This is the first attempt to flexibilize the relationship between the Flutter GUI clients and Subiquity server. Replacing the socket paths passed around in the API surface by a higher level construct enables us soon to compose other connections, like TCP, without changing the API.