### PR TITLE
Refactoring wsl wizard

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -6,6 +6,7 @@ import 'package:yaru/yaru.dart';
 import 'l10n.dart';
 import 'locale.dart';
 import 'wizard.dart';
+import 'routes.dart';
 
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({
@@ -40,13 +41,21 @@ class UbuntuWslSetupApp extends StatelessWidget {
   }
 
   Widget buildWizard(BuildContext context) {
-    switch (variant) {
+    if (variant == null) {
+      return const SizedBox.shrink();
+    }
+
+    return UbuntuWslSetupWizard(
+      initialRoute: initialRoute ?? routeForVariant(variant!),
+    );
+  }
+
+  String routeForVariant(Variant value) {
+    switch (value) {
       case Variant.WSL_SETUP:
-        return UbuntuWslSetupWizard(initialRoute: initialRoute);
+        return Routes.selectLanguage;
       case Variant.WSL_CONFIGURATION:
-        return UbuntuWslReconfigureWizard(initialRoute: initialRoute);
-      case null:
-        return const SizedBox.shrink();
+        return Routes.advancedReconfig;
       default:
         throw UnsupportedError('Unsupported WSL variant: $variant');
     }

--- a/packages/ubuntu_wsl_setup/lib/routes.dart
+++ b/packages/ubuntu_wsl_setup/lib/routes.dart
@@ -5,4 +5,6 @@ abstract class Routes {
   static const configurationUI = '/configuration-ui';
   static const applyingChanges = '/applying-changes';
   static const setupComplete = '/setup-complete';
+  static const advancedReconfig = '/advanced-reconfig';
+  static const applyingChangesReconfig = '/applying-changes-reconfig';
 }

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -38,31 +38,13 @@ class UbuntuWslSetupWizard extends StatelessWidget {
         Routes.setupComplete: const WizardRoute(
           builder: SetupCompletePage.create,
         ),
-      },
-    );
-  }
-}
-
-class UbuntuWslReconfigureWizard extends StatelessWidget {
-  const UbuntuWslReconfigureWizard({
-    Key? key,
-    this.initialRoute,
-  }) : super(key: key);
-
-  final String? initialRoute;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wizard(
-      initialRoute: initialRoute ?? Routes.advancedReconfig,
-      routes: const <String, WizardRoute>{
-        Routes.advancedReconfig: WizardRoute(
+        Routes.advancedReconfig: const WizardRoute(
           builder: AdvancedSetupPage.create,
         ),
-        Routes.configurationUI: WizardRoute(
+        Routes.configurationUI: const WizardRoute(
           builder: ConfigurationUIPage.create,
         ),
-        Routes.applyingChangesReconfig: WizardRoute(
+        Routes.applyingChangesReconfig: const WizardRoute(
           builder: ApplyingChangesPage.create,
         ),
       },

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -54,15 +54,15 @@ class UbuntuWslReconfigureWizard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wizard(
-      initialRoute: initialRoute ?? Routes.advancedSetup,
+      initialRoute: initialRoute ?? Routes.advancedReconfig,
       routes: const <String, WizardRoute>{
-        Routes.advancedSetup: WizardRoute(
+        Routes.advancedReconfig: WizardRoute(
           builder: AdvancedSetupPage.create,
         ),
         Routes.configurationUI: WizardRoute(
           builder: ConfigurationUIPage.create,
         ),
-        Routes.applyingChanges: WizardRoute(
+        Routes.applyingChangesReconfig: WizardRoute(
           builder: ApplyingChangesPage.create,
         ),
       },


### PR DESCRIPTION
At the first glance this seems redundant, but consider that we are about to add a different startup behavior that will delay considerably the moment the app is informed about the server variant (due WSL distribution registration). That behavior will require creating a new route (the slide show), but other than that the rest of the wizard would be duplication of what we currently have. The current design would require creating at least one new wizard class to accomodate that scenario. And with a new dimmension to decide upon (instead of just the variant): which Platform are we running on.
So, since the wizard_router started supporting per route onNext customisation we can build a single wizard able to start at different routes preserving the current behavior while making it easy to add new routes and conditions to jump between those routes.
This PR starts exploring this feature, for now just joining the wizards into one. Later, on top of this, I'll place a different `initalRoute` that will explore the `routeForVariant()` method as its `onNext` to select where it goes to.