### PR TITLE
InstallationState.proceedToSetup is terminal

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_model.dart
@@ -62,7 +62,7 @@ class InstallationSlidesModel extends SafeChangeNotifier {
         if (status?.state == ApplicationState.ERROR) {
           _setState(InstallationState.serverStartupError);
         }
-        if (isServerUp) {
+        if (status != null && status.state != ApplicationState.ERROR) {
           _setState(InstallationState.serverUp);
         }
       });

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_model.dart
@@ -75,7 +75,7 @@ class InstallationSlidesModel extends SafeChangeNotifier {
   }
 
   void _setState(InstallationState value) {
-    if (_state == value) {
+    if (_state == InstallationState.proceedToSetup || _state == value) {
       return;
     }
     _state = value;


### PR DESCRIPTION
Noticed during live run testing with an actual WSL image. Installation slides view model should not allow further state transitions after the `proceedToSetup` state. This prevents executing code when the slide show is not the current page.