### PR TITLE
Upgrade wizard_router

### DIFF
--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
       path: packages/ubuntu_widgets
   url_launcher: ^6.1.0
   window_manager: ^0.2.5
-  wizard_router: ^0.8.0
+  wizard_router: ^0.9.0
   yaru: ^0.3.2
 
 dev_dependencies:


### PR DESCRIPTION
[WizardScope.replace()](ubuntu-flutter-community/wizard_router#21) will be used for the link from guided to manual partitioning in #819.