### PR TITLE
Cross platform server/paths

### DIFF
--- a/packages/subiquity_client/lib/src/server/paths.dart
+++ b/packages/subiquity_client/lib/src/server/paths.dart
@@ -45,5 +45,8 @@ Future<String> _findSubiquityPath() async {
   } else {
     log.debug('Found subiquity_client in ${package.root.path}');
   }
-  return p.join(package?.root.path ?? Directory.current.path, 'subiquity');
+  return p.join(
+    package?.root.toFilePath() ?? Directory.current.path,
+    'subiquity',
+  );
 }


### PR DESCRIPTION
`package.root.path` returns Unix style paths even when running on Windows.
This could cause crashes on test code running on Windows. No real issue is anticipated in production.

Even though, let's use `toFilePath()` to ensure a cross platform path representation.