### PR TITLE
Adds the command line option for WSL distro name

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -22,6 +22,15 @@ feeds the installer with partial information to prefill the
 screens, yet allowing user to overwrite any of those during setup.
   ''',
     );
+    parser.addOption(
+      'distro-name',
+      valueHelp: 'distro name',
+      help: '''
+  The name under which the distribution this application will setup or
+  configure is registered in WSL.
+  ''',
+      defaultsTo: const String.fromEnvironment('DISTRONAME'),
+    );
   })!;
   final variant = ValueNotifier<Variant?>(null);
   final liveRun = isLiveRun(options);


### PR DESCRIPTION
It defaults to the value DISTRONAME if --dart-defined.
Its purpose is let the application know the name of the distro that will run Subiquity.
It will be irrelevant on Linux, though.