### PR TITLE
Replace deprecated hashList() with Object.hashAll()

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -57,7 +57,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
       final model = Provider.of<AllocateDiskSpaceModel>(context, listen: false);
       if (model.selectedDiskIndex != -1) {
         _scrollController.scrollToIndex(
-          hashList([model.selectedDiskIndex, model.selectedObjectIndex]),
+          Object.hashAll([model.selectedDiskIndex, model.selectedObjectIndex]),
         );
       }
     });

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -43,7 +43,7 @@ class StorageTable extends StatelessWidget {
       return child;
     }
 
-    final index = hashList([disk, object]);
+    final index = Object.hashAll([disk, object]);
     return AutoScrollTag(
       key: ValueKey(index),
       index: index,
@@ -83,7 +83,7 @@ class StorageTable extends StatelessWidget {
           objectIndex < disk.partitions.length;
           ++objectIndex)
         DataRow(
-          key: ValueKey(hashList([diskIndex, objectIndex])),
+          key: ValueKey(Object.hashAll([diskIndex, objectIndex])),
           selected: isSelected?.call(diskIndex, objectIndex) ?? false,
           onSelectChanged: canSelect?.call(diskIndex, objectIndex) == true
               ? (selected) {


### PR DESCRIPTION
With the latest Flutter master:
```
info • 'hashList' is deprecated and shouldn't be used. Use Object.hashAll() or Object.hashAllUnordered() instead. This feature was deprecated in v3.1.0-0.0.pre.897 • lib/pages/allocate_disk_space/storage_table.dart:86:25 • deprecated_member_use
```