### PR TITLE
Write changes to disk: present all non-preserved entries

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -12,13 +12,14 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
 
   final SubiquityClient _client;
   final DiskStorageService _service;
-  Map<Disk, List<Partition>>? _partitions;
+  List<Disk>? _disks;
+  Map<String, List<Partition>>? _partitions;
 
   /// The list of non-preserved disks.
-  List<Disk> get disks => _partitions?.keys.toList() ?? [];
+  List<Disk> get disks => _disks ?? [];
 
-  /// Returns the list of non-preserved partitions fro the given disk.
-  List<Partition> partitions(Disk disk) => _partitions?[disk] ?? [];
+  /// A map of non-preserved partitions per each disk (sysname).
+  Map<String, List<Partition>> get partitions => _partitions ?? {};
 
   /// Initializes the model.
   Future<void> init() => _service.getStorage().then(_updateDisks);
@@ -30,18 +31,15 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
   }
 
   void _updateDisks(List<Disk> disks) {
-    final changes = disks.where((d) => d.preserve == false);
+    _disks = disks.where((d) => d.preserve == false).toList();
     _partitions = Map.fromEntries(
-      changes.map((disk) {
+      disks.map((disk) {
         final partitions = disk.partitions
             .whereType<Partition>()
             .where((p) => p.preserve == false)
             .toList();
-        return MapEntry(
-          disk.copyWith(partitions: partitions),
-          partitions,
-        );
-      }),
+        return MapEntry(disk.sysname, partitions);
+      }).where((entry) => entry.value.isNotEmpty),
     );
     notifyListeners();
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -80,13 +80,13 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
           child: Text(lang.writeChangesPartitionsHeader),
         ),
         const SizedBox(height: 10),
-        for (final disk in model.disks)
-          for (final partition in model.partitions(disk))
+        for (final entry in model.partitions.entries)
+          for (final partition in entry.value)
             Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _PartitionLabel(disk, partition),
+                _PartitionLabel(entry.key, partition),
                 const SizedBox(height: kContentSpacing / 2),
               ],
             ),
@@ -105,22 +105,23 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
 }
 
 class _PartitionLabel extends StatelessWidget {
-  _PartitionLabel(this.disk, this.partition) : super(key: ValueKey(partition));
+  _PartitionLabel(this.sysname, this.partition)
+      : super(key: ValueKey(partition));
 
-  final Disk disk;
+  final String sysname;
   final Partition partition;
 
   String formatPartition(AppLocalizations lang) {
     if (partition.mount?.isNotEmpty == true) {
       return lang.writeChangesPartitionEntryMounted(
-        disk.sysname,
+        sysname,
         partition.number ?? 0,
         partition.format ?? '',
         partition.mount ?? '',
       );
     } else {
       return lang.writeChangesPartitionEntryUnmounted(
-        disk.sysname,
+        sysname,
         partition.number ?? 0,
         partition.format ?? '',
       );

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -14,20 +14,20 @@ import 'write_changes_to_disk_model_test.mocks.dart';
 void main() {
   final testDisks = <Disk>[
     testDisk(
-      id: 'a',
+      path: '/dev/sda',
       preserve: false,
       partitions: [Partition(number: 1, preserve: false)],
     ),
     testDisk(
-      id: 'b',
+      path: '/dev/sdb',
       preserve: true,
       partitions: [
         Partition(number: 1),
-        Partition(number: 2, grubDevice: true),
+        Partition(number: 2, preserve: false),
       ],
     ),
     testDisk(
-      id: 'c',
+      path: '/dev/sdc',
       preserve: false,
       partitions: [
         Partition(number: 3, preserve: false),
@@ -36,18 +36,7 @@ void main() {
     ),
   ];
 
-  final nonPreservedDisks = <Disk>[
-    testDisk(
-      id: 'a',
-      preserve: false,
-      partitions: [Partition(number: 1, preserve: false)],
-    ),
-    testDisk(
-      id: 'c',
-      preserve: false,
-      partitions: [Partition(number: 3, preserve: false)],
-    ),
-  ];
+  final nonPreservedDisks = <Disk>[testDisks.first, testDisks.last];
 
   test('get storage', () async {
     final client = MockSubiquityClient();
@@ -59,10 +48,14 @@ void main() {
     verify(service.getStorage()).called(1);
 
     expect(model.disks, equals(nonPreservedDisks));
-    expect(model.partitions(nonPreservedDisks.first),
-        equals([Partition(number: 1, preserve: false)]));
-    expect(model.partitions(nonPreservedDisks.last),
-        equals([Partition(number: 3, preserve: false)]));
+    expect(
+      model.partitions,
+      equals({
+        'sda': [Partition(number: 1, preserve: false)],
+        'sdb': [Partition(number: 2, preserve: false)],
+        'sdc': [Partition(number: 3, preserve: false)],
+      }),
+    );
   });
 
   test('start installation', () async {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -59,13 +59,13 @@ final testDisks = <Disk>[
   ),
 ];
 
-WriteChangesToDiskModel buildModel({List<Disk>? disks}) {
+WriteChangesToDiskModel buildModel({
+  List<Disk>? disks,
+  Map<String, List<Partition>>? partitions,
+}) {
   final model = MockWriteChangesToDiskModel();
   when(model.disks).thenReturn(disks ?? <Disk>[]);
-  when(model.partitions(testDisks.first))
-      .thenReturn(testDisks.first.partitions.whereType<Partition>().toList());
-  when(model.partitions(testDisks.last))
-      .thenReturn(testDisks.last.partitions.whereType<Partition>().toList());
+  when(model.partitions).thenReturn(partitions ?? <String, List<Partition>>{});
   return model;
 }
 
@@ -90,7 +90,10 @@ void main() {
   }
 
   testWidgets('list of disks and partitions', (tester) async {
-    final model = buildModel(disks: testDisks);
+    final model = buildModel(disks: testDisks, partitions: {
+      testDisks.first.sysname: testDisks.first.partitions.cast<Partition>(),
+      testDisks.last.sysname: testDisks.last.partitions.cast<Partition>(),
+    });
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     for (final disk in testDisks) {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
@@ -72,6 +72,11 @@ class MockWriteChangesToDiskModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i4.Disk>[])
           as List<_i4.Disk>);
   @override
+  Map<String, List<_i4.Partition>> get partitions =>
+      (super.noSuchMethod(Invocation.getter(#partitions),
+              returnValue: <String, List<_i4.Partition>>{})
+          as Map<String, List<_i4.Partition>>);
+  @override
   bool get isDisposed =>
       (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
           as bool);
@@ -79,10 +84,6 @@ class MockWriteChangesToDiskModel extends _i1.Mock
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
-  @override
-  List<_i4.Partition> partitions(_i4.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#partitions, [disk]),
-          returnValue: <_i4.Partition>[]) as List<_i4.Partition>);
   @override
   _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),


### PR DESCRIPTION
Collect the list of non-preserved partitions from all disks, not only from non-preserved disks.

Before:
- collect non-preserved disks, and then non-preserved partitions from them

After:
- collect non-preserved disks
- collect non-preserved partitions from all disks

This is necessary for the upcoming guided installation alongside an existing OS, where the entire disk won't be reformatted and thus, is considered preserved.

Ref: #819