### PR TITLE
Remove Subiquity init and startup callbacks

### DIFF
--- a/packages/subiquity_client/lib/src/server.dart
+++ b/packages/subiquity_client/lib/src/server.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
 
-import 'package:meta/meta.dart';
-
 import 'endpoint.dart';
 import 'server/common.dart';
 import 'server/process.dart';
@@ -19,12 +17,6 @@ class SubiquityServer {
 
   SubiquityServer({this.process, required this.endpoint});
 
-  /// A callback for integration testing purposes. The callback is called when
-  /// the server has been started and thus, the application is ready for
-  /// integration testing.
-  @visibleForTesting
-  static void Function(Endpoint)? startupCallback;
-
   Future<Endpoint> start({
     List<String>? args,
     Map<String, String>? environment,
@@ -33,10 +25,7 @@ class SubiquityServer {
       await process!.start(additionalArgs: args, additionalEnv: environment);
     }
 
-    return _waitSubiquity(endpoint).then((_) {
-      startupCallback?.call(endpoint);
-      return endpoint;
-    });
+    return _waitSubiquity(endpoint).then((_) => endpoint);
   }
 
   static Future<void> _waitSubiquity(Endpoint endpoint) async {

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -39,8 +39,7 @@ void main() {
       username: 'user',
     );
 
-    app.main(<String>[]);
-    await waitForSubiquityServer();
+    await app.main(<String>[]);
     await tester.pumpAndSettle();
 
     await testWelcomePage(tester, language: language);
@@ -100,8 +99,7 @@ void main() {
       ),
     ];
 
-    app.main(<String>[]);
-    await waitForSubiquityServer();
+    await app.main(<String>[]);
     await tester.pumpAndSettle();
 
     await testWelcomePage(tester);
@@ -149,13 +147,12 @@ void main() {
   });
 
   testWidgets('turn off bitlocker', (tester) async {
-    app.main(<String>[
+    await app.main(<String>[
       '--machine-config',
       'examples/win10.json',
       '--initial-route',
       Routes.writeChangesToDisk,
     ]);
-    await waitForSubiquityServer();
     await tester.pumpAndSettle();
 
     await testWriteChangesToDiskPage(tester);

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -102,7 +102,7 @@ Future<void> runInstallerApp(
 
   final appStatus = ValueNotifier(AppStatus.loading);
 
-  runWizardApp(
+  await runWizardApp(
     ValueListenableBuilder<AppStatus>(
       valueListenable: appStatus,
       builder: (context, value, child) {
@@ -128,11 +128,10 @@ Future<void> runInstallerApp(
         '--storage-version=2',
       ],
     ],
-    onInitSubiquity: (client) {
-      appStatus.value = AppStatus.ready;
-      client.setVariant(Variant.DESKTOP);
-    },
   );
+
+  appStatus.value = AppStatus.ready;
+  return subiquityClient.setVariant(Variant.DESKTOP);
 }
 
 class UbuntuDesktopInstallerApp extends StatelessWidget {

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -99,16 +99,6 @@ Future<void> _verifyGoldenFile(String fileName, String goldenName) async {
   );
 }
 
-/// Waits for the subiquity server to be ready for integration testing.
-Future<void> waitForSubiquityServer() async {
-  final startup = Completer();
-  callback(Endpoint endpoint) => startup.complete();
-
-  SubiquityServer.startupCallback = callback;
-  addTearDown(() => SubiquityServer.startupCallback = null);
-  return startup.future;
-}
-
 /// Cleans up the .subiquity directory to ensure a clean test environment for
 /// integration test cases.
 Future<void> cleanUpSubiquity() async {

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -16,25 +16,23 @@ import 'utils.dart';
 /// @internal
 final log = Logger(_appName);
 
-/// The signature of a callback for initializing the Subiquity [client], which
-/// is called when the server connection has been established.
-typedef SubiquityInitCallback = void Function(SubiquityClient client);
-
 bool isLiveRun(ArgResults? options) {
   return options != null && options['dry-run'] != true;
 }
 
 /// Initializes and runs the given [app].
 ///
-/// Optionally, the Subiquity client] and server may be overridden for building
+/// Optionally, the Subiquity client and server may be overridden for building
 /// wizard variants and for testing purposes.
-Future<void> runWizardApp(
+///
+/// Returns a future that completes when the Subiquity server is ready to
+/// receive requests.
+Future<bool?> runWizardApp(
   Widget app, {
   ArgResults? options,
   required SubiquityClient subiquityClient,
   required SubiquityServer subiquityServer,
   SubiquityStatusMonitor? subiquityMonitor,
-  SubiquityInitCallback? onInitSubiquity,
   List<String>? serverArgs,
   Map<String, String>? serverEnvironment,
 }) async {
@@ -45,17 +43,14 @@ Future<void> runWizardApp(
     );
   }
 
-  subiquityServer
+  final subiquityReady = subiquityServer
       .start(args: serverArgs, environment: serverEnvironment)
-      .then((endpoint) {
+      .then((endpoint) async {
     subiquityClient.open(endpoint);
-    subiquityMonitor?.start(endpoint);
-
-    onInitSubiquity?.call(subiquityClient);
 
     // Use the default values for a number of endpoints
     // for which a UI page isn't implemented yet.
-    subiquityClient.markConfigured([
+    await subiquityClient.markConfigured([
       'drivers',
       'mirror',
       'proxy',
@@ -64,6 +59,8 @@ Future<void> runWizardApp(
       'snaplist',
       'ubuntu_pro',
     ]);
+
+    return subiquityMonitor?.start(endpoint);
   });
 
   registerServiceInstance(subiquityClient);
@@ -81,12 +78,14 @@ Future<void> runWizardApp(
     destroyWindow();
   });
 
-  runZonedGuarded(() {
+  return runZonedGuarded<Future<bool?>>(() {
     FlutterError.onError = (error) {
       log.error('Unhandled exception', error.exception, error.stack);
     };
 
-    return runApp(app);
+    runApp(app);
+
+    return subiquityReady;
   }, (error, stack) => log.error('Unhandled exception', error, stack));
 }
 

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -31,12 +31,10 @@ void main() {
       subiquityServer: server,
       serverArgs: ['--foo', 'bar'],
       serverEnvironment: {'baz': 'qux'},
-      onInitSubiquity: (client) => client.setVariant(Variant.DESKTOP),
     );
     verify(server.start(args: ['--foo', 'bar'], environment: {'baz': 'qux'}))
         .called(1);
     verify(client.open(endpoint)).called(1);
-    verify(client.setVariant(Variant.DESKTOP)).called(1);
   });
 
   testWidgets('registers the client', (tester) async {

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -17,8 +17,7 @@ void main() {
 
   // Select language and setup profile
   testWidgets('basic setup', (tester) async {
-    app.main(<String>[]);
-    await waitForSubiquityServer();
+    await app.main(<String>[]);
     await tester.pumpAndSettle();
 
     await testSelectYourLanguagePage(tester, language: 'Français');
@@ -44,8 +43,7 @@ void main() {
 
   // enter all WSLConfigurationBase values
   testWidgets('advanced setup', (tester) async {
-    app.main(<String>['--initial-route', Routes.profileSetup]);
-    await waitForSubiquityServer();
+    await app.main(<String>['--initial-route', Routes.profileSetup]);
     await tester.pumpAndSettle();
 
     await testProfileSetupPage(
@@ -76,8 +74,7 @@ void main() {
 
   // enter all WSLConfigurationAdvanced values
   testWidgets('reconfiguration', (tester) async {
-    app.main(<String>['--reconfigure']);
-    await waitForSubiquityServer();
+    await app.main(<String>['--reconfigure']);
     await tester.pumpAndSettle();
 
     await testAdvancedSetupPage(tester);


### PR DESCRIPTION
This approach makes sure that all involved futures are awaited, and that integration tests can simply await main() to reach the ready-for-testing state.