### PR TITLE
Subiquity process factory for WSL

### DIFF
--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -82,15 +82,12 @@ class SubiquityProcess {
   /// The process created by the [start] method.
   Process? _serverProcess;
 
-  // TODO: remove this ignore lint clauses at next.
   SubiquityProcess(
     this.command,
     this.args, {
     this.workingDirectory,
     this.environment,
-    // ignore: unused_element
     this.deferStart,
-    // ignore: unused_element
     this.onProcessStart,
   });
 

--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -136,6 +136,54 @@ class SubiquityProcess {
     );
   }
 
+  /// Able to start the server inside [distroName] on WSL from the Windows host
+  /// by running [command] with [args] as [user].
+  ///
+  /// The environment variables map [env] in set on the host side, thus
+  /// affecting the environment of the wsl.exe program. To share host
+  /// environment variables with the distro by listing their names to [wslenv]
+  /// (with their applicable flags), whether they are part of [env] or not.
+  /// The list will be appended to $env:WSLENV.
+  ///
+  /// To know more about sharing env vars to WSL see:
+  /// https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
+  factory SubiquityProcess.wsl(
+    String distroName,
+    String command, {
+    List<String>? args,
+    String? user,
+    Map<String, String>? env,
+    String? wslenv,
+    ServerMode? serverMode,
+    Future<void>? defer,
+    Future<void> Function()? onProcessStart,
+  }) {
+    final environment = {
+      ...?env,
+      // WSL interoperability has its environment variable sharing mechanism.
+      if (wslenv != null) ...{
+        'WSLENV': '${Platform.environment['WSLENV']}:$wslenv',
+      }
+    };
+
+    final arguments = [
+      '-d',
+      distroName,
+      if (user != null) ...['-u', user],
+      command,
+      ...?args,
+      if (serverMode == ServerMode.DRY_RUN) ...['--dry-run'],
+    ];
+
+    return SubiquityProcess(
+      'wsl',
+      arguments,
+      environment: environment,
+      deferStart: defer,
+      onProcessStart: onProcessStart,
+    );
+  }
+
   /// Starts the server.
   Future<void> start({
     List<String>? additionalArgs,

--- a/packages/subiquity_client/test/subiquity_process_test.dart
+++ b/packages/subiquity_client/test/subiquity_process_test.dart
@@ -1,0 +1,68 @@
+import 'package:subiquity_client/subiquity_server.dart';
+import 'package:test/test.dart';
+
+// Test only the command line composition. Obviously starting a process here
+// Would require the underlying execution platform, which makes the test suite
+// inherently not cross platform.
+void main() {
+  const pymodule = 'pytest';
+  const distro = 'Ubuntu';
+  const variable = 'TMPDIR/p';
+  const user = 'ubuntu';
+  const dryRunFlag = '--dry-run';
+  const command = 'whoami';
+
+  group('Python factory', () {
+    test('<pymodule> is a python arg', () async {
+      final process = SubiquityProcess.python(pymodule);
+      // The actual command has to be wsl.exe
+      expect(process.args.contains(pymodule), isTrue);
+    });
+
+    test('SNAP related is added in DRY_RUN', () async {
+      final process = SubiquityProcess.python(
+        pymodule,
+        serverMode: ServerMode.DRY_RUN,
+      );
+      expect(process.environment?['SNAP_NAME'], isNotNull);
+    });
+
+    test('DRY_RUN cli flag', () async {
+      final process = SubiquityProcess.python(
+        pymodule,
+        serverMode: ServerMode.DRY_RUN,
+      );
+      expect(process.args.contains(dryRunFlag), isTrue);
+    });
+  });
+  group('WSL factory', () {
+    // Test only the command line composition. Obviously starting a process here
+    // Would require Windows and WSL, which makes the test not cross platform.
+    test('<distroName> and <commands> are wsl.exe args', () async {
+      final process = SubiquityProcess.wsl(distro, command);
+      // The actual command has to be wsl.exe
+      expect(process.args.contains(distro), isTrue);
+      expect(process.args.contains(command), isTrue);
+    });
+
+    test('<user> is also part of wsl.exe args', () async {
+      final process = SubiquityProcess.wsl(distro, command, user: user);
+      expect(process.args.contains(user), isTrue);
+    });
+
+    test('WSLENV is :\$appended', () async {
+      // This ensures we are not overriding any preexisting variable share.
+      final process = SubiquityProcess.wsl(distro, command, wslenv: variable);
+      expect(process.environment!['WSLENV']!.endsWith(':$variable'), isTrue);
+    });
+
+    test('DRY_RUN cli flag', () async {
+      final process = SubiquityProcess.wsl(
+        distro,
+        command,
+        serverMode: ServerMode.DRY_RUN,
+      );
+      expect(process.args.contains(dryRunFlag), isTrue);
+    });
+  });
+}

--- a/packages/subiquity_client/test/windows_only_wsl_tests.dart
+++ b/packages/subiquity_client/test/windows_only_wsl_tests.dart
@@ -1,0 +1,95 @@
+@TestOn('windows')
+// The tests below require a Windows host with WSL 2 enabled and some Linux
+// distribution already installed (by default Ubuntu-22.04 but can be overriden
+// by a --dart-define=DISTRONAME=<your-distro-name>)
+
+import 'dart:io';
+
+import 'package:subiquity_client/subiquity_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const distroName = String.fromEnvironment(
+    'DISTRONAME',
+    defaultValue: 'Ubuntu-22.04',
+  );
+
+  group('run in WSL:', () {
+    test('Linux exit code is process.exitCode', () async {
+      const foo = '42';
+      final process = SubiquityProcess.wsl(
+        distroName,
+        'bash',
+        args: ['-c', 'exit $foo'],
+      );
+      await process.start();
+      addTearDown(process.stop);
+      expect(await process.exitCode, int.parse(foo));
+    });
+
+    test('share env vars', () async {
+      const foo = '42';
+      // This environment is on the host side.
+      final env = {'TEST_VAR': foo};
+      final process = SubiquityProcess.wsl(
+        distroName,
+        'bash',
+        // This must exit $foo if the env var is correcly passed.
+        args: ['-c', 'exit \$TEST_VAR'],
+        env: env,
+        // This exposes TEST_VAR to the WSL instance.
+        wslenv: 'TEST_VAR',
+      );
+      await process.start();
+      addTearDown(process.stop);
+      expect(await process.exitCode, int.parse(foo));
+    });
+
+    test('late passing env vars', () async {
+      const foo = '42';
+      // This environment is on the host side.
+      final env = {'TEST_VAR': foo};
+      final process = SubiquityProcess.wsl(
+        distroName,
+        'bash',
+        // This must exit $foo if the env var is correcly passed.
+        args: ['-c', 'exit \$TEST_VAR'],
+        // This exposes TEST_VAR to the WSL instance.
+        wslenv: 'TEST_VAR',
+      );
+      await process.start(additionalEnv: env);
+      addTearDown(process.stop);
+      expect(await process.exitCode, int.parse(foo));
+    });
+
+    test('WSL path translation is respected', () async {
+      // This environment is on the host side.
+      final env = {'PLACE': Platform.environment['USERPROFILE'] ?? 'C:\\Users'};
+      final process = SubiquityProcess.wsl(
+        distroName,
+        'ls',
+        args: ['-l', '\$PLACE', '>', '/dev/null'],
+        // If the path was not translated, ls would exit 2.
+        wslenv: 'PLACE/p',
+      );
+      await process.start(additionalEnv: env);
+      addTearDown(process.stop);
+      expect(await process.exitCode, 0);
+    });
+
+    test('as <user>', () async {
+      // This environment is on the host side.
+      const user = 'root';
+      const uid = 0;
+      final process = SubiquityProcess.wsl(
+        distroName,
+        'bash',
+        user: user,
+        args: ['-c', '[ \$(id -u) -eq $uid ]'],
+      );
+      await process.start();
+      addTearDown(process.stop);
+      expect(await process.exitCode, uid);
+    });
+  });
+}


### PR DESCRIPTION
Able to start a Subiquity server inside a WSL Linux distribution from the outside (host) environment.
With same portable and some non-portable tests. I'll figure out later how I want to setup a CI for Windows-specfic testing. That's more likely to live outside the UDI repository.
The added behavior is not used just yet.