### PR TITLE
DiskStorageService: expose guided storage choice

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -30,9 +30,13 @@ class DiskStorageService {
   bool? _hasBitLocker;
   bool? _hasMultipleDisks;
   List<OsProber>? _existingOS;
+  GuidedChoiceV2? _guidedChoice;
 
   /// Whether the system has multiple disks available for guided partitioning.
   bool get hasMultipleDisks => _hasMultipleDisks ?? false;
+
+  /// Whether a guided storage target was chosen.
+  bool get hasGuidedChoice => _guidedChoice != null;
 
   /// Whether the storage configuration is missing a root partition.
   bool get needRoot => _needRoot ?? true;
@@ -66,9 +70,9 @@ class DiskStorageService {
   Future<GuidedStorageResponseV2> setGuidedStorage(
       GuidedStorageTarget target) async {
     final response = await _client.getGuidedStorageV2();
-    final choice = response.configured?.copyWith(target: target) ??
+    _guidedChoice = response.configured?.copyWith(target: target) ??
         GuidedChoiceV2(target: target);
-    return _client.setGuidedStorageV2(choice.copyWith(useLvm: useLvm));
+    return _client.setGuidedStorageV2(_guidedChoice!.copyWith(useLvm: useLvm));
   }
 
   List<Disk> _updateStorage(StorageResponseV2 response) {
@@ -126,6 +130,7 @@ class DiskStorageService {
   /// Resets the current storage configuration to allow reverting back to the
   /// original configuration.
   Future<List<Disk>> resetStorage() {
+    _guidedChoice = null;
     return _client.resetStorageV2().then(_updateStorage);
   }
 

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -36,6 +36,10 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
+  bool get hasGuidedChoice => (super
+          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
+      as bool);
+  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -40,6 +40,10 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
+  bool get hasGuidedChoice => (super
+          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
+      as bool);
+  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -36,6 +36,10 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
+  bool get hasGuidedChoice => (super
+          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
+      as bool);
+  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -247,6 +247,24 @@ void main() {
     await service.init();
     expect(service.existingOS, equals([win10, ubuntu2110, ubuntu2204]));
   });
+
+  test('guided choice', () async {
+    final target = GuidedStorageTargetReformat(diskId: testDisks.last.id);
+    final choice = GuidedChoiceV2(target: target, useLvm: false);
+    when(client.setGuidedStorageV2(choice))
+        .thenAnswer((_) async => GuidedStorageResponseV2(configured: choice));
+    when(client.resetStorageV2())
+        .thenAnswer((_) async => testStorageResponse());
+
+    final service = DiskStorageService(client);
+    expect(service.hasGuidedChoice, isFalse);
+
+    await service.setGuidedStorage(target);
+    expect(service.hasGuidedChoice, isTrue);
+
+    await service.resetStorage();
+    expect(service.hasGuidedChoice, isFalse);
+  });
 }
 
 StorageResponseV2 testStorageResponse({

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -36,6 +36,10 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
+  bool get hasGuidedChoice => (super
+          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
+      as bool);
+  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);


### PR DESCRIPTION
The information will be used for implementing the navigation flow for
guided storage resize (#819).

In principle, a guided storage target is automatically chosen whenever
possible i.e. if there's a) only one disk to erase or b) enough free
space for the installation. If an automatic choice is made, the
respective pages for selecting or resizing a guided storage are skipped.
The value of this property will be checked in the wizard router when
choosing the next page.