### PR TITLE
Adds TCP Helpers

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
@@ -1,19 +1,22 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 
 // This is inherently a race condition on its own, because in between finding an
 // available port and using it, the system may have binded other socket.
-FutureOr<RawServerSocket?> _tryBindUnsafe({
+// Thus, the solution is to hold the socket binded.
+FutureOr<ServerSocket?> _tryBindUnsafe({
   required int lower,
   required int higher,
 }) async {
-  final socket = await RawServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  final port = socket.port;
-  if (port > lower && port < higher) {
+  var rand = Random.secure();
+  var port = lower + rand.nextInt(higher - lower);
+  try {
+    final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, port);
     return socket;
-  }
-  socket.close();
+  } on SocketException {
   return null;
+  }
 }
 
 /// Returns a RawServerSocket already binded to a port in the open interval

--- a/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+import 'dart:io';
+
+// This is inherently a race condition on its own, because in between finding an
+// available port and using it, the system may have binded other socket.
+FutureOr<RawServerSocket?> _tryBindUnsafe({
+  required int lower,
+  required int higher,
+}) async {
+  final socket = await RawServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  if (port > lower && port < higher) {
+    return socket;
+  }
+  socket.close();
+  return null;
+}
+
+/// Returns a RawServerSocket already binded to a port in the open interval
+/// [lower]-[higher] of the loopback interface where the referred range is
+/// a subset of the platform ephemeral port range.
+/// On failure returns null. [maxAttempts] limits the amount of asynchronous
+/// iterations performed.
+Future<RawServerSocket?> getSocketHolder({
+  required int lower,
+  required int higher,
+  int maxAttempts = 10,
+}) async {
+  assert(maxAttempts > 0, 'At least one attempt will be done anyway.');
+  RawServerSocket? value;
+  int attemptsCount = 0;
+  await Future.doWhile(() async {
+    attemptsCount++;
+    value = await _tryBindUnsafe(lower: lower, higher: higher);
+    return value == null && attemptsCount <= maxAttempts;
+  });
+  return value;
+}

--- a/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
@@ -19,23 +19,25 @@ FutureOr<ServerSocket?> _tryBindUnsafe({
   }
 }
 
-/// Returns a ServerSocket already binded to a randomly-selected port in the
-/// open interval [lower]-[higher] of the loopback interface where the referred
-/// range is a subset of the platform ephemeral port range.
-/// On failure returns null. [maxAttempts] limits the amount of asynchronous
-/// iterations performed.
-Future<ServerSocket?> getRandomPortSocket({
-  required int lower,
-  required int higher,
-  int maxAttempts = 10,
-}) async {
-  assert(maxAttempts > 0, 'At least one attempt will be done anyway.');
-  ServerSocket? value;
-  int attemptsCount = 0;
-  await Future.doWhile(() async {
-    attemptsCount++;
-    value = await _tryBindUnsafe(lower: lower, higher: higher);
-    return value == null && attemptsCount <= maxAttempts;
-  });
-  return value;
+class TcpHelperService {
+  /// Returns a ServerSocket already binded to a randomly-selected port in the
+  /// open interval [lower]-[higher] of the loopback interface where the referred
+  /// range is a subset of the platform ephemeral port range.
+  /// On failure returns null. [maxAttempts] limits the amount of asynchronous
+  /// iterations performed.
+  static Future<ServerSocket?> getRandomPortSocket({
+    required int lower,
+    required int higher,
+    int maxAttempts = 10,
+  }) async {
+    assert(maxAttempts > 0, 'At least one attempt will be done anyway.');
+    ServerSocket? value;
+    int attemptsCount = 0;
+    await Future.doWhile(() async {
+      attemptsCount++;
+      value = await _tryBindUnsafe(lower: lower, higher: higher);
+      return value == null && attemptsCount <= maxAttempts;
+    });
+    return value;
+  }
 }

--- a/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/tcp_helpers.dart
@@ -15,22 +15,22 @@ FutureOr<ServerSocket?> _tryBindUnsafe({
     final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, port);
     return socket;
   } on SocketException {
-  return null;
+    return null;
   }
 }
 
-/// Returns a RawServerSocket already binded to a port in the open interval
-/// [lower]-[higher] of the loopback interface where the referred range is
-/// a subset of the platform ephemeral port range.
+/// Returns a ServerSocket already binded to a randomly-selected port in the
+/// open interval [lower]-[higher] of the loopback interface where the referred
+/// range is a subset of the platform ephemeral port range.
 /// On failure returns null. [maxAttempts] limits the amount of asynchronous
 /// iterations performed.
-Future<RawServerSocket?> getSocketHolder({
+Future<ServerSocket?> getRandomPortSocket({
   required int lower,
   required int higher,
   int maxAttempts = 10,
 }) async {
   assert(maxAttempts > 0, 'At least one attempt will be done anyway.');
-  RawServerSocket? value;
+  ServerSocket? value;
   int attemptsCount = 0;
   await Future.doWhile(() async {
     attemptsCount++;

--- a/packages/ubuntu_wsl_setup/lib/services/tcp_socket.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/tcp_socket.dart
@@ -19,7 +19,7 @@ FutureOr<ServerSocket?> _tryBindUnsafe({
   }
 }
 
-class TcpHelperService {
+class TcpSocketService {
   /// Ephemeral port ranges (* chart is not on scale)
   ///
   /// ```
@@ -36,7 +36,7 @@ class TcpHelperService {
   /// is a subset of the platform ephemeral port range, limited by [kMinPortNo]
   /// and [kMaxPortNo]. [maxAttempts] limits the amount of asynchronous
   /// iterations performed. On failure returns null.
-  static Future<ServerSocket?> getRandomPortSocket({
+  Future<ServerSocket?> getRandomPortSocket({
     int lower = kMinPortNo,
     int higher = kMaxPortNo,
     int maxAttempts = 10,

--- a/packages/ubuntu_wsl_setup/test/services_test.dart
+++ b/packages/ubuntu_wsl_setup/test/services_test.dart
@@ -8,7 +8,7 @@ void main() {
     // The broader the range, more quickly we should exit the loop.
     final lower = Platform.isWindows ? 49152 : 32768;
     const higher = 60000;
-    final socket = await getSocketHolder(lower: lower, higher: higher);
+    final socket = await getRandomPortSocket(lower: lower, higher: higher);
     addTearDown(socket!.close);
     expect(socket.port, inExclusiveRange(lower, higher));
   });
@@ -17,7 +17,7 @@ void main() {
     // The range below is forbidden (outside of the ephemeral port range).
     const lower = 80;
     const higher = 88;
-    final socket = await getSocketHolder(
+    final socket = await getRandomPortSocket(
       lower: lower,
       higher: higher,
       maxAttempts: 3,

--- a/packages/ubuntu_wsl_setup/test/services_test.dart
+++ b/packages/ubuntu_wsl_setup/test/services_test.dart
@@ -8,7 +8,10 @@ void main() {
     // The broader the range, more quickly we should exit the loop.
     final lower = Platform.isWindows ? 49152 : 32768;
     const higher = 60000;
-    final socket = await getRandomPortSocket(lower: lower, higher: higher);
+    final socket = await TcpHelperService.getRandomPortSocket(
+      lower: lower,
+      higher: higher,
+    );
     addTearDown(socket!.close);
     expect(socket.port, inExclusiveRange(lower, higher));
   });
@@ -17,7 +20,7 @@ void main() {
     // The range below is forbidden (outside of the ephemeral port range).
     const lower = 80;
     const higher = 88;
-    final socket = await getRandomPortSocket(
+    final socket = await TcpHelperService.getRandomPortSocket(
       lower: lower,
       higher: higher,
       maxAttempts: 3,

--- a/packages/ubuntu_wsl_setup/test/services_test.dart
+++ b/packages/ubuntu_wsl_setup/test/services_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:ubuntu_wsl_setup/services/tcp_helpers.dart';
+import 'package:ubuntu_wsl_setup/services/tcp_socket.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -8,7 +8,8 @@ void main() {
     // The broader the range, more quickly we should exit the loop.
     const lower = 50000;
     const higher = 60000;
-    final socket = await TcpHelperService.getRandomPortSocket(
+    final service = TcpSocketService();
+    final socket = await service.getRandomPortSocket(
       lower: lower,
       higher: higher,
     );
@@ -21,7 +22,8 @@ void main() {
       () async {
         const lower = 50000;
         const higher = 51000;
-        final socket = await TcpHelperService.getRandomPortSocket(
+        final service = TcpSocketService();
+        final socket = await service.getRandomPortSocket(
           lower: lower,
           higher: higher,
           maxAttempts: 3,
@@ -42,7 +44,8 @@ void main() {
     const higher = 88;
     ServerSocket? socket;
     Future<void> closure() async {
-      socket = await TcpHelperService.getRandomPortSocket(
+      final service = TcpSocketService();
+      socket = await service.getRandomPortSocket(
         lower: lower,
         higher: higher,
         maxAttempts: 3,

--- a/packages/ubuntu_wsl_setup/test/services_test.dart
+++ b/packages/ubuntu_wsl_setup/test/services_test.dart
@@ -1,10 +1,12 @@
+import 'dart:io';
+
 import 'package:ubuntu_wsl_setup/services/tcp_helpers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('ensures range is respected', () async {
     // The broader the range, more quickly we should exit the loop.
-    const lower = 50000;
+    final lower = Platform.isWindows ? 49152 : 32768;
     const higher = 60000;
     final socket = await getSocketHolder(lower: lower, higher: higher);
     addTearDown(socket!.close);

--- a/packages/ubuntu_wsl_setup/test/services_test.dart
+++ b/packages/ubuntu_wsl_setup/test/services_test.dart
@@ -1,0 +1,27 @@
+import 'package:ubuntu_wsl_setup/services/tcp_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ensures range is respected', () async {
+    // The broader the range, more quickly we should exit the loop.
+    const lower = 50000;
+    const higher = 60000;
+    final socket = await getSocketHolder(lower: lower, higher: higher);
+    addTearDown(socket!.close);
+    expect(socket.port, inExclusiveRange(lower, higher));
+  });
+
+  test('wont attempt forever', () async {
+    // The range below is forbidden (outside of the ephemeral port range).
+    const lower = 80;
+    const higher = 88;
+    final socket = await getSocketHolder(
+      lower: lower,
+      higher: higher,
+      maxAttempts: 3,
+    );
+    //extra precaution in case test fails.
+    addTearDown(() => socket?.close());
+    expect(socket, isNull);
+  });
+}


### PR DESCRIPTION
Useful to safely find a port available on the system.

Subiquity will bind on that port later, on the Linux side.
This socket must be held binded prior to and closed just before the client attempts to connect to minimize chance of race condition. This way the localhost loopback interface forwarding will just work. Automagically.
It's required that the port range is agreed between Linux and Windows.

Testing suggestions are welcome.