### PR TITLE
Extracts out of the SubiquityServer class path-related methods

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -1,17 +1,12 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
-import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 
 import 'endpoint.dart';
-
-enum ServerMode { LIVE, DRY_RUN }
-
-/// @internal
-final log = Logger('subiquity_server');
+import 'server/common.dart';
+import 'server/paths.dart';
 
 abstract class SubiquityServer {
   Process? _serverProcess;
@@ -36,45 +31,6 @@ abstract class SubiquityServer {
   // The name of the server's Python module.
   String get _pythonModule;
 
-  // The path of the socket is fixed in live-run mode. In dry-run mode, it needs
-  // to be resolved based on the location of the `subiquity_client` package.
-  Future<String> _getSocketPath(ServerMode mode) async {
-    if (mode == ServerMode.DRY_RUN) {
-      // Use a relative path to avoid hitting AF_UNIX path length limit because
-      // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
-      // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
-      return p.relative(p.join(await _getSubiquityPath(), '.subiquity/socket'));
-    }
-    return '/run/subiquity/socket';
-  }
-
-  String? _subiquityPath;
-
-  // Returns the location of the local subiquity submodule.
-  Future<String> _getSubiquityPath() async {
-    return _subiquityPath ??= await findSubiquityPath();
-  }
-
-  // Finds local subiquity relative to the `subiquity_client` Dart package.
-  static Future<String> findSubiquityPath() async {
-    Object? error;
-    final config = await findPackageConfig(
-      Directory.current,
-      onError: (e) => error = e,
-    );
-    final package = config?.packages
-        .firstWhere((package) => package.name == 'subiquity_client');
-    if (package == null) {
-      log.warning(
-          'Unable to find the subiquity_client package. '
-          'Falling back to the current working dir: ${Directory.current.path}',
-          error);
-    } else {
-      log.debug('Found subiquity_client in ${package.root.path}');
-    }
-    return p.join(package?.root.path ?? Directory.current.path, 'subiquity');
-  }
-
   // Prefer local curtin and probert python modules that are pinned to the
   // correct versions
   Map<String, String> _pythonPath(String subiquityPath) {
@@ -87,7 +43,7 @@ abstract class SubiquityServer {
 
   Future<Endpoint> start(ServerMode serverMode,
       {List<String>? args, Map<String, String>? environment}) async {
-    final socketPath = await _getSocketPath(serverMode);
+    final socketPath = await SubiquityPaths.getSocketPath(serverMode);
     final endpoint = Endpoint.unix(socketPath);
     if (_shouldStart(serverMode)) {
       var subiquityCmd = <String>[
@@ -107,7 +63,7 @@ abstract class SubiquityServer {
 
   Future<void> _startSubiquity(ServerMode serverMode, List<String> subiquityCmd,
       Map<String, String>? environment) async {
-    final subiquityPath = await _getSubiquityPath();
+    final subiquityPath = await SubiquityPaths.getSubiquityPath();
     String? workingDirectory;
     // try using local subiquity
     if (Directory(subiquityPath).existsSync()) {

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -43,7 +43,7 @@ abstract class SubiquityServer {
 
   Future<Endpoint> start(ServerMode serverMode,
       {List<String>? args, Map<String, String>? environment}) async {
-    final socketPath = await SubiquityPaths.getSocketPath(serverMode);
+    final socketPath = await getSocketPath(serverMode);
     final endpoint = Endpoint.unix(socketPath);
     if (_shouldStart(serverMode)) {
       var subiquityCmd = <String>[
@@ -63,7 +63,7 @@ abstract class SubiquityServer {
 
   Future<void> _startSubiquity(ServerMode serverMode, List<String> subiquityCmd,
       Map<String, String>? environment) async {
-    final subiquityPath = await SubiquityPaths.getSubiquityPath();
+    final subiquityPath = await getSubiquityPath();
     String? workingDirectory;
     // try using local subiquity
     if (Directory(subiquityPath).existsSync()) {

--- a/packages/subiquity_client/lib/src/server/common.dart
+++ b/packages/subiquity_client/lib/src/server/common.dart
@@ -1,0 +1,6 @@
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+enum ServerMode { LIVE, DRY_RUN }
+
+/// @internal
+final log = Logger('subiquity_server');

--- a/packages/subiquity_client/lib/src/server/paths.dart
+++ b/packages/subiquity_client/lib/src/server/paths.dart
@@ -5,29 +5,27 @@ import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
-class SubiquityPaths {
-  static String? _subiquityPath;
-  static String? _socketPath;
+String? _subiquityPath;
+String? _socketPath;
 
-  static Future<String> getSubiquityPath() async {
-    return _subiquityPath ??= await _findSubiquityPath();
-  }
+Future<String> getSubiquityPath() async {
+  return _subiquityPath ??= await _findSubiquityPath();
+}
 
-  static Future<String> getSocketPath(ServerMode mode) async {
-    return _socketPath ??= await _getSocketPath(mode);
-  }
+Future<String> getSocketPath(ServerMode mode) async {
+  return _socketPath ??= await _getSocketPath(mode);
+}
 
-  // The path of the socket is fixed in live-run mode. In dry-run mode, it needs
-  // to be resolved based on the location of the `subiquity_client` package.
-  static Future<String> _getSocketPath(ServerMode mode) async {
-    if (mode == ServerMode.DRY_RUN) {
-      // Use a relative path to avoid hitting AF_UNIX path length limit because
-      // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
-      // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
-      return p.relative(p.join(await getSubiquityPath(), '.subiquity/socket'));
-    }
-    return '/run/subiquity/socket';
+// The path of the socket is fixed in live-run mode. In dry-run mode, it needs
+// to be resolved based on the location of the `subiquity_client` package.
+Future<String> _getSocketPath(ServerMode mode) async {
+  if (mode == ServerMode.DRY_RUN) {
+    // Use a relative path to avoid hitting AF_UNIX path length limit because
+    // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
+    // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
+    return p.relative(p.join(await getSubiquityPath(), '.subiquity/socket'));
   }
+  return '/run/subiquity/socket';
 }
 
 // Finds local subiquity relative to the `subiquity_client` Dart package.

--- a/packages/subiquity_client/lib/src/server/paths.dart
+++ b/packages/subiquity_client/lib/src/server/paths.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
+
+import 'common.dart';
+
+class SubiquityPaths {
+  static String? _subiquityPath;
+  static String? _socketPath;
+
+  static Future<String> getSubiquityPath() async {
+    return _subiquityPath ??= await _findSubiquityPath();
+  }
+
+  static Future<String> getSocketPath(ServerMode mode) async {
+    return _socketPath ??= await _getSocketPath(mode);
+  }
+
+  // The path of the socket is fixed in live-run mode. In dry-run mode, it needs
+  // to be resolved based on the location of the `subiquity_client` package.
+  static Future<String> _getSocketPath(ServerMode mode) async {
+    if (mode == ServerMode.DRY_RUN) {
+      // Use a relative path to avoid hitting AF_UNIX path length limit because
+      // <path/to/ubuntu-desktop-installer>/packages/subiquity_client/subiquity/.subiquity/socket>
+      // grows easily to more than 108-1 characters (char sockaddr_un::sun_path[108]).
+      return p.relative(p.join(await getSubiquityPath(), '.subiquity/socket'));
+    }
+    return '/run/subiquity/socket';
+  }
+}
+
+// Finds local subiquity relative to the `subiquity_client` Dart package.
+Future<String> _findSubiquityPath() async {
+  Object? error;
+  final config = await findPackageConfig(
+    Directory.current,
+    onError: (e) => error = e,
+  );
+  final package = config?.packages
+      .firstWhere((package) => package.name == 'subiquity_client');
+  if (package == null) {
+    log.warning(
+        'Unable to find the subiquity_client package. '
+        'Falling back to the current working dir: ${Directory.current.path}',
+        error);
+  } else {
+    log.debug('Found subiquity_client in ${package.root.path}');
+  }
+  return p.join(package?.root.path ?? Directory.current.path, 'subiquity');
+}

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -1,4 +1,6 @@
 library subiquity_server;
 
 export 'src/endpoint.dart';
-export 'src/server.dart' hide log;
+export 'src/server/common.dart' hide log;
+export 'src/server/paths.dart';
+export 'src/server.dart';

--- a/packages/subiquity_client/test/subiquity_paths_test.dart
+++ b/packages/subiquity_client/test/subiquity_paths_test.dart
@@ -1,0 +1,17 @@
+import 'package:subiquity_client/subiquity_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('race does not change the result', () async {
+    final call1 = SubiquityPaths.getSubiquityPath();
+    final call2 = SubiquityPaths.getSubiquityPath();
+
+    expect(await call1, await call2);
+  });
+  test('race does not change the result 2', () async {
+    final call1 = SubiquityPaths.getSocketPath(ServerMode.DRY_RUN);
+    final call2 = SubiquityPaths.getSocketPath(ServerMode.DRY_RUN);
+
+    expect(await call1, await call2);
+  });
+}

--- a/packages/subiquity_client/test/subiquity_paths_test.dart
+++ b/packages/subiquity_client/test/subiquity_paths_test.dart
@@ -3,14 +3,14 @@ import 'package:test/test.dart';
 
 void main() {
   test('race does not change the result', () async {
-    final call1 = SubiquityPaths.getSubiquityPath();
-    final call2 = SubiquityPaths.getSubiquityPath();
+    final call1 = getSubiquityPath();
+    final call2 = getSubiquityPath();
 
     expect(await call1, await call2);
   });
   test('race does not change the result 2', () async {
-    final call1 = SubiquityPaths.getSocketPath(ServerMode.DRY_RUN);
-    final call2 = SubiquityPaths.getSocketPath(ServerMode.DRY_RUN);
+    final call1 = getSocketPath(ServerMode.DRY_RUN);
+    final call2 = getSocketPath(ServerMode.DRY_RUN);
 
     expect(await call1, await call2);
   });

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -10,6 +10,7 @@ import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/src/client.dart' as _i7;
 import 'package:subiquity_client/src/endpoint.dart' as _i4;
 import 'package:subiquity_client/src/server.dart' as _i8;
+import 'package:subiquity_client/src/server/common.dart' as _i9;
 import 'package:subiquity_client/src/types.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -381,7 +382,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   }
 
   @override
-  _i6.Future<_i4.Endpoint> start(_i8.ServerMode? serverMode,
+  _i6.Future<_i4.Endpoint> start(_i9.ServerMode? serverMode,
           {List<String>? args, Map<String, String>? environment}) =>
       (super.noSuchMethod(
               Invocation.method(#start, [serverMode],

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -15,7 +15,7 @@ import 'widget_testers.dart';
 /// The path to the `.subiquity` directory.
 Future<String> get subiquityPath async {
   return p.join(
-    await SubiquityPaths.getSubiquityPath(),
+    await getSubiquityPath(),
     '.subiquity',
   );
 }

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -15,7 +15,7 @@ import 'widget_testers.dart';
 /// The path to the `.subiquity` directory.
 Future<String> get subiquityPath async {
   return p.join(
-    await SubiquityServer.findSubiquityPath(),
+    await SubiquityPaths.getSubiquityPath(),
     '.subiquity',
   );
 }


### PR DESCRIPTION
This is the first step towards simplifying the SubiquityServer class.

Those paths are only relevant if we start Subiquity by directly executing Python on the same host. So far that's all we do. But that is about to change when we start Subiquity inside WSL from the OOBE running on the host (for example). A similar concept would be launching Subiquity inside a LXD container. That will make more sense when we extract the launching logic as well.

By the magic of the operator `??=` we are able to cache the results of finding the subiquity_client package directory and subiquity socket paths, so we only assign the static variables once (race conditions might be created with two subsequent invocations of _findSubiquityPath() happen before a future could complete, but even so that won't be a problem because it will assign the same value twice and never again).

The definitions below were also moved to a separate file, so the new files related to the server can easily import it. We could make them `part of` but I think the current approach makes the `subiquity_server.dart` file simpler than the alternative.

```dart
enum ServerMode { LIVE, DRY_RUN }

/// @internal
final log = Logger('subiquity_server');
```
