### PR TITLE
Add missing WidgetsFlutterBinding.ensureInitialized()

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -77,6 +77,7 @@ void runInstallerApp(
 
   final interfaceSettings = GSettings('org.gnome.desktop.interface');
 
+  WidgetsFlutterBinding.ensureInitialized();
   onWindowClosed().then((_) async {
     await interfaceSettings.close();
   });


### PR DESCRIPTION
Before calling into WindowManager, which relies on the bindings.

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Binding has not yet been initialized.
The "instance" getter on the ServicesBinding binding mixin is only available once that binding has been initialized.
Typically, this is done by calling "WidgetsFlutterBinding.ensureInitialized()" or "runApp()" (the latter calls the former). Typically this call is done in the "void main()" method. The "ensureInitialized" method is idempotent; calling it multiple times is not harmful. After calling that method, the "instance" getter will return the binding.
In a test, one can call "TestWidgetsFlutterBinding.ensureInitialized()" as the first line in the test's "main()" method to initialize the binding.
If ServicesBinding is a custom binding mixin, there must also be a custom binding class, like WidgetsFlutterBinding, but that mixes in the selected binding, and that is the class that must be constructed before using the "instance" getter.
```