### PR TITLE
Await window_manager initialization

### DIFF
--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -55,7 +55,7 @@ Future<bool?> runWizardApp(
     registerServiceInstance(subiquityMonitor);
   }
 
-  WidgetsFlutterBinding.ensureInitialized();
+  await ensureInitialized();
   await setupAppLocalizations();
 
   onWindowClosed().then((_) async {

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -55,7 +55,7 @@ Future<bool?> runWizardApp(
     registerServiceInstance(subiquityMonitor);
   }
 
-  await ensureInitialized();
+  ensureInitialized();
   await setupAppLocalizations();
 
   onWindowClosed().then((_) async {

--- a/packages/ubuntu_wizard/lib/src/utils/window.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/window.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:window_manager/window_manager.dart';
 

--- a/packages/ubuntu_wizard/lib/src/utils/window.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/window.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -42,4 +43,10 @@ Future<void> setWindowTitle(String title) {
 // ignore: avoid_positional_boolean_parameters
 Future<void> setWindowClosable(bool closable) {
   return windowManager.setClosable(closable);
+}
+
+/// Ensures initialization of the plugin(s) related to managing windows.
+Future<void> ensureInitialized() {
+  WidgetsFlutterBinding.ensureInitialized();
+  return windowManager.ensureInitialized();
 }

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -147,5 +148,31 @@ void main() {
     );
 
     verifyNever(client.markConfigured(any));
+  });
+
+  testWidgets('ensure initialized', (tester) async {
+    var wmInit = false;
+    final methodChannel = MethodChannel('window_manager');
+    methodChannel.setMockMethodCallHandler((call) async {
+      if (call.method == 'ensureInitialized') {
+        wmInit = true;
+      }
+      if (call.method == 'close') {}
+    });
+    final client = MockSubiquityClient();
+    final server = MockSubiquityServer();
+    when(server.start(
+            args: anyNamed('args'), environment: anyNamed('environment')))
+        .thenAnswer(
+      (_) async => Endpoint.unix(''),
+    );
+
+    await runWizardApp(
+      SizedBox(),
+      subiquityClient: client,
+      subiquityServer: server,
+    );
+
+    expect(wmInit, isTrue);
   });
 }


### PR DESCRIPTION
`window_manager` basically does nothing without that call on Windows OS, it's during that call that the plugin retrieves the top-level HWND, which is later target of all the plugin methods.

While the plugin could retrieve that information from the `view()->GetNativeWindow()` at each method call, that could be less performant, I guess.

Anyway, it's easier to fix it here than on the plugin and upgrading it.