### PR TITLE
Set coding style for native code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Google
+---
+Language: Cpp
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/packages/ubuntu_wsl_setup/windows/runner/main.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/main.cpp
@@ -6,7 +6,7 @@
 #include "utils.h"
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
-                      _In_ wchar_t *command_line, _In_ int show_command) {
+                      _In_ wchar_t* command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {
@@ -19,8 +19,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   flutter::DartProject project(L"data");
 
-  std::vector<std::string> command_line_arguments =
-      GetCommandLineArguments();
+  std::vector<std::string> command_line_arguments = GetCommandLineArguments();
 
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 

--- a/packages/ubuntu_wsl_setup/windows/runner/resource.h
+++ b/packages/ubuntu_wsl_setup/windows/runner/resource.h
@@ -2,15 +2,15 @@
 // Microsoft Visual C++ generated include file.
 // Used by Runner.rc
 //
-#define IDI_APP_ICON                    101
+#define IDI_APP_ICON 101
 
 // Next default values for new objects
 //
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        102
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_RESOURCE_VALUE 102
+#define _APS_NEXT_COMMAND_VALUE 40001
+#define _APS_NEXT_CONTROL_VALUE 1001
+#define _APS_NEXT_SYMED_VALUE 101
 #endif
 #endif

--- a/packages/ubuntu_wsl_setup/windows/runner/utils.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/utils.cpp
@@ -9,7 +9,7 @@
 
 void CreateAndAttachConsole() {
   if (::AllocConsole()) {
-    FILE *unused;
+    FILE* unused;
     if (freopen_s(&unused, "CONOUT$", "w", stdout)) {
       _dup2(_fileno(stdout), 1);
     }
@@ -45,17 +45,16 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
-      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+  int target_length =
+      ::WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string, -1,
+                            nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
-      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string, -1, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/packages/ubuntu_wsl_setup/windows/runner/win32_window.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/win32_window.cpp
@@ -93,17 +93,14 @@ void WindowClassRegistrar::UnregisterWindowClass() {
   class_registered_ = false;
 }
 
-Win32Window::Win32Window() {
-  ++g_active_window_count;
-}
+Win32Window::Win32Window() { ++g_active_window_count; }
 
 Win32Window::~Win32Window() {
   --g_active_window_count;
   Destroy();
 }
 
-bool Win32Window::CreateAndShow(const std::wstring& title,
-                                const Point& origin,
+bool Win32Window::CreateAndShow(const std::wstring& title, const Point& origin,
                                 const Size& size) {
   Destroy();
 
@@ -130,8 +127,7 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
 }
 
 // static
-LRESULT CALLBACK Win32Window::WndProc(HWND const window,
-                                      UINT const message,
+LRESULT CALLBACK Win32Window::WndProc(HWND const window, UINT const message,
                                       WPARAM const wparam,
                                       LPARAM const lparam) noexcept {
   if (message == WM_NCCREATE) {
@@ -150,9 +146,7 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window,
 }
 
 LRESULT
-Win32Window::MessageHandler(HWND hwnd,
-                            UINT const message,
-                            WPARAM const wparam,
+Win32Window::MessageHandler(HWND hwnd, UINT const message, WPARAM const wparam,
                             LPARAM const lparam) noexcept {
   switch (message) {
     case WM_DESTROY:
@@ -227,9 +221,7 @@ RECT Win32Window::GetClientArea() {
   return frame;
 }
 
-HWND Win32Window::GetHandle() {
-  return window_handle_;
-}
+HWND Win32Window::GetHandle() { return window_handle_; }
 
 void Win32Window::SetQuitOnClose(bool quit_on_close) {
   quit_on_close_ = quit_on_close;

--- a/packages/ubuntu_wsl_setup/windows/runner/win32_window.h
+++ b/packages/ubuntu_wsl_setup/windows/runner/win32_window.h
@@ -34,8 +34,7 @@ class Win32Window {
   // consistent size to will treat the width height passed in to this function
   // as logical pixels and scale to appropriate for the default monitor. Returns
   // true if the window was created successfully.
-  bool CreateAndShow(const std::wstring& title,
-                     const Point& origin,
+  bool CreateAndShow(const std::wstring& title, const Point& origin,
                      const Size& size);
 
   // Release OS resources associated with window.
@@ -58,8 +57,7 @@ class Win32Window {
   // Processes and route salient window messages for mouse handling,
   // size change and DPI. Delegates handling of these to member overloads that
   // inheriting classes can handle.
-  virtual LRESULT MessageHandler(HWND window,
-                                 UINT const message,
+  virtual LRESULT MessageHandler(HWND window, UINT const message,
                                  WPARAM const wparam,
                                  LPARAM const lparam) noexcept;
 
@@ -78,8 +76,7 @@ class Win32Window {
   // non-client DPI scaling so that the non-client area automatically
   // responsponds to changes in DPI. All other messages are handled by
   // MessageHandler.
-  static LRESULT CALLBACK WndProc(HWND const window,
-                                  UINT const message,
+  static LRESULT CALLBACK WndProc(HWND const window, UINT const message,
                                   WPARAM const wparam,
                                   LPARAM const lparam) noexcept;
 


### PR DESCRIPTION
Set the standard window size and adds a custom `.clang-format` file for consistency when editing C++ source files, imported from [flutter/plugins](https://github.com/flutter/plugins/blob/main/.clang-format) and [flutter/packages](https://github.com/flutter/packages/blob/main/.clang-format):
```
BasedOnStyle: Google
---
Language: Cpp
DerivePointerAlignment: false
PointerAlignment: Left
```

The files inside the `**/linux` subdirectories won't change at all when formatted using clang-format. The Windows app template, on the other hand, doesn't seem to follow a specific coding style, thus besides submitting a `.clang-format` configuration file, this PR also formats the non-compliant files.