### PR TITLE
Adds option to start only the server for WSL

### DIFF
--- a/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
+++ b/packages/ubuntu_wsl_setup/ubuntu-wsl-setup
@@ -595,11 +595,14 @@ export LIVE_RUN=1
 BIN=$SNAP/usr/libexec/ubuntu_wsl_setup
 args=""
 for arg in $@; do
+  if [ ${arg} = "--server-only" ]; then
+    BIN="$PYTHON -m system_setup.cmd.server"
+    continue
+  fi
   if [ ${arg} = "-t" -o ${arg} = "--text" ]; then
     BIN="$PYTHON -m system_setup.cmd.tui"
     continue
   fi
-
   args="$args $arg"
 done
 


### PR DESCRIPTION
This will mainly help during development.
At some point a version of this script will be placed inside Subiquity snap.
Enables the new worklfow (OOBE on Windows) with the current image builds (where bootstraping the UDI snap is required due lack of snapd support and still the OOBE will be running on Windows).