### PR TITLE
Build workflow for the WSL OOBE target

### DIFF
--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -1,0 +1,43 @@
+name: Windows WSL Setup CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/subiquity_client/**
+      - packages/ubuntu_wizard/**
+      - packages/ubuntu_wsl_setup/**
+      - .github/workflows/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - packages/subiquity_client/**
+      - packages/ubuntu_wizard/**
+      - packages/ubuntu_wsl_setup/**
+      - .github/workflows/**      
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: subosito/flutter-action@v1
+      with:
+        channel: 'stable'
+
+    - name: Install Melos
+      run: flutter pub global activate melos
+
+    - name: Bootstrap workspace
+      run: melos bootstrap
+
+    - name: Build Windows Target
+      working-directory: packages\ubuntu_wsl_setup\
+      run: flutter build -t .\lib\main_win.dart

--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    
+
     - uses: actions/checkout@v2
       with:
         submodules: recursive
@@ -32,18 +32,8 @@ jobs:
       with:
         channel: 'stable'
 
-    - name: Install Melos
-      run: flutter pub global activate melos
-
-    - name: Bootstrap workspace
-      shell: powershell
-      run: |
-# Bootstrapping is a file system intensive operation, which seems to recycle
-# some temporary file names. Windows is known for file system race conditions
-# when deleting or renaming files, so running melos just once will likely fail.
-        Invoke-Command -ErrorAction 'Ignore' -ScriptBlock {melos bootstrap}
-        melos bootstrap
-
     - name: Build Windows Target
       working-directory: packages\ubuntu_wsl_setup\
-      run: flutter build -t .\lib\main_win.dart
+      run: |
+        flutter pub get
+        flutter build windows -t .\lib\main_win.dart

--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -36,7 +36,13 @@ jobs:
       run: flutter pub global activate melos
 
     - name: Bootstrap workspace
-      run: melos bootstrap
+      shell: powershell
+      run: |
+# Bootstrapping is a file system intensive operation, which seems to recycle
+# some temporary file names. Windows is known for file system race conditions
+# when deleting or renaming files, so running melos just once will likely fail.
+        Invoke-Command -ErrorAction 'Ignore' -ScriptBlock {melos bootstrap}
+        melos bootstrap
 
     - name: Build Windows Target
       working-directory: packages\ubuntu_wsl_setup\


### PR DESCRIPTION
We can discuss later about the other pieces of a good CI workflow, but at least since we are touching native files which may introduce silent failures, attempting to build the Windows entry point app when relevant pull requests are opened should be a good starting point.

This filters out PR's that don't touch either the `.github/workflows` directory as well as the packages `ubuntu_wsl_setup`, `ubuntu_wizard` and `subiquity_client`.