### PR TITLE
Prepare DiskStorageService for new guided partitioning

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -46,6 +46,6 @@ class SelectGuidedStorageModel extends SafeChangeNotifier {
 
   /// Resets the guided storage selection.
   Future<void> resetGuidedStorage() {
-    return _service.resetGuidedStorage();
+    return _service.resetStorage();
   }
 }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -2,10 +2,10 @@
 // in ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
+import 'dart:async' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
     as _i2;
 
@@ -28,14 +28,6 @@ class MockDiskStorageService extends _i1.Mock
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  set storage(List<_i3.Disk>? _storage) =>
-      super.noSuchMethod(Invocation.setter(#storage, _storage),
-          returnValueForMissingStub: null);
-  @override
-  set guidedStorage(List<_i3.Disk>? _guidedStorage) =>
-      super.noSuchMethod(Invocation.setter(#guidedStorage, _guidedStorage),
-          returnValueForMissingStub: null);
   @override
   bool get hasMultipleDisks =>
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
@@ -73,67 +65,62 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<List<_i3.Disk>> getGuidedStorage() =>
+  _i3.Future<List<_i4.Disk>> getGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<void> setGuidedStorage([_i3.Disk? disk]) =>
+  _i3.Future<void> setGuidedStorage([_i4.Disk? disk]) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorage, [disk]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<void> resetGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
-  @override
-  _i4.Future<List<_i3.Disk>> getStorage() =>
+  _i3.Future<List<_i4.Disk>> getStorage() =>
       (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addPartition(
-          _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> addPartition(
+          _i4.Disk? disk, _i4.Gap? gap, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> editPartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> editPartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> deletePartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> deletePartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> setStorage(List<_i3.Disk>? disks) =>
+  _i3.Future<List<_i4.Disk>> setStorage(List<_i4.Disk>? disks) =>
       (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> resetStorage() =>
+  _i3.Future<List<_i4.Disk>> resetStorage() =>
       (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addBootPartition(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> addBootPartition(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> reformatDisk(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> reformatDisk(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -2,12 +2,12 @@
 // in ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
+import 'dart:async' as _i3;
 
 import 'package:file/file.dart' as _i6;
 import 'package:file/local.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
     as _i2;
 import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
@@ -32,14 +32,6 @@ class MockDiskStorageService extends _i1.Mock
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  set storage(List<_i3.Disk>? _storage) =>
-      super.noSuchMethod(Invocation.setter(#storage, _storage),
-          returnValueForMissingStub: null);
-  @override
-  set guidedStorage(List<_i3.Disk>? _guidedStorage) =>
-      super.noSuchMethod(Invocation.setter(#guidedStorage, _guidedStorage),
-          returnValueForMissingStub: null);
   @override
   bool get hasMultipleDisks =>
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
@@ -77,69 +69,64 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<List<_i3.Disk>> getGuidedStorage() =>
+  _i3.Future<List<_i4.Disk>> getGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<void> setGuidedStorage([_i3.Disk? disk]) =>
+  _i3.Future<void> setGuidedStorage([_i4.Disk? disk]) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorage, [disk]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<void> resetGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
-  @override
-  _i4.Future<List<_i3.Disk>> getStorage() =>
+  _i3.Future<List<_i4.Disk>> getStorage() =>
       (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addPartition(
-          _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> addPartition(
+          _i4.Disk? disk, _i4.Gap? gap, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> editPartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> editPartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> deletePartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> deletePartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> setStorage(List<_i3.Disk>? disks) =>
+  _i3.Future<List<_i4.Disk>> setStorage(List<_i4.Disk>? disks) =>
       (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> resetStorage() =>
+  _i3.Future<List<_i4.Disk>> resetStorage() =>
       (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addBootPartition(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> addBootPartition(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> reformatDisk(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> reformatDisk(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
 }
 
 /// A class which mocks [TelemetryService].
@@ -171,8 +158,8 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
       super.noSuchMethod(Invocation.method(#setPartitionMethod, [method]),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
+  _i3.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
       (super.noSuchMethod(Invocation.method(#done, [], {#fs: fs}),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -173,6 +173,8 @@ void main() {
     when(client.isOpen).thenAnswer((_) async => true);
     when(client.getGuidedStorage()).thenAnswer(
         (_) async => GuidedStorageResponse(status: ProbeStatus.DONE));
+    when(client.getStorageV2()).thenAnswer((_) async => StorageResponseV2(
+        disks: [], installMinimumSize: 0, needBoot: false, needRoot: false));
     when(client.hasRst()).thenAnswer((_) async => false);
     when(client.hasBitLocker()).thenAnswer((_) async => false);
     registerMockService<SubiquityClient>(client);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
@@ -62,11 +62,11 @@ void main() {
 
   test('reset guided storage', () async {
     final service = MockDiskStorageService();
-    when(service.resetGuidedStorage()).thenAnswer((_) async => testStorages);
+    when(service.resetStorage()).thenAnswer((_) async => testStorages);
 
     final model = SelectGuidedStorageModel(service);
     await model.resetGuidedStorage();
-    verify(service.resetGuidedStorage()).called(1);
+    verify(service.resetStorage()).called(1);
   });
 
   test('notify changes', () {

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -2,10 +2,10 @@
 // in ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
+import 'dart:async' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
     as _i2;
 
@@ -28,14 +28,6 @@ class MockDiskStorageService extends _i1.Mock
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  set storage(List<_i3.Disk>? _storage) =>
-      super.noSuchMethod(Invocation.setter(#storage, _storage),
-          returnValueForMissingStub: null);
-  @override
-  set guidedStorage(List<_i3.Disk>? _guidedStorage) =>
-      super.noSuchMethod(Invocation.setter(#guidedStorage, _guidedStorage),
-          returnValueForMissingStub: null);
   @override
   bool get hasMultipleDisks =>
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
@@ -73,67 +65,62 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<List<_i3.Disk>> getGuidedStorage() =>
+  _i3.Future<List<_i4.Disk>> getGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<void> setGuidedStorage([_i3.Disk? disk]) =>
+  _i3.Future<void> setGuidedStorage([_i4.Disk? disk]) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorage, [disk]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<void> resetGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
-  @override
-  _i4.Future<List<_i3.Disk>> getStorage() =>
+  _i3.Future<List<_i4.Disk>> getStorage() =>
       (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addPartition(
-          _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> addPartition(
+          _i4.Disk? disk, _i4.Gap? gap, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> editPartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> editPartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> deletePartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> deletePartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> setStorage(List<_i3.Disk>? disks) =>
+  _i3.Future<List<_i4.Disk>> setStorage(List<_i4.Disk>? disks) =>
       (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> resetStorage() =>
+  _i3.Future<List<_i4.Disk>> resetStorage() =>
       (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addBootPartition(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> addBootPartition(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> reformatDisk(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> reformatDisk(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/widget_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_test.dart
@@ -29,8 +29,8 @@ void main() {
     when(client.hasBitLocker()).thenAnswer((_) async => false);
     when(client.keyboard()).thenAnswer((_) async =>
         KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
-    when(client.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponse(status: ProbeStatus.DONE));
+    when(client.getStorageV2()).thenAnswer((_) async => StorageResponseV2(
+        disks: [], installMinimumSize: 0, needBoot: false, needRoot: false));
     when(client.isOpen).thenAnswer((_) async => true);
     registerMockService<SubiquityClient>(client);
     registerMockService<DiskStorageService>(DiskStorageService(client));

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -2,10 +2,10 @@
 // in ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
+import 'dart:async' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
+import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
     as _i2;
 
@@ -28,14 +28,6 @@ class MockDiskStorageService extends _i1.Mock
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  set storage(List<_i3.Disk>? _storage) =>
-      super.noSuchMethod(Invocation.setter(#storage, _storage),
-          returnValueForMissingStub: null);
-  @override
-  set guidedStorage(List<_i3.Disk>? _guidedStorage) =>
-      super.noSuchMethod(Invocation.setter(#guidedStorage, _guidedStorage),
-          returnValueForMissingStub: null);
   @override
   bool get hasMultipleDisks =>
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
@@ -73,67 +65,62 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
+  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+      returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<List<_i3.Disk>> getGuidedStorage() =>
+  _i3.Future<List<_i4.Disk>> getGuidedStorage() =>
       (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<void> setGuidedStorage([_i3.Disk? disk]) =>
+  _i3.Future<void> setGuidedStorage([_i4.Disk? disk]) =>
       (super.noSuchMethod(Invocation.method(#setGuidedStorage, [disk]),
           returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValueForMissingStub: Future<void>.value()) as _i3.Future<void>);
   @override
-  _i4.Future<void> resetGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetGuidedStorage, []),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
-  @override
-  _i4.Future<List<_i3.Disk>> getStorage() =>
+  _i3.Future<List<_i4.Disk>> getStorage() =>
       (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addPartition(
-          _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> addPartition(
+          _i4.Disk? disk, _i4.Gap? gap, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> editPartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> editPartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> deletePartition(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+  _i3.Future<List<_i4.Disk>> deletePartition(
+          _i4.Disk? disk, _i4.Partition? partition) =>
       (super.noSuchMethod(
               Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> setStorage(List<_i3.Disk>? disks) =>
+  _i3.Future<List<_i4.Disk>> setStorage(List<_i4.Disk>? disks) =>
       (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> resetStorage() =>
+  _i3.Future<List<_i4.Disk>> resetStorage() =>
       (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> addBootPartition(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> addBootPartition(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
   @override
-  _i4.Future<List<_i3.Disk>> reformatDisk(_i3.Disk? disk) =>
+  _i3.Future<List<_i4.Disk>> reformatDisk(_i4.Disk? disk) =>
       (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: Future<List<_i3.Disk>>.value(<_i3.Disk>[]))
-          as _i4.Future<List<_i3.Disk>>);
+              returnValue: Future<List<_i4.Disk>>.value(<_i4.Disk>[]))
+          as _i3.Future<List<_i4.Disk>>);
 }


### PR DESCRIPTION
The new guided storage API no longer provides a list of disks, but
presents a list of targets for reformatting disks, resizing partitions,
and using gaps between partitions. This change prepares for the API
switch by removing such incompatible assumptions.

Ref: #819