### PR TITLE
UDI: skip disabled routes instead of commenting them out

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -230,23 +230,25 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
       routes: <String, WizardRoute>{
         Routes.welcome: WizardRoute(
           builder: WelcomePage.create,
-          onNext: (_) => !service.hasRst ? Routes.keyboardLayout : null,
+          // skip Routes.tryOrInstall (https://github.com/canonical/ubuntu-desktop-installer/issues/373)
+          // onNext: (_) => !service.hasRst ? Routes.keyboardLayout : null,
+          onNext: (_) =>
+              !service.hasRst ? Routes.keyboardLayout : Routes.turnOffRST,
         ),
-        // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-        // Routes.tryOrInstall: WizardRoute(
-        //   builder: TryOrInstallPage.create,
-        //   onNext: (settings) {
-        //     switch (settings.arguments as Option?) {
-        //       case Option.repairUbuntu:
-        //         return Routes.repairUbuntu;
-        //       case Option.tryUbuntu:
-        //         return Routes.tryUbuntu;
-        //       default:
-        //         if (model.hasRst) return Routes.turnOffRST;
-        //         return Routes.keyboardLayout;
-        //     }
-        //   },
-        // ),
+        Routes.tryOrInstall: WizardRoute(
+          builder: TryOrInstallPage.create,
+          onNext: (settings) {
+            switch (settings.arguments as Option?) {
+              case Option.repairUbuntu:
+                return Routes.repairUbuntu;
+              case Option.tryUbuntu:
+                return Routes.tryUbuntu;
+              default:
+                if (service.hasRst) return Routes.turnOffRST;
+                return Routes.keyboardLayout;
+            }
+          },
+        ),
         Routes.turnOffRST: const WizardRoute(
           builder: TurnOffRSTPage.create,
         ),
@@ -301,17 +303,18 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
         Routes.whereAreYou: const WizardRoute(
           builder: WhereAreYouPage.create,
         ),
-        Routes.whoAreYou: const WizardRoute(
+        Routes.whoAreYou: WizardRoute(
           builder: WhoAreYouPage.create,
+          // skip Routes.chooseYourLook (https://github.com/canonical/ubuntu-desktop-installer/issues/373)
+          onNext: (_) => Routes.installationSlides,
         ),
         // https://github.com/canonical/ubuntu-desktop-installer/issues/41
         // Routes.configureActiveDirectory: const WizardRoute(
         //   builder: ConfigureActiveDirectoryPage.create,
         // ),
-        // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-        // Routes.chooseYourLook: const WizardRoute(
-        //   builder: ChooseYourLookPage.create,
-        // ),
+        Routes.chooseYourLook: const WizardRoute(
+          builder: ChooseYourLookPage.create,
+        ),
         Routes.installationSlides: const WizardRoute(
           builder: InstallationSlidesPage.create,
         ),


### PR DESCRIPTION
Some pages that are not fully functional were taken out (#373) but it's
still sometimes necessary to be able to test them.

With this change, it becomes more convenient because even though the
route is always skipped in production, it becomes possible to choose it
for testing purposes. Previously, the route did not exist at all so one
would need to first edit code and uncomment the route to be able to test
the respective page. Now, one can set e.g. Routes.tryOrInstall or
Routes.chooseYourLook as Routes.initialRoute (or pass --initial-route).