### PR TITLE
Ensures port is used on Uri.http

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -42,13 +42,18 @@ class SubiquityException implements Exception {
 class SubiquityClient {
   final _client = HttpClient();
   late Endpoint _endpoint;
+  late String _host;
   final _isOpen = Completer<bool>();
 
   Future<bool> get isOpen => _isOpen.future;
 
+  Uri url(String unencodedPath, [Map<String, dynamic>? queryParameters]) =>
+      Uri.http(_host, unencodedPath, queryParameters);
+
   void open(Endpoint endpoint) {
     log.info('Opening socket to $endpoint');
     _endpoint = endpoint;
+    _host = endpoint.authority;
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
       return Socket.startConnect(endpoint.address, endpoint.port);
     };
@@ -81,8 +86,7 @@ class SubiquityClient {
   }
 
   Future<Variant> variant() async {
-    final request =
-        await _openUrl('GET', Uri.http('localhost', 'meta/client_variant'));
+    final request = await _openUrl('GET', url('meta/client_variant'));
     final response = await request.close();
 
     final responseStr = await _receive('variant()', response);
@@ -93,15 +97,13 @@ class SubiquityClient {
   Future<void> setVariant(Variant variant) async {
     final variantString = variant.toVariantString();
     final request = await _openUrl(
-        'POST',
-        Uri.http('localhost', 'meta/client_variant',
-            {'variant': '"$variantString"'}));
+        'POST', url('meta/client_variant', {'variant': '"$variantString"'}));
     final response = await request.close();
     await _receive('setVariant("$variantString")', response);
   }
 
   Future<SourceSelectionAndSetting> source() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'source'));
+    final request = await _openUrl('GET', url('source'));
     final response = await request.close();
 
     final json = await _receiveJson('source()', response);
@@ -109,14 +111,14 @@ class SubiquityClient {
   }
 
   Future<void> setSource(String sourceId) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'source', {'source_id': '"$sourceId"'}));
+    final request =
+        await _openUrl('POST', url('source', {'source_id': '"$sourceId"'}));
     final response = await request.close();
     await _receive('setSource("$sourceId")', response);
   }
 
   Future<String> locale() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'locale'));
+    final request = await _openUrl('GET', url('locale'));
     final response = await request.close();
 
     final responseStr = await _receive('locale()', response);
@@ -124,14 +126,14 @@ class SubiquityClient {
   }
 
   Future<void> setLocale(String locale) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'locale'));
+    final request = await _openUrl('POST', url('locale'));
     request.write('"$locale"');
     final response = await request.close();
     await _receive('setLocale("$locale")', response);
   }
 
   Future<KeyboardSetup> keyboard() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'keyboard'));
+    final request = await _openUrl('GET', url('keyboard'));
     final response = await request.close();
 
     final keyboardJson = await _receiveJson('keyboard()', response);
@@ -139,14 +141,14 @@ class SubiquityClient {
   }
 
   Future<void> setKeyboard(KeyboardSetting setting) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'keyboard'));
+    final request = await _openUrl('POST', url('keyboard'));
     request.write(jsonEncode(setting.toJson()));
     final response = await request.close();
     await _receive('setKeyboard(${jsonEncode(setting.toJson())})', response);
   }
 
   Future<String> proxy() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'proxy'));
+    final request = await _openUrl('GET', url('proxy'));
     final response = await request.close();
 
     final responseStr = await _receive('proxy()', response);
@@ -154,14 +156,14 @@ class SubiquityClient {
   }
 
   Future<void> setProxy(String proxy) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'proxy'));
+    final request = await _openUrl('POST', url('proxy'));
     request.write('"$proxy"');
     final response = await request.close();
     await _receive('setProxy("$proxy")', response);
   }
 
   Future<String> mirror() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'mirror'));
+    final request = await _openUrl('GET', url('mirror'));
     final response = await request.close();
 
     final responseStr = await _receive('mirror()', response);
@@ -169,15 +171,14 @@ class SubiquityClient {
   }
 
   Future<void> setMirror(String mirror) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'mirror'));
+    final request = await _openUrl('POST', url('mirror'));
     request.write('"$mirror"');
     final response = await request.close();
     await _receive('setMirror("$mirror")', response);
   }
 
   Future<bool> freeOnly() async {
-    final request =
-        await _openUrl('GET', Uri.http('localhost', 'meta/free_only'));
+    final request = await _openUrl('GET', url('meta/free_only'));
     final response = await request.close();
 
     final responseBool = await _receive('freeOnly()', response);
@@ -186,14 +187,14 @@ class SubiquityClient {
 
   // ignore: avoid_positional_boolean_parameters
   Future<void> setFreeOnly(bool enable) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'meta/free_only', {'enable': '$enable'}));
+    final request =
+        await _openUrl('POST', url('meta/free_only', {'enable': '$enable'}));
     final response = await request.close();
     await _receive('setFreeOnly("$freeOnly")', response);
   }
 
   Future<IdentityData> identity() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'identity'));
+    final request = await _openUrl('GET', url('identity'));
     final response = await request.close();
 
     final identityJson = await _receiveJson('identity()', response);
@@ -201,7 +202,7 @@ class SubiquityClient {
   }
 
   Future<void> setIdentity(IdentityData identity) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'identity'));
+    final request = await _openUrl('POST', url('identity'));
     request.write(jsonEncode(identity.toJson()));
     final response = await request.close();
     await _receive('setIdentity(${jsonEncode(identity.toJson())})', response);
@@ -224,7 +225,7 @@ class SubiquityClient {
   }
 
   Future<TimeZoneInfo> timezone() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'timezone'));
+    final request = await _openUrl('GET', url('timezone'));
     final response = await request.close();
 
     final timezoneJson = await _receiveJson('timezone()', response);
@@ -232,14 +233,14 @@ class SubiquityClient {
   }
 
   Future<void> setTimezone(String timezone) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'timezone', {'tz': '"$timezone"'}));
+    final request =
+        await _openUrl('POST', url('timezone', {'tz': '"$timezone"'}));
     final response = await request.close();
     await _receive('setTimezone("$timezone")', response);
   }
 
   Future<SSHData> ssh() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'ssh'));
+    final request = await _openUrl('GET', url('ssh'));
     final response = await request.close();
 
     final sshJson = await _receiveJson('ssh()', response);
@@ -247,7 +248,7 @@ class SubiquityClient {
   }
 
   Future<void> setSsh(SSHData ssh) async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'ssh'));
+    final request = await _openUrl('POST', url('ssh'));
     request.write(jsonEncode(ssh.toJson()));
     final response = await request.close();
     await _receive('setSsh(${jsonEncode(ssh.toJson())})', response);
@@ -258,13 +259,12 @@ class SubiquityClient {
     late Map<String, dynamic> statusJson;
 
     if (current != null) {
-      final request = await _openUrl('GET',
-          Uri.http('localhost', 'meta/status', {'cur': '"${current.name}"'}));
+      final request = await _openUrl(
+          'GET', url('meta/status', {'cur': '"${current.name}"'}));
       final response = await request.close();
       statusJson = await _receiveJson('status("${current.name}")', response);
     } else {
-      final request =
-          await _openUrl('GET', Uri.http('localhost', 'meta/status'));
+      final request = await _openUrl('GET', url('meta/status'));
       final response = await request.close();
       statusJson = await _receiveJson('status()', response);
     }
@@ -279,7 +279,7 @@ class SubiquityClient {
   Future<void> markConfigured(List<String> endpointNames) async {
     final request = await _openUrl(
         'POST',
-        Uri.http('localhost', 'meta/mark_configured',
+        url('meta/mark_configured',
             {'endpoint_names': jsonEncode(endpointNames)}));
     final response = await request.close();
     await _receive('markConfigured(${jsonEncode(endpointNames)})', response);
@@ -287,16 +287,15 @@ class SubiquityClient {
 
   /// Confirm that the installation should proceed.
   Future<void> confirm(String tty) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'meta/confirm', {'tty': '"$tty"'}));
+    final request =
+        await _openUrl('POST', url('meta/confirm', {'tty': '"$tty"'}));
     final response = await request.close();
     await _receive('confirm("$tty")', response);
   }
 
   /// Returns whether RST is turned on.
   Future<bool> hasRst() async {
-    final request =
-        await _openUrl('GET', Uri.http('localhost', 'storage/has_rst'));
+    final request = await _openUrl('GET', url('storage/has_rst'));
     final response = await request.close();
 
     final responseBool = await _receive('hasRst()', response);
@@ -305,8 +304,7 @@ class SubiquityClient {
 
   /// Returns whether any disks contain BitLocker partitions.
   Future<bool> hasBitLocker() async {
-    final request =
-        await _openUrl('GET', Uri.http('localhost', 'storage/has_bitlocker'));
+    final request = await _openUrl('GET', url('storage/has_bitlocker'));
     final response = await request.close();
 
     final responseStr = await _receive('hasBitLocker()', response);
@@ -315,8 +313,8 @@ class SubiquityClient {
 
   /// Get guided disk options.
   Future<GuidedStorageResponse> getGuidedStorage({bool wait = true}) async {
-    final request = await _openUrl(
-        'GET', Uri.http('localhost', 'storage/guided', {'wait': '$wait'}));
+    final request =
+        await _openUrl('GET', url('storage/guided', {'wait': '$wait'}));
     final response = await request.close();
 
     final responseJson =
@@ -325,8 +323,7 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> setGuidedStorageV2(GuidedChoice choice) async {
-    final request =
-        await _openUrl('POST', Uri.http('localhost', 'storage/v2/guided'));
+    final request = await _openUrl('POST', url('storage/v2/guided'));
     request.write(jsonEncode(choice.toJson()));
     final response = await request.close();
 
@@ -336,7 +333,7 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> getStorageV2() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'storage/v2'));
+    final request = await _openUrl('GET', url('storage/v2'));
     final response = await request.close();
 
     final responseJson = await _receiveJson('getStorageV2()', response);
@@ -344,7 +341,7 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> setStorageV2() async {
-    final request = await _openUrl('POST', Uri.http('localhost', 'storage/v2'));
+    final request = await _openUrl('POST', url('storage/v2'));
     final response = await request.close();
 
     final responseJson = await _receiveJson('setStorageV2()', response);
@@ -352,8 +349,7 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> resetStorageV2() async {
-    final request =
-        await _openUrl('POST', Uri.http('localhost', 'storage/v2/reset'));
+    final request = await _openUrl('POST', url('storage/v2/reset'));
     final response = await request.close();
 
     final responseJson = await _receiveJson('resetStorageV2()', response);
@@ -362,8 +358,7 @@ class SubiquityClient {
 
   Future<StorageResponseV2> addPartitionV2(
       Disk disk, Gap gap, Partition partition) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'storage/v2/add_partition'));
+    final request = await _openUrl('POST', url('storage/v2/add_partition'));
     request.write(jsonEncode(<String, dynamic>{
       'disk_id': disk.id,
       'gap': gap.toJson(),
@@ -378,8 +373,7 @@ class SubiquityClient {
 
   Future<StorageResponseV2> editPartitionV2(
       Disk disk, Partition partition) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'storage/v2/edit_partition'));
+    final request = await _openUrl('POST', url('storage/v2/edit_partition'));
     request.write(jsonEncode(<String, dynamic>{
       'disk_id': disk.id,
       'partition': partition.toJson(),
@@ -393,8 +387,7 @@ class SubiquityClient {
 
   Future<StorageResponseV2> deletePartitionV2(
       Disk disk, Partition partition) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'storage/v2/delete_partition'));
+    final request = await _openUrl('POST', url('storage/v2/delete_partition'));
     request.write(jsonEncode(<String, dynamic>{
       'disk_id': disk.id,
       'partition': partition.toJson(),
@@ -407,10 +400,8 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> addBootPartitionV2(Disk disk) async {
-    final request = await _openUrl(
-        'POST',
-        Uri.http('localhost', 'storage/v2/add_boot_partition',
-            {'disk_id': '"${disk.id}"'}));
+    final request = await _openUrl('POST',
+        url('storage/v2/add_boot_partition', {'disk_id': '"${disk.id}"'}));
     final response = await request.close();
 
     final responseJson =
@@ -419,8 +410,7 @@ class SubiquityClient {
   }
 
   Future<StorageResponseV2> reformatDiskV2(Disk disk) async {
-    final request = await _openUrl(
-        'POST', Uri.http('localhost', 'storage/v2/reformat_disk'));
+    final request = await _openUrl('POST', url('storage/v2/reformat_disk'));
     request.write(jsonEncode({'disk_id': disk.id}));
     final response = await request.close();
 
@@ -430,27 +420,23 @@ class SubiquityClient {
   }
 
   Future<void> reboot({bool immediate = false}) async {
-    final request = await _openUrl(
-        'POST',
-        Uri.http('localhost', 'shutdown',
-            {'mode': '"REBOOT"', 'immediate': '$immediate'}));
+    final request = await _openUrl('POST',
+        url('shutdown', {'mode': '"REBOOT"', 'immediate': '$immediate'}));
     try {
       await request.close();
     } on HttpException catch (_) {}
   }
 
   Future<void> shutdown({bool immediate = false}) async {
-    final request = await _openUrl(
-        'POST',
-        Uri.http('localhost', 'shutdown',
-            {'mode': '"POWEROFF"', 'immediate': '$immediate'}));
+    final request = await _openUrl('POST',
+        url('shutdown', {'mode': '"POWEROFF"', 'immediate': '$immediate'}));
     try {
       await request.close();
     } on HttpException catch (_) {}
   }
 
   Future<WSLConfigurationBase> wslConfigurationBase() async {
-    final request = await _openUrl('GET', Uri.http('localhost', 'wslconfbase'));
+    final request = await _openUrl('GET', url('wslconfbase'));
     final response = await request.close();
 
     final json = await _receiveJson('wslconfbase()', response);
@@ -458,16 +444,14 @@ class SubiquityClient {
   }
 
   Future<void> setWslConfigurationBase(WSLConfigurationBase conf) async {
-    final request =
-        await _openUrl('POST', Uri.http('localhost', 'wslconfbase'));
+    final request = await _openUrl('POST', url('wslconfbase'));
     request.write(jsonEncode(conf.toJson()));
     final response = await request.close();
     await _receive('setWslconfbase(${jsonEncode(conf.toJson())})', response);
   }
 
   Future<WSLConfigurationAdvanced> wslConfigurationAdvanced() async {
-    final request =
-        await _openUrl('GET', Uri.http('localhost', 'wslconfadvanced'));
+    final request = await _openUrl('GET', url('wslconfadvanced'));
     final response = await request.close();
 
     final json = await _receiveJson('wslconfadvanced()', response);
@@ -476,8 +460,7 @@ class SubiquityClient {
 
   Future<void> setWslConfigurationAdvanced(
       WSLConfigurationAdvanced conf) async {
-    final request =
-        await _openUrl('POST', Uri.http('localhost', 'wslconfadvanced'));
+    final request = await _openUrl('POST', url('wslconfadvanced'));
     request.write(jsonEncode(conf.toJson()));
     final response = await request.close();
     await _receive(
@@ -485,8 +468,8 @@ class SubiquityClient {
   }
 
   Future<AnyStep> getKeyboardStep([String? step = '0']) async {
-    final request = await _openUrl('GET',
-        Uri.http('localhost', 'keyboard/steps', {'index': '"${step ?? 0}"'}));
+    final request = await _openUrl(
+        'GET', url('keyboard/steps', {'index': '"${step ?? 0}"'}));
     final response = await request.close();
 
     final json = await _receiveJson('getKeyboardStep($step)', response);

--- a/packages/subiquity_client/lib/src/endpoint.dart
+++ b/packages/subiquity_client/lib/src/endpoint.dart
@@ -22,4 +22,8 @@ class Endpoint {
   @override
   String toString() =>
       'Endpoint(${address.address} ${port != 0 ? ', port: $port' : ''})';
+
+  String get authority => address.type == InternetAddressType.unix
+      ? 'localhost'
+      : '${address.host}${port != 0 ? ':$port' : ''}';
 }

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -160,8 +160,10 @@ abstract class SubiquityServer {
     // allow 10s maximum for the server to start responding
     for (var i = 0; i < 10; ++i) {
       try {
-        final request =
-            await client.openUrl('GET', Uri.http('localhost', 'meta/status'));
+        final request = await client.openUrl(
+          'GET',
+          Uri.http(endpoint.authority, 'meta/status'),
+        );
         await request.close();
         break;
       } on Exception catch (_) {

--- a/packages/subiquity_client/test/endpoint_test.dart
+++ b/packages/subiquity_client/test/endpoint_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:subiquity_client/src/endpoint.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('endpoint authority tcp', () {
+    final ep = Endpoint(
+        InternetAddress('8.8.8.8', type: InternetAddressType.IPv4),
+        port: 80);
+    expect(ep.authority, '8.8.8.8:80');
+  });
+
+  test('endpoint authority tcp localhost', () {
+    final ep = Endpoint.localhost(3344);
+    expect(ep.authority, '127.0.0.1:3344');
+  });
+
+  test('endpoint authority unix', () {
+    final ep = Endpoint.unix('/tmp/socket');
+    expect(ep.authority, 'localhost');
+  });
+}

--- a/packages/subiquity_client/test/status_monitor_test.dart
+++ b/packages/subiquity_client/test/status_monitor_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/src/endpoint.dart';
 import 'package:subiquity_client/src/status_monitor.dart';
 import 'package:subiquity_client/src/types.dart';
 import 'package:test/test.dart';
@@ -34,10 +35,7 @@ final isDone = testStatus(ApplicationState.DONE);
 
 @GenerateMocks([HttpClient, HttpClientRequest, HttpClientResponse])
 void main() {
-  final addr = InternetAddress(
-    '/tmp/subiquity.sock',
-    type: InternetAddressType.unix,
-  );
+  final addr = Endpoint.unix('/tmp/subiquity.sock');
   group('start', () {
     test('before listen', () async {
       final client = createMockClient();

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -24,35 +24,37 @@ import 'package:subiquity_client/src/types.dart' as _i3;
 
 class _FakeDBusValue_0 extends _i1.Fake implements _i2.DBusValue {}
 
-class _FakeSourceSelectionAndSetting_1 extends _i1.Fake
+class _FakeUri_1 extends _i1.Fake implements Uri {}
+
+class _FakeSourceSelectionAndSetting_2 extends _i1.Fake
     implements _i3.SourceSelectionAndSetting {}
 
-class _FakeKeyboardSetup_2 extends _i1.Fake implements _i3.KeyboardSetup {}
+class _FakeKeyboardSetup_3 extends _i1.Fake implements _i3.KeyboardSetup {}
 
-class _FakeIdentityData_3 extends _i1.Fake implements _i3.IdentityData {}
+class _FakeIdentityData_4 extends _i1.Fake implements _i3.IdentityData {}
 
-class _FakeTimeZoneInfo_4 extends _i1.Fake implements _i3.TimeZoneInfo {}
+class _FakeTimeZoneInfo_5 extends _i1.Fake implements _i3.TimeZoneInfo {}
 
-class _FakeSSHData_5 extends _i1.Fake implements _i3.SSHData {}
+class _FakeSSHData_6 extends _i1.Fake implements _i3.SSHData {}
 
-class _FakeApplicationStatus_6 extends _i1.Fake
+class _FakeApplicationStatus_7 extends _i1.Fake
     implements _i3.ApplicationStatus {}
 
-class _FakeGuidedStorageResponse_7 extends _i1.Fake
+class _FakeGuidedStorageResponse_8 extends _i1.Fake
     implements _i3.GuidedStorageResponse {}
 
-class _FakeStorageResponseV2_8 extends _i1.Fake
+class _FakeStorageResponseV2_9 extends _i1.Fake
     implements _i3.StorageResponseV2 {}
 
-class _FakeWSLConfigurationBase_9 extends _i1.Fake
+class _FakeWSLConfigurationBase_10 extends _i1.Fake
     implements _i3.WSLConfigurationBase {}
 
-class _FakeWSLConfigurationAdvanced_10 extends _i1.Fake
+class _FakeWSLConfigurationAdvanced_11 extends _i1.Fake
     implements _i3.WSLConfigurationAdvanced {}
 
-class _FakeAnyStep_11 extends _i1.Fake implements _i3.AnyStep {}
+class _FakeAnyStep_12 extends _i1.Fake implements _i3.AnyStep {}
 
-class _FakeEndpoint_12 extends _i1.Fake implements _i4.Endpoint {}
+class _FakeEndpoint_13 extends _i1.Fake implements _i4.Endpoint {}
 
 /// A class which mocks [GSettings].
 ///
@@ -122,6 +124,11 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<bool> get isOpen => (super.noSuchMethod(Invocation.getter(#isOpen),
       returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
+  Uri url(String? unencodedPath, [Map<String, dynamic>? queryParameters]) =>
+      (super.noSuchMethod(
+          Invocation.method(#url, [unencodedPath, queryParameters]),
+          returnValue: _FakeUri_1()) as Uri);
+  @override
   void open(_i4.Endpoint? endpoint) =>
       super.noSuchMethod(Invocation.method(#open, [endpoint]),
           returnValueForMissingStub: null);
@@ -143,7 +150,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<_i3.SourceSelectionAndSetting> source() =>
       (super.noSuchMethod(Invocation.method(#source, []),
               returnValue: Future<_i3.SourceSelectionAndSetting>.value(
-                  _FakeSourceSelectionAndSetting_1()))
+                  _FakeSourceSelectionAndSetting_2()))
           as _i6.Future<_i3.SourceSelectionAndSetting>);
   @override
   _i6.Future<void> setSource(String? sourceId) =>
@@ -162,7 +169,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.KeyboardSetup> keyboard() => (super.noSuchMethod(
           Invocation.method(#keyboard, []),
-          returnValue: Future<_i3.KeyboardSetup>.value(_FakeKeyboardSetup_2()))
+          returnValue: Future<_i3.KeyboardSetup>.value(_FakeKeyboardSetup_3()))
       as _i6.Future<_i3.KeyboardSetup>);
   @override
   _i6.Future<void> setKeyboard(_i3.KeyboardSetting? setting) =>
@@ -199,7 +206,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.IdentityData> identity() => (super.noSuchMethod(
           Invocation.method(#identity, []),
-          returnValue: Future<_i3.IdentityData>.value(_FakeIdentityData_3()))
+          returnValue: Future<_i3.IdentityData>.value(_FakeIdentityData_4()))
       as _i6.Future<_i3.IdentityData>);
   @override
   _i6.Future<void> setIdentity(_i3.IdentityData? identity) =>
@@ -215,7 +222,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.TimeZoneInfo> timezone() => (super.noSuchMethod(
           Invocation.method(#timezone, []),
-          returnValue: Future<_i3.TimeZoneInfo>.value(_FakeTimeZoneInfo_4()))
+          returnValue: Future<_i3.TimeZoneInfo>.value(_FakeTimeZoneInfo_5()))
       as _i6.Future<_i3.TimeZoneInfo>);
   @override
   _i6.Future<void> setTimezone(String? timezone) =>
@@ -225,7 +232,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.SSHData> ssh() =>
       (super.noSuchMethod(Invocation.method(#ssh, []),
-              returnValue: Future<_i3.SSHData>.value(_FakeSSHData_5()))
+              returnValue: Future<_i3.SSHData>.value(_FakeSSHData_6()))
           as _i6.Future<_i3.SSHData>);
   @override
   _i6.Future<void> setSsh(_i3.SSHData? ssh) =>
@@ -236,7 +243,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<_i3.ApplicationStatus> status({_i3.ApplicationState? current}) =>
       (super.noSuchMethod(Invocation.method(#status, [], {#current: current}),
               returnValue: Future<_i3.ApplicationStatus>.value(
-                  _FakeApplicationStatus_6()))
+                  _FakeApplicationStatus_7()))
           as _i6.Future<_i3.ApplicationStatus>);
   @override
   _i6.Future<void> markConfigured(List<String>? endpointNames) =>
@@ -261,32 +268,32 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
       (super.noSuchMethod(
               Invocation.method(#getGuidedStorage, [], {#wait: wait}),
               returnValue: Future<_i3.GuidedStorageResponse>.value(
-                  _FakeGuidedStorageResponse_7()))
+                  _FakeGuidedStorageResponse_8()))
           as _i6.Future<_i3.GuidedStorageResponse>);
   @override
   _i6.Future<_i3.StorageResponseV2> setGuidedStorageV2(
           _i3.GuidedChoice? choice) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorageV2, [choice]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> getStorageV2() => (super.noSuchMethod(
           Invocation.method(#getStorageV2, []),
           returnValue:
-              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
+              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9()))
       as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> setStorageV2() => (super.noSuchMethod(
           Invocation.method(#setStorageV2, []),
           returnValue:
-              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
+              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9()))
       as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> resetStorageV2() => (super.noSuchMethod(
           Invocation.method(#resetStorageV2, []),
           returnValue:
-              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_8()))
+              Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9()))
       as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> addPartitionV2(
@@ -294,7 +301,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
       (super.noSuchMethod(
               Invocation.method(#addPartitionV2, [disk, gap, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> editPartitionV2(
@@ -302,7 +309,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
       (super.noSuchMethod(
               Invocation.method(#editPartitionV2, [disk, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> deletePartitionV2(
@@ -310,19 +317,19 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
       (super.noSuchMethod(
               Invocation.method(#deletePartitionV2, [disk, partition]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> addBootPartitionV2(_i3.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartitionV2, [disk]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> reformatDiskV2(_i3.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDiskV2, [disk]),
               returnValue: Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_8()))
+                  _FakeStorageResponseV2_9()))
           as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
@@ -338,7 +345,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<_i3.WSLConfigurationBase> wslConfigurationBase() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationBase, []),
               returnValue: Future<_i3.WSLConfigurationBase>.value(
-                  _FakeWSLConfigurationBase_9()))
+                  _FakeWSLConfigurationBase_10()))
           as _i6.Future<_i3.WSLConfigurationBase>);
   @override
   _i6.Future<void> setWslConfigurationBase(_i3.WSLConfigurationBase? conf) =>
@@ -349,7 +356,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<_i3.WSLConfigurationAdvanced> wslConfigurationAdvanced() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationAdvanced, []),
               returnValue: Future<_i3.WSLConfigurationAdvanced>.value(
-                  _FakeWSLConfigurationAdvanced_10()))
+                  _FakeWSLConfigurationAdvanced_11()))
           as _i6.Future<_i3.WSLConfigurationAdvanced>);
   @override
   _i6.Future<void> setWslConfigurationAdvanced(
@@ -361,7 +368,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.AnyStep> getKeyboardStep([String? step = r'0']) =>
       (super.noSuchMethod(Invocation.method(#getKeyboardStep, [step]),
-              returnValue: Future<_i3.AnyStep>.value(_FakeAnyStep_11()))
+              returnValue: Future<_i3.AnyStep>.value(_FakeAnyStep_12()))
           as _i6.Future<_i3.AnyStep>);
 }
 
@@ -379,7 +386,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
       (super.noSuchMethod(
               Invocation.method(#start, [serverMode],
                   {#args: args, #environment: environment}),
-              returnValue: Future<_i4.Endpoint>.value(_FakeEndpoint_12()))
+              returnValue: Future<_i4.Endpoint>.value(_FakeEndpoint_13()))
           as _i6.Future<_i4.Endpoint>);
   @override
   _i6.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -51,7 +51,7 @@ Future<void> runWizardApp(
       .start(serverMode, args: serverArgs, environment: serverEnvironment)
       .then((endpoint) {
     subiquityClient.open(endpoint);
-    subiquityMonitor?.start(endpoint.address, port: endpoint.port);
+    subiquityMonitor?.start(endpoint);
 
     onInitSubiquity?.call(subiquityClient);
 

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -114,7 +114,7 @@ void main() {
   testWidgets('starts and registers the monitor', (tester) async {
     final endpoint = Endpoint.unix('/tmp/subiquity.sock');
     final monitor = MockSubiquityStatusMonitor();
-    when(monitor.start(endpoint.address)).thenAnswer((_) async => true);
+    when(monitor.start(endpoint)).thenAnswer((_) async => true);
 
     final server = MockSubiquityServer();
     when(server.start(any,
@@ -129,6 +129,6 @@ void main() {
     );
 
     expect(getService<SubiquityStatusMonitor>(), equals(monitor));
-    verify(monitor.start(endpoint.address)).called(1);
+    verify(monitor.start(endpoint)).called(1);
   });
 }

--- a/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
@@ -7,6 +7,7 @@ import 'dart:convert' as _i2;
 import 'dart:io' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/src/endpoint.dart' as _i7;
 import 'package:subiquity_client/src/status_monitor.dart' as _i5;
 import 'package:subiquity_client/src/types.dart' as _i6;
 
@@ -93,8 +94,8 @@ class MockSubiquityStatusMonitor extends _i1.Mock
               returnValue: Stream<_i6.ApplicationStatus?>.empty())
           as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(_i3.InternetAddress? address, {int? port = 0}) =>
-      (super.noSuchMethod(Invocation.method(#start, [address], {#port: port}),
+  _i4.Future<bool> start(_i7.Endpoint? endpoint) =>
+      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
           returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
   @override
   _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),

--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
@@ -7,6 +7,7 @@ import 'dart:convert' as _i2;
 import 'dart:io' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/src/endpoint.dart' as _i7;
 import 'package:subiquity_client/src/status_monitor.dart' as _i5;
 import 'package:subiquity_client/src/types.dart' as _i6;
 
@@ -93,8 +94,8 @@ class MockSubiquityStatusMonitor extends _i1.Mock
               returnValue: Stream<_i6.ApplicationStatus?>.empty())
           as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(_i3.InternetAddress? address, {int? port = 0}) =>
-      (super.noSuchMethod(Invocation.method(#start, [address], {#port: port}),
+  _i4.Future<bool> start(_i7.Endpoint? endpoint) =>
+      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
           returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
   @override
   _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),


### PR DESCRIPTION
In my experimentations setting the destination port on the connection factory (in Socket.startConnect) is not enough  when [openUrl](https://api.flutter.dev/flutter/dart-io/HttpClient/openUrl.html) is used, because it expects the full authority (i.e. "host:port") specified in the Uri paramter.
This creates the authority getter on the endpoint to facilitate formatting uri's.
Also subiquity client, server and monitor are modified to take this new method in consideration when building HTTP uri's.

It took me a while to convince myself about why this is necessary in the first place.