### PR TITLE
Fix and clean up url launcher tests

### DIFF
--- a/packages/ubuntu_wizard/test/url_launcher_test.dart
+++ b/packages/ubuntu_wizard/test/url_launcher_test.dart
@@ -3,7 +3,6 @@ import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/src/utils/url_launcher.dart';
-import 'package:url_launcher/url_launcher.dart' show WebViewConfiguration;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 // ignore_for_file: prefer_mixin
@@ -48,11 +47,6 @@ void main() {
   });
 }
 
-const expectedUseWebView = true;
-const expectedWebViewConfiguration = WebViewConfiguration();
-const expectedUniversalLinksOnly = false;
-const expectedWebOnlyWindowName = null;
-
 void createPlatformMock(
   String url, {
   required bool canLaunch,
@@ -60,16 +54,7 @@ void createPlatformMock(
 }) {
   final mock = MockUrlLauncherPlatform();
   when(mock.canLaunch(url)).thenAnswer((_) async => canLaunch);
-  when(mock.launch(
-    url,
-    useSafariVC: expectedUseWebView,
-    useWebView: expectedUseWebView,
-    enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
-    enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
-    universalLinksOnly: expectedUniversalLinksOnly,
-    headers: expectedWebViewConfiguration.headers,
-    webOnlyWindowName: expectedWebOnlyWindowName,
-  )).thenAnswer((_) async => result);
+  when(mock.launchUrl(url, any)).thenAnswer((_) async => result);
   UrlLauncherPlatform.instance = mock;
 }
 
@@ -83,27 +68,9 @@ void verifyPlatformMock({
   verify(mock.canLaunch(url)).called(1);
 
   if (canLaunch) {
-    verify(mock.launch(
-      url,
-      useSafariVC: expectedUseWebView,
-      useWebView: expectedUseWebView,
-      enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
-      enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
-      universalLinksOnly: expectedUniversalLinksOnly,
-      headers: expectedWebViewConfiguration.headers,
-      webOnlyWindowName: expectedWebOnlyWindowName,
-    )).called(1);
+    verify(mock.launchUrl(url, any)).called(1);
   } else {
-    verifyNever(mock.launch(
-      url,
-      useSafariVC: expectedUseWebView,
-      useWebView: expectedUseWebView,
-      enableJavaScript: expectedWebViewConfiguration.enableJavaScript,
-      enableDomStorage: expectedWebViewConfiguration.enableDomStorage,
-      universalLinksOnly: expectedUniversalLinksOnly,
-      headers: expectedWebViewConfiguration.headers,
-      webOnlyWindowName: expectedWebOnlyWindowName,
-    ));
+    verifyNever(mock.launchUrl(url, any));
   }
 }
 
@@ -119,30 +86,9 @@ class MockUrlLauncherPlatform extends Mock
   }
 
   @override
-  Future<bool> launch(
-    String url, {
-    required bool useSafariVC,
-    required bool useWebView,
-    required bool enableJavaScript,
-    required bool enableDomStorage,
-    required bool universalLinksOnly,
-    required Map<String, String> headers,
-    String? webOnlyWindowName,
-  }) {
+  Future<bool> launchUrl(String url, LaunchOptions? options) {
     return super.noSuchMethod(
-      Invocation.method(
-        #launch,
-        [url],
-        {
-          #useSafariVC: useSafariVC,
-          #useWebView: useWebView,
-          #enableJavaScript: enableJavaScript,
-          #enableDomStorage: enableDomStorage,
-          #universalLinksOnly: universalLinksOnly,
-          #headers: headers,
-          #webOnlyWindowName: webOnlyWindowName,
-        },
-      ),
+      Invocation.method(#launchUrl, [url, options]),
       returnValue: Future.value(false),
     );
   }


### PR DESCRIPTION
The platform interface has changed so that all launch options are
bundled into an object. We don't really care about the exact options,
just using the defaults, so it can be "any" instead of trying to match
the values.