### PR TITLE
Extracts logic to start the server out of the SubiquityServer class

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -1,23 +1,17 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 
 import 'endpoint.dart';
 import 'server/common.dart';
+import 'server/process.dart';
 import 'server/paths.dart';
-import 'server/pidfile.dart';
 
-abstract class SubiquityServer {
-  Process? _serverProcess;
+class SubiquityServer {
+  /// An optional server launcher, should we need to start the server.
+  SubiquityProcess? launcher;
 
-  SubiquityServer._();
-
-  /// Creates a new subiquity server.
-  factory SubiquityServer() => _SubiquityServerImpl();
-
-  /// Creates a WSL variant of the server.
-  factory SubiquityServer.wsl() => _WslSubiquityServerImpl();
+  SubiquityServer({this.launcher});
 
   /// A callback for integration testing purposes. The callback is called when
   /// the server has been started and thus, the application is ready for
@@ -25,86 +19,18 @@ abstract class SubiquityServer {
   @visibleForTesting
   static void Function(Endpoint)? startupCallback;
 
-  // Whether the server process should be started in the specified mode.
-  bool _shouldStart(ServerMode mode);
-
-  // The name of the server's Python module.
-  String get _pythonModule;
-
-  // Prefer local curtin and probert python modules that are pinned to the
-  // correct versions
-  Map<String, String> _pythonPath(String subiquityPath) {
-    final pythonPath = (Platform.environment['PYTHONPATH'] ?? '').split(':');
-    pythonPath.add(subiquityPath);
-    pythonPath.add(p.join(subiquityPath, 'curtin'));
-    pythonPath.add(p.join(subiquityPath, 'probert'));
-    return {'PYTHONPATH': pythonPath.join(':')};
-  }
-
   Future<Endpoint> start(ServerMode serverMode,
       {List<String>? args, Map<String, String>? environment}) async {
     final socketPath = await getSocketPath(serverMode);
     final endpoint = Endpoint.unix(socketPath);
-    if (_shouldStart(serverMode)) {
-      var subiquityCmd = <String>[
-        '-m',
-        _pythonModule,
-        if (serverMode == ServerMode.DRY_RUN) '--dry-run',
-        ...?args,
-      ];
-      await _startSubiquity(serverMode, subiquityCmd, environment);
+    if (launcher != null) {
+      await launcher!.start(additionalArgs: args, additionalEnv: environment);
     }
 
     return _waitSubiquity(endpoint).then((_) {
       startupCallback?.call(endpoint);
       return endpoint;
     });
-  }
-
-  Future<void> _startSubiquity(ServerMode serverMode, List<String> subiquityCmd,
-      Map<String, String>? environment) async {
-    final subiquityPath = await getSubiquityPath();
-    String? workingDirectory;
-    // try using local subiquity
-    if (Directory(subiquityPath).existsSync()) {
-      workingDirectory = subiquityPath;
-    }
-
-    // kill the existing test server if it's already running, so they don't pile
-    // up on hot restarts
-    final pid = await readPidFile();
-    if (pid != null) {
-      Process.killPid(pid);
-    }
-
-    // Use `/usr/bin/python3` over `/snap/flutter/current/usr/bin/python3` when
-    // developing with flutter-snap on the desktop. This ensures that subiquity
-    // has locally installed Python module dependencies available. (#364)
-    _serverProcess = await Process.start(
-      Platform.environment['SNAP_PYTHON'] ?? '/usr/bin/python3',
-      subiquityCmd,
-      workingDirectory: workingDirectory,
-      environment: {
-        ..._pythonPath(subiquityPath),
-        if (serverMode == ServerMode.DRY_RUN) ...{
-          // so subiquity doesn't think it's some other snap (e.g. flutter or vs code)
-          'SNAP': '.',
-          'SNAP_NAME': 'subiquity',
-          'SNAP_REVISION': '',
-          'SNAP_VERSION': '',
-        },
-        ...?environment,
-      },
-    ).then((process) {
-      stdout.addStream(process.stdout);
-      stderr.addStream(process.stderr);
-      return process;
-    });
-    log.info(
-      'Starting server (PID: ${_serverProcess!.pid}) with args: $subiquityCmd',
-    );
-
-    await writePidFile(_serverProcess!.pid);
   }
 
   static Future<void> _waitSubiquity(Endpoint endpoint) async {
@@ -129,35 +55,5 @@ abstract class SubiquityServer {
     client.close();
   }
 
-  Future<void> stop() async {
-    try {
-      await pidFile().delete();
-    } on FileSystemException catch (_) {}
-    _serverProcess?.kill();
-    await _serverProcess?.exitCode;
-  }
-}
-
-class _SubiquityServerImpl extends SubiquityServer {
-  _SubiquityServerImpl() : super._();
-
-  // Normally, the server is already running in live mode and thus, only
-  // started in dry-run mode.
-  @override
-  bool _shouldStart(ServerMode mode) => mode == ServerMode.DRY_RUN;
-
-  @override
-  String get _pythonModule => 'subiquity.cmd.server';
-}
-
-// A server that runs in a WSL environment.
-class _WslSubiquityServerImpl extends SubiquityServer {
-  _WslSubiquityServerImpl() : super._();
-
-  // The server should be always started in WSL because there's no systemd.
-  @override
-  bool _shouldStart(ServerMode mode) => true;
-
-  @override
-  String get _pythonModule => 'system_setup.cmd.server';
+  Future<void> stop() async => await launcher?.stop();
 }

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -7,11 +7,17 @@ import 'server/common.dart';
 import 'server/process.dart';
 import 'server/paths.dart';
 
+Future<Endpoint> defaultEndpoint(ServerMode serverMode) async {
+  final socketPath = await getSocketPath(serverMode);
+  return Endpoint.unix(socketPath);
+}
+
 class SubiquityServer {
   /// An optional server launcher, should we need to start the server.
   SubiquityProcess? launcher;
+  final Endpoint endpoint;
 
-  SubiquityServer({this.launcher});
+  SubiquityServer({this.launcher, required this.endpoint});
 
   /// A callback for integration testing purposes. The callback is called when
   /// the server has been started and thus, the application is ready for
@@ -19,10 +25,10 @@ class SubiquityServer {
   @visibleForTesting
   static void Function(Endpoint)? startupCallback;
 
-  Future<Endpoint> start(ServerMode serverMode,
-      {List<String>? args, Map<String, String>? environment}) async {
-    final socketPath = await getSocketPath(serverMode);
-    final endpoint = Endpoint.unix(socketPath);
+  Future<Endpoint> start({
+    List<String>? args,
+    Map<String, String>? environment,
+  }) async {
     if (launcher != null) {
       await launcher!.start(additionalArgs: args, additionalEnv: environment);
     }

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -14,10 +14,10 @@ Future<Endpoint> defaultEndpoint(ServerMode serverMode) async {
 
 class SubiquityServer {
   /// An optional server launcher, should we need to start the server.
-  SubiquityProcess? launcher;
+  SubiquityProcess? process;
   final Endpoint endpoint;
 
-  SubiquityServer({this.launcher, required this.endpoint});
+  SubiquityServer({this.process, required this.endpoint});
 
   /// A callback for integration testing purposes. The callback is called when
   /// the server has been started and thus, the application is ready for
@@ -29,8 +29,8 @@ class SubiquityServer {
     List<String>? args,
     Map<String, String>? environment,
   }) async {
-    if (launcher != null) {
-      await launcher!.start(additionalArgs: args, additionalEnv: environment);
+    if (process != null) {
+      await process!.start(additionalArgs: args, additionalEnv: environment);
     }
 
     return _waitSubiquity(endpoint).then((_) {
@@ -61,5 +61,5 @@ class SubiquityServer {
     client.close();
   }
 
-  Future<void> stop() async => await launcher?.stop();
+  Future<void> stop() async => await process?.stop();
 }

--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -61,5 +61,5 @@ class SubiquityServer {
     client.close();
   }
 
-  Future<void> stop() async => await process?.stop();
+  Future<void> stop() async => process?.stop();
 }

--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -18,9 +18,7 @@ Map<String, String> _pythonPath(String subiquityPath) {
 /// This class knows the many ways with which we may want to start Subiquity.
 /// Starting the server builds on top of [Process.start], so this launcher
 /// can be customized by implementing factory constructors that adjust the
-/// [command] and [args] (and possibly some factories to enable enhancing the
-/// command line arguments, working directory and environment with the results
-/// of asynchronous computations).
+/// [command] and [args].
 /// The example below would allow starting subiquity inside a WSL2 distro
 /// while the GUI client is running on the Windows host.
 ///
@@ -30,12 +28,11 @@ Map<String, String> _pythonPath(String subiquityPath) {
 ///     {List<String>? args,
 ///     Future<void>? defer,
 ///     Future<void> Function()? onProcessStart,
-///     Future<List<String>> Function()? argumentsFactory}) {
+///     }) {
 ///   return SubiquityProcess._(
 ///     'wsl',
 ///     args: ['-d', distroName, command, ...?args],
 ///     deferStart: defer,
-///     argsFactory: argumentsFactory,
 ///     onProcessStart: onProcessStart,
 ///   );
 /// }

--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'common.dart';
+import 'pidfile.dart';
+
+// Prefer local curtin and probert python modules that are pinned to the
+// correct versions
+Map<String, String> _pythonPath(String subiquityPath) {
+  final pythonPath = (Platform.environment['PYTHONPATH'] ?? '').split(':');
+  pythonPath.add(subiquityPath);
+  pythonPath.add(p.join(subiquityPath, 'curtin'));
+  pythonPath.add(p.join(subiquityPath, 'probert'));
+  return {'PYTHONPATH': pythonPath.join(':')};
+}
+
+/// Manages the Subiquity process.
+/// This class knows the many ways with which we may want to start Subiquity.
+/// Starting the server builds on top of [Process.start], so this launcher
+/// can be customized by implementing factory constructors that adjust the
+/// [command] and [args] (and possibly some factories to enable enhancing the
+/// command line arguments, working directory and environment with the results
+/// of asynchronous computations).
+/// The example below would allow starting subiquity inside a WSL2 distro
+/// while the GUI client is running on the Windows host.
+///
+/// ```dart
+/// /// Able to start the server inside [distroName] on WSL from the Windows host.
+/// factory SubiquityProcess.wsl(String distroName, String command,
+///     {List<String>? args,
+///     Future<void>? defer,
+///     Future<void> Function()? onProcessStart,
+///     Future<List<String>> Function()? argumentsFactory}) {
+///   return SubiquityProcess._(
+///     'wsl',
+///     args: ['-d', distroName, command, ...?args],
+///     deferStart: defer,
+///     argsFactory: argumentsFactory,
+///     onProcessStart: onProcessStart,
+///   );
+/// }
+/// ```
+///
+/// The following would allow starting subiquity inside an LXD container while
+/// the GUI is running on the Linux host, which could be good for testing.
+///
+///```dart
+/// /// Able to start the server inside [container] on LXD from the Linux host.
+/// factory SubiquityProcess.lxd(String container, String command,
+///     {List<String>? args, bool runAsDaemon = false, String? configFile}) {
+///   final lxcArgs = <String>[
+///     '-n',
+///     container,
+///     runAsDaemon ? '-d' : '',
+///     if (configFile != null) ...['-f', configFile],
+///     '--',
+///     command,
+///     ...?args
+///  ];
+///  return SubiquityProcess('lxc-execute', lxcArgs);
+///}
+///```
+///
+class SubiquityProcess {
+  /// The program the process will run.
+  final String command;
+
+  /// The program arguments.
+  final List<String> args;
+
+  /// The process working directory
+  final String? workingDirectory;
+
+  /// The process environment variables.
+  final Map<String, String>? environment;
+
+  /// An optional future that must be awaited on before starting the server.
+  /// It may be used to prevent starting the server before a certain condition
+  /// is met or a certain event happens.
+  final Future<void>? deferStart;
+
+  /// An action one may want to take after calling [Process.start].
+  final Future<void> Function()? onProcessStart;
+
+  /// The process created by the [start] method.
+  Process? _serverProcess;
+
+  // TODO: remove this ignore lint clauses at next.
+  SubiquityProcess(
+    this.command,
+    this.args, {
+    this.workingDirectory,
+    this.environment,
+    // ignore: unused_element
+    this.deferStart,
+    // ignore: unused_element
+    this.onProcessStart,
+  });
+
+  /// Able to start subiquity by running the raw [command] with [args] without
+  /// further customisation or logic, intended for the simpler cases.
+  factory SubiquityProcess.command(String command, List<String> args) {
+    return SubiquityProcess(command, args);
+  }
+
+  /// Able to start the server module [pythonModule] using Python defined either
+  /// by [pythonExecutable] or via the SNAP_PYTHON environment variable.
+  /// Defaults to system's default (usually located at /usr/bin/python3).
+  factory SubiquityProcess.python(
+    String pythonModule, {
+    String? pythonExecutable,
+    String? subiquityPath,
+    ServerMode? serverMode,
+  }) {
+    final cmd = pythonExecutable ??
+        Platform.environment['SNAP_PYTHON'] ??
+        '/usr/bin/python3';
+
+    final arguments = ['-m', pythonModule];
+    final env = <String, String>{};
+
+    if (serverMode == ServerMode.DRY_RUN) {
+      arguments.add('--dry-run');
+      env.addAll({
+        // so subiquity doesn't think it's some other snap (e.g. flutter or vs code)
+        'SNAP': '.',
+        'SNAP_NAME': 'subiquity',
+        'SNAP_REVISION': '',
+        'SNAP_VERSION': '',
+      });
+    }
+    if (subiquityPath != null) env.addAll(_pythonPath(subiquityPath));
+    return SubiquityProcess(
+      cmd,
+      arguments,
+      // will try using local subiquity
+      workingDirectory: subiquityPath,
+      environment: env,
+    );
+  }
+
+  /// Starts the server.
+  Future<void> start({
+    List<String>? additionalArgs,
+    Map<String, String>? additionalEnv,
+  }) async {
+    // kill the existing test server if it's already running, so they don't pile
+    // up on hot restarts
+    final pid = await readPidFile();
+    if (pid != null) {
+      Process.killPid(pid);
+    }
+
+    if (deferStart != null) {
+      await deferStart;
+    }
+
+    _serverProcess = await Process.start(
+      command,
+      [...args, ...?additionalArgs],
+      workingDirectory: workingDirectory,
+      environment: {...?environment, ...?additionalEnv},
+    ).then((process) {
+      stdout.addStream(process.stdout);
+      stderr.addStream(process.stderr);
+      return process;
+    });
+    log.info('Starting server (PID: ${_serverProcess!.pid}) with args: $args');
+
+    await onProcessStart?.call();
+    await writePidFile(_serverProcess!.pid);
+  }
+
+  Future<void> stop() async {
+    try {
+      await pidFile().delete();
+    } on FileSystemException catch (_) {}
+    _serverProcess?.kill();
+    await _serverProcess?.exitCode;
+  }
+
+  Future<int>? get exitCode => _serverProcess?.exitCode;
+}

--- a/packages/subiquity_client/lib/subiquity_server.dart
+++ b/packages/subiquity_client/lib/subiquity_server.dart
@@ -2,5 +2,6 @@ library subiquity_server;
 
 export 'src/endpoint.dart';
 export 'src/server/common.dart' hide log;
+export 'src/server/process.dart';
 export 'src/server/paths.dart';
 export 'src/server.dart';

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -30,7 +30,6 @@ void main() {
       await process.start(additionalEnv: env);
       addTearDown(process.stop);
       expect(await process.exitCode, int.parse(foo));
-      await process.stop();
     });
 
     test('call back on process start', () async {
@@ -43,7 +42,6 @@ void main() {
       await process.start();
       addTearDown(process.stop);
       expect(cbCalled, isTrue);
-      await process.stop();
     });
 
     test('defer launch', () async {
@@ -54,7 +52,6 @@ void main() {
       await process.start();
       addTearDown(process.stop);
       expect(futAwaited, isTrue);
-      await process.stop();
     });
   });
 

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -21,9 +21,19 @@ void main() {
 
   group('subiquity', () {
     setUpAll(() async {
-      testServer = SubiquityServer();
+      final subiquityPath = await getSubiquityPath();
+      final endpoint = await defaultEndpoint(ServerMode.DRY_RUN);
+      final process = SubiquityProcess.python(
+        'subiquity.cmd.server',
+        serverMode: ServerMode.DRY_RUN,
+        subiquityPath: subiquityPath,
+      );
+      testServer = SubiquityServer(
+        launcher: process,
+        endpoint: endpoint,
+      );
       client = SubiquityClient();
-      final socketPath = await testServer.start(ServerMode.DRY_RUN, args: [
+      final socketPath = await testServer.start(args: [
         '--machine-config',
         'examples/simple.json',
         '--source-catalog',
@@ -446,9 +456,19 @@ void main() {
 
   group('wsl', () {
     setUpAll(() async {
-      testServer = SubiquityServer.wsl();
+      final endpoint = await defaultEndpoint(ServerMode.DRY_RUN);
+      final subiquityPath = await getSubiquityPath();
+      final process = SubiquityProcess.python(
+        'system_setup.cmd.server',
+        serverMode: ServerMode.DRY_RUN,
+        subiquityPath: subiquityPath,
+      );
+      testServer = SubiquityServer(
+        launcher: process,
+        endpoint: endpoint,
+      );
       client = SubiquityClient();
-      final socketPath = await testServer.start(ServerMode.DRY_RUN);
+      final socketPath = await testServer.start();
       client.open(socketPath);
     });
 

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -65,7 +65,7 @@ void main() {
         subiquityPath: subiquityPath,
       );
       testServer = SubiquityServer(
-        launcher: process,
+        process: process,
         endpoint: endpoint,
       );
       client = SubiquityClient();
@@ -500,7 +500,7 @@ void main() {
         subiquityPath: subiquityPath,
       );
       testServer = SubiquityServer(
-        launcher: process,
+        process: process,
         endpoint: endpoint,
       );
       client = SubiquityClient();

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -23,7 +23,7 @@ void main() {
     test('set additional environment before starting the process', () async {
       const foo = '42';
       final env = {'TEST_VAR': foo};
-      final process = SubiquityProcess(
+      final process = SubiquityProcess.command(
         'bash',
         ['-c', 'exit \$TEST_VAR'],
       );

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -28,6 +28,7 @@ void main() {
         ['-c', 'exit \$TEST_VAR'],
       );
       await process.start(additionalEnv: env);
+      addTearDown(process.stop);
       expect(await process.exitCode, int.parse(foo));
       await process.stop();
     });
@@ -40,6 +41,7 @@ void main() {
         onProcessStart: () async => cbCalled = true,
       );
       await process.start();
+      addTearDown(process.stop);
       expect(cbCalled, isTrue);
       await process.stop();
     });
@@ -50,6 +52,7 @@ void main() {
       final process = SubiquityProcess('bash', ['-c', 'exit 0'],
           deferStart: fut.then((_) => futAwaited = true));
       await process.start();
+      addTearDown(process.stop);
       expect(futAwaited, isTrue);
       await process.stop();
     });

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -53,7 +53,7 @@ Future<void> runInstallerApp(
   final subiquityPath = await getSubiquityPath();
   final endpoint = await defaultEndpoint(serverMode);
 
-  final launcher = liveRun
+  final process = liveRun
       ? null
       : SubiquityProcess.python(
           'subiquity.cmd.server',
@@ -61,7 +61,7 @@ Future<void> runInstallerApp(
           subiquityPath: subiquityPath,
         );
   final subiquityServer = SubiquityServer(
-    launcher: launcher,
+    process: process,
     endpoint: endpoint,
   );
 

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -1,3 +1,3 @@
 import 'installer.dart';
 
-void main(List<String> args) => runInstallerApp(args);
+void main(List<String> args) async => runInstallerApp(args);

--- a/packages/ubuntu_desktop_installer/lib/main.dart
+++ b/packages/ubuntu_desktop_installer/lib/main.dart
@@ -1,3 +1,3 @@
 import 'installer.dart';
 
-void main(List<String> args) async => runInstallerApp(args);
+Future<void> main(List<String> args) async => runInstallerApp(args);

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -10,7 +10,7 @@ import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/src/client.dart' as _i7;
 import 'package:subiquity_client/src/endpoint.dart' as _i4;
 import 'package:subiquity_client/src/server.dart' as _i8;
-import 'package:subiquity_client/src/server/common.dart' as _i9;
+import 'package:subiquity_client/src/server/process.dart' as _i9;
 import 'package:subiquity_client/src/types.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -382,11 +382,18 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   }
 
   @override
-  _i6.Future<_i4.Endpoint> start(_i9.ServerMode? serverMode,
+  set launcher(_i9.SubiquityProcess? _launcher) =>
+      super.noSuchMethod(Invocation.setter(#launcher, _launcher),
+          returnValueForMissingStub: null);
+  @override
+  _i4.Endpoint get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint),
+      returnValue: _FakeEndpoint_13()) as _i4.Endpoint);
+  @override
+  _i6.Future<_i4.Endpoint> start(
           {List<String>? args, Map<String, String>? environment}) =>
       (super.noSuchMethod(
-              Invocation.method(#start, [serverMode],
-                  {#args: args, #environment: environment}),
+              Invocation.method(
+                  #start, [], {#args: args, #environment: environment}),
               returnValue: Future<_i4.Endpoint>.value(_FakeEndpoint_13()))
           as _i6.Future<_i4.Endpoint>);
   @override

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -382,8 +382,8 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   }
 
   @override
-  set launcher(_i9.SubiquityProcess? _launcher) =>
-      super.noSuchMethod(Invocation.setter(#launcher, _launcher),
+  set process(_i9.SubiquityProcess? _process) =>
+      super.noSuchMethod(Invocation.setter(#process, _process),
           returnValueForMissingStub: null);
   @override
   _i4.Endpoint get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint),

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -45,10 +45,8 @@ Future<void> runWizardApp(
     );
   }
 
-  final serverMode = isLiveRun(options) ? ServerMode.LIVE : ServerMode.DRY_RUN;
-
   subiquityServer
-      .start(serverMode, args: serverArgs, environment: serverEnvironment)
+      .start(args: serverArgs, environment: serverEnvironment)
       .then((endpoint) {
     subiquityClient.open(endpoint);
     subiquityMonitor?.start(endpoint);

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/app.dart';
@@ -22,7 +21,7 @@ void main() {
   testWidgets('initializes subiquity', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
-    when(server.start(any,
+    when(server.start(
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer((_) async => endpoint);
 
@@ -34,8 +33,8 @@ void main() {
       serverEnvironment: {'baz': 'qux'},
       onInitSubiquity: (client) => client.setVariant(Variant.DESKTOP),
     );
-    verify(server.start(ServerMode.DRY_RUN,
-        args: ['--foo', 'bar'], environment: {'baz': 'qux'})).called(1);
+    verify(server.start(args: ['--foo', 'bar'], environment: {'baz': 'qux'}))
+        .called(1);
     verify(client.open(endpoint)).called(1);
     verify(client.setVariant(Variant.DESKTOP)).called(1);
   });
@@ -43,7 +42,7 @@ void main() {
   testWidgets('registers the client', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
-    when(server.start(any,
+    when(server.start(
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer(
       (_) async => Endpoint.unix(''),
@@ -119,7 +118,7 @@ void main() {
     when(monitor.start(endpoint)).thenAnswer((_) async => true);
 
     final server = MockSubiquityServer();
-    when(server.start(any,
+    when(server.start(
             args: anyNamed('args'), environment: anyNamed('environment')))
         .thenAnswer((_) async => endpoint);
 

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -26,7 +26,7 @@ screens, yet allowing user to overwrite any of those during setup.
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final subiquityPath = await getSubiquityPath();
   final endpoint = await defaultEndpoint(serverMode);
-  final launcher = SubiquityProcess.python(
+  final procecss = SubiquityProcess.python(
     'system_setup.cmd.server',
     serverMode: serverMode,
     subiquityPath: subiquityPath,
@@ -49,7 +49,7 @@ screens, yet allowing user to overwrite any of those during setup.
     ),
     options: options,
     subiquityClient: SubiquityClient(),
-    subiquityServer: SubiquityServer(launcher: launcher, endpoint: endpoint),
+    subiquityServer: SubiquityServer(process: procecss, endpoint: endpoint),
     subiquityMonitor: subiquityMonitor,
     onInitSubiquity: (client) {
       client.variant().then((value) {

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'app.dart';
 import 'installing_state.dart';
 
-void main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final options = parseCommandLine(args, onPopulateOptions: (parser) {
     parser.addFlag('reconfigure');
     parser.addOption(


### PR DESCRIPTION
This enables further composition combining any sort of command line programs and arguments that we can think of to use to start the server. My idea is to expose context-aware factory constructors as we find need to start subiquity in such contexts. For instance, `SubiquityLauncher.python()` combines the parameters to enable the GUI to launch subiquity on the same host it's running by invoking `python3 -m [pythonModule]`. A `SubiquityLauncher.lxd()` would have different parameters to compose a command line that would allow start subiquity inside an LXD container while the GUI would be running outside of the container, on the host environment. (Just an idea, not implemented yet). 

There are some parameters apparently not used in the general constructors which I plan to use in my next PR which will implement a `SubiquityLauncher.wsl()` and make use of it. I'll remove the `ignore lint` clauses then.

Most of this PR is just moving code out of the SubiquityServer class. Conceptually it is not that big. I promise the next ones will be smaller. :D