### PR TITLE
Use handy_window

### DIFF
--- a/packages/ubuntu_desktop_installer/linux/CMakeLists.txt
+++ b/packages/ubuntu_desktop_installer/linux/CMakeLists.txt
@@ -64,13 +64,6 @@ set_target_properties(${BINARY_NAME}
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
 )
 
-pkg_check_modules(LIBHANDY IMPORTED_TARGET libhandy-1)
-if(LIBHANDY_FOUND)
-  set(ENABLE_LIBHANDY ON)
-  add_definitions("-DHAVE_LIBHANDY")
-  target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::LIBHANDY)
-endif(LIBHANDY_FOUND)
-
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_svg: ^1.1.0
   form_field_validator: ^1.1.0
   gsettings: ^0.2.5
+  handy_window: ^0.1.5
   intl: ^0.17.0
   meta: ^1.7.0
   nm: ^0.5.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,25 +142,8 @@ parts:
       - zip
     override-prime: ''
 
-  libhandy:
-    source: https://gitlab.gnome.org/GNOME/libhandy.git
-    source-branch: libhandy-1-2
-    source-depth: 1
-    plugin: meson
-    meson-parameters:
-      - --prefix=/usr
-      - --buildtype=release
-      - -Dvapi=false
-      - -Dintrospection=disabled
-      - -Dgtk_doc=false
-      - -Dtests=false
-      - -Dexamples=false
-      - -Dglade_catalog=disabled
-    build-packages:
-      - libgtk-3-dev
-
   ubuntu-desktop-installer:
-    after: [flutter-git, libhandy]
+    after: [flutter-git]
     source: .
     source-type: git
     plugin: nil


### PR DESCRIPTION
The [handy_window](https://pub.dev/packages/handy_window) plugin makes it straightforward to use `HdyWindow` from [libhandy](https://gitlab.gnome.org/GNOME/libhandy). We can remove all libhandy references - the plugin will take care of building and setting it up.