### PR TITLE
Allocate disk space: remove a hard-coded height to fix overflow

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -81,37 +82,33 @@ class PartitionLegend extends StatelessWidget {
     final model = Provider.of<AllocateDiskSpaceModel>(context);
     final lang = AppLocalizations.of(context);
 
-    final objects = model.selectedDisk?.partitions;
+    final objects = model.selectedDisk?.partitions ?? [];
 
-    return SizedBox(
-      height: 48,
-      child: ListView.separated(
-        shrinkWrap: true,
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: objects?.length ?? 0,
-        separatorBuilder: (context, index) => const SizedBox(width: 40),
-        itemBuilder: (context, index) {
-          final object = objects![index];
-          if (object is Gap) {
-            return _PartitionLabel(
-              size: object.size,
-              title: lang.freeDiskSpace,
-              borderColor: Theme.of(context).dividerColor,
-            );
-          }
-
-          final partition = object as Partition;
-
-          return _PartitionLabel(
-            // TODO:
-            // - localize?
-            // - partition type?
-            title: '${model.selectedDisk!.id}${partition.number}',
-            size: partition.size ?? 0,
-            color: _partitionColor(index, objects.length),
-          );
-        },
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: objects
+            .mapIndexed((index, object) => Padding(
+                  padding:
+                      EdgeInsetsDirectional.only(start: index > 0 ? 40 : 0),
+                  child: object.map(
+                    partition: (partition) => _PartitionLabel(
+                      // TODO:
+                      // - localize?
+                      // - partition type?
+                      title: '${model.selectedDisk!.id}${partition.number}',
+                      size: partition.size ?? 0,
+                      color: _partitionColor(index, objects.length),
+                    ),
+                    gap: (gap) => _PartitionLabel(
+                      size: gap.size,
+                      title: lang.freeDiskSpace,
+                      borderColor: Theme.of(context).dividerColor,
+                    ),
+                  ),
+                ))
+            .toList(),
       ),
     );
   }


### PR DESCRIPTION
A hard-coded 48px value was used because a horizontal ListView doesn't
calculate intrinsic height. Use SingleChildScrollView + Row to ensure
that the height is calculated as appropriate. This is fine for a list of
partition labels because the amount is never going to be awfully high.