### PR TITLE
Check if subiquity path exists before passing it to the process class

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -50,7 +52,8 @@ Future<void> runInstallerApp(
   final subiquityClient = SubiquityClient();
   final bool liveRun = isLiveRun(options);
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
-  final subiquityPath = await getSubiquityPath();
+  final subiquityPath = await getSubiquityPath()
+      .then((dir) => Directory(dir).existsSync() ? dir : null);
   final endpoint = await defaultEndpoint(serverMode);
 
   final process = liveRun

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -29,7 +29,7 @@ screens, yet allowing user to overwrite any of those during setup.
   final subiquityPath = await getSubiquityPath()
       .then((dir) => Directory(dir).existsSync() ? dir : null);
   final endpoint = await defaultEndpoint(serverMode);
-  final procecss = SubiquityProcess.python(
+  final process = SubiquityProcess.python(
     'system_setup.cmd.server',
     serverMode: serverMode,
     subiquityPath: subiquityPath,
@@ -52,7 +52,7 @@ screens, yet allowing user to overwrite any of those during setup.
     ),
     options: options,
     subiquityClient: SubiquityClient(),
-    subiquityServer: SubiquityServer(process: procecss, endpoint: endpoint),
+    subiquityServer: SubiquityServer(process: process, endpoint: endpoint),
     subiquityMonitor: subiquityMonitor,
     onInitSubiquity: (client) {
       client.variant().then((value) {

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/widgets.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
@@ -24,7 +26,8 @@ screens, yet allowing user to overwrite any of those during setup.
   final variant = ValueNotifier<Variant?>(null);
   final liveRun = isLiveRun(options);
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
-  final subiquityPath = await getSubiquityPath();
+  final subiquityPath = await getSubiquityPath()
+      .then((dir) => Directory(dir).existsSync() ? dir : null);
   final endpoint = await defaultEndpoint(serverMode);
   final procecss = SubiquityProcess.python(
     'system_setup.cmd.server',


### PR DESCRIPTION
I noticed a `File not found crash` in WSL preview, which seems to be due the working directory (I'm sure that Python and the required modules exist inside the snap). I'd expect a more specific exception message, but that's the way it is. Since the subiquityPath is passed at the highest level, I thought checking whether it exists or not and what to do with that information also belongs to that level. Right now it looks code duplication. That might change in the future. It's worthy mentioning that the check existed until recently, thus a regression.

_I also took the opportunity to fix a typo nearby_ :D