### PR TITLE
Move UDI's mark_configured from the common wizard to the installer

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -131,7 +131,19 @@ Future<void> runInstallerApp(
   );
 
   appStatus.value = AppStatus.ready;
-  return subiquityClient.setVariant(Variant.DESKTOP);
+  await subiquityClient.setVariant(Variant.DESKTOP);
+
+  // Use the default values for a number of endpoints
+  // for which a UI page isn't implemented yet.
+  return subiquityClient.markConfigured([
+    'drivers',
+    'mirror',
+    'proxy',
+    'network',
+    'ssh',
+    'snaplist',
+    'ubuntu_pro',
+  ]);
 }
 
 class UbuntuDesktopInstallerApp extends StatelessWidget {

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -47,19 +47,6 @@ Future<bool?> runWizardApp(
       .start(args: serverArgs, environment: serverEnvironment)
       .then((endpoint) async {
     subiquityClient.open(endpoint);
-
-    // Use the default values for a number of endpoints
-    // for which a UI page isn't implemented yet.
-    await subiquityClient.markConfigured([
-      'drivers',
-      'mirror',
-      'proxy',
-      'network',
-      'ssh',
-      'snaplist',
-      'ubuntu_pro',
-    ]);
-
     return subiquityMonitor?.start(endpoint);
   });
 

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -130,4 +130,22 @@ void main() {
     expect(getService<SubiquityStatusMonitor>(), equals(monitor));
     verify(monitor.start(endpoint)).called(1);
   });
+
+  testWidgets('does not mark UI-specific pages configured', (tester) async {
+    final client = MockSubiquityClient();
+    final server = MockSubiquityServer();
+    when(server.start(
+            args: anyNamed('args'), environment: anyNamed('environment')))
+        .thenAnswer(
+      (_) async => Endpoint.unix(''),
+    );
+
+    await runWizardApp(
+      SizedBox(),
+      subiquityClient: client,
+      subiquityServer: server,
+    );
+
+    verifyNever(client.markConfigured(any));
+  });
 }


### PR DESCRIPTION
All these controllers are UDI-specific and marking them configured is
irrelevant to WSL. Thus, moving them from the shared ubuntu_wizard to
UDI makes most sense. At the same time, this fixes the regression
introduced by #958 that markConfigured() must be called after
setVariant().