### PR TITLE
Generalize and promote StorageSizeBox

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -5,8 +5,8 @@ import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 import '../../l10n.dart';
+import '../../widgets.dart';
 import 'allocate_disk_space_model.dart';
-import 'storage_size_box.dart';
 import 'storage_types.dart';
 
 /// Shows a confirmation dialog with the given title and message.

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -78,7 +78,7 @@ Future<void> showCreatePartitionDialog(
                   return StorageSizeBox(
                     size: partitionSize.value,
                     unit: partitionUnit.value,
-                    available: gap.size,
+                    maximum: gap.size,
                     onSizeChanged: (v) => partitionSize.value = v,
                     onUnitSelected: (v) => partitionUnit.value = v,
                   );

--- a/packages/ubuntu_desktop_installer/lib/widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets.dart
@@ -1,0 +1,1 @@
+export 'widgets/storage_size_box.dart';

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -4,7 +4,7 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../../l10n.dart';
+import '../l10n.dart';
 
 /// Storage size entry with a spinbox and a data size unit dropdown.
 class StorageSizeBox extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -31,7 +31,10 @@ class StorageSizeBox extends StatelessWidget {
   /// The maximum value in bytes.
   final int maximum;
 
+  /// The callback called whenever the size changes.
   final ValueChanged<int> onSizeChanged;
+
+  /// The callback called whenever the user selects a size unit.
   final ValueChanged<DataUnit> onUnitSelected;
 
   /// Whether the widget should automatically gain focus if nothing else is

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -12,7 +12,8 @@ class StorageSizeBox extends StatelessWidget {
     Key? key,
     required this.size,
     required this.unit,
-    required this.available,
+    this.minimum = 0,
+    required this.maximum,
     required this.onSizeChanged,
     required this.onUnitSelected,
   }) : super(key: key);
@@ -23,8 +24,11 @@ class StorageSizeBox extends StatelessWidget {
   /// The unit for visualization.
   final DataUnit unit;
 
+  /// The minimum value in bytes.
+  final int minimum;
+
   /// The maximum value in bytes.
-  final int available;
+  final int maximum;
 
   final ValueChanged<int> onSizeChanged;
   final ValueChanged<DataUnit> onUnitSelected;
@@ -37,7 +41,8 @@ class StorageSizeBox extends StatelessWidget {
         Expanded(
           child: SpinBox(
             value: fromBytes(size, unit),
-            max: fromBytes(available, unit),
+            min: fromBytes(minimum, unit),
+            max: fromBytes(maximum, unit),
             onChanged: (value) => onSizeChanged(toBytes(value, unit)),
           ),
         ),

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -16,6 +16,7 @@ class StorageSizeBox extends StatelessWidget {
     required this.maximum,
     required this.onSizeChanged,
     required this.onUnitSelected,
+    this.autofocus = false,
   }) : super(key: key);
 
   /// The current value in bytes.
@@ -33,6 +34,10 @@ class StorageSizeBox extends StatelessWidget {
   final ValueChanged<int> onSizeChanged;
   final ValueChanged<DataUnit> onUnitSelected;
 
+  /// Whether the widget should automatically gain focus if nothing else is
+  /// already focused.
+  final bool autofocus;
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -44,6 +49,7 @@ class StorageSizeBox extends StatelessWidget {
             min: fromBytes(minimum, unit),
             max: fromBytes(maximum, unit),
             onChanged: (value) => onSizeChanged(toBytes(value, unit)),
+            autofocus: autofocus,
           ),
         ),
         const SizedBox(width: kButtonBarSpacing),

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -17,6 +17,7 @@ class StorageSizeBox extends StatelessWidget {
     required this.onSizeChanged,
     required this.onUnitSelected,
     this.autofocus = false,
+    this.spacing = kButtonBarSpacing,
   }) : super(key: key);
 
   /// The current value in bytes.
@@ -41,6 +42,10 @@ class StorageSizeBox extends StatelessWidget {
   /// already focused.
   final bool autofocus;
 
+  /// The spacing between the value spinbox and the unit dropdown. Defaults to
+  /// `kButtonBarSpacing`.
+  final double spacing;
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -55,7 +60,7 @@ class StorageSizeBox extends StatelessWidget {
             autofocus: autofocus,
           ),
         ),
-        const SizedBox(width: kButtonBarSpacing),
+        SizedBox(width: spacing),
         IntrinsicWidth(
           child: DropdownBuilder<DataUnit>(
             values: DataUnit.values,

--- a/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_size_box.dart';
+import 'package:ubuntu_desktop_installer/widgets/storage_size_box.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
@@ -16,7 +18,7 @@ void main() {
       StorageSizeBox(
         unit: DataUnit.megabytes,
         size: toBytes(123, DataUnit.megabytes),
-        available: toBytes(500, DataUnit.megabytes),
+        maximum: toBytes(500, DataUnit.megabytes),
         onSizeChanged: (value) => size = value,
         onUnitSelected: (_) {},
       ),
@@ -39,7 +41,7 @@ void main() {
       StorageSizeBox(
         unit: DataUnit.gigabytes,
         size: toBytes(1, DataUnit.gigabytes),
-        available: toBytes(5, DataUnit.gigabytes),
+        maximum: toBytes(5, DataUnit.gigabytes),
         onSizeChanged: (_) {},
         onUnitSelected: (value) => unit = value,
       ),
@@ -62,7 +64,7 @@ void main() {
         StorageSizeBox(
           unit: DataUnit.gigabytes,
           size: fiveGb,
-          available: fiveGb,
+          maximum: fiveGb,
           onSizeChanged: (_) {},
           onUnitSelected: (_) {},
         ),
@@ -75,7 +77,7 @@ void main() {
         StorageSizeBox(
           unit: DataUnit.megabytes,
           size: fiveGb,
-          available: fiveGb,
+          maximum: fiveGb,
           onSizeChanged: (_) {},
           onUnitSelected: (_) {},
         ),
@@ -89,7 +91,7 @@ void main() {
         StorageSizeBox(
           unit: DataUnit.kilobytes,
           size: fiveGb,
-          available: fiveGb,
+          maximum: fiveGb,
           onSizeChanged: (_) {},
           onUnitSelected: (_) {},
         ),
@@ -97,6 +99,37 @@ void main() {
       expect(find.widgetWithText(SpinBox, (5 * 1024 * 1024).toString()),
           findsOneWidget);
     });
+  });
+
+  testWidgets('range', (tester) async {
+    int? size;
+
+    await tester.pumpStorageSizeBox(
+      StorageSizeBox(
+        unit: DataUnit.bytes,
+        size: 1,
+        minimum: 1,
+        maximum: 9,
+        onSizeChanged: (value) => size = value,
+        onUnitSelected: (_) {},
+      ),
+    );
+
+    await tester.tap(find.byType(StorageSizeBox));
+
+    // up until max
+    for (var i = 2; i <= 10; ++i) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(size, equals(math.min(i, 9)));
+    }
+
+    // down until min
+    for (var i = 8; i >= 0; --i) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(size, equals(math.max(1, i)));
+    }
   });
 }
 

--- a/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
@@ -106,6 +106,7 @@ void main() {
 
     await tester.pumpStorageSizeBox(
       StorageSizeBox(
+        autofocus: true,
         unit: DataUnit.bytes,
         size: 1,
         minimum: 1,
@@ -114,8 +115,6 @@ void main() {
         onUnitSelected: (_) {},
       ),
     );
-
-    await tester.tap(find.byType(StorageSizeBox));
 
     // up until max
     for (var i = 2; i <= 10; ++i) {


### PR DESCRIPTION
The widget was previously only used in _Allocate disk space_ but it would be useful in _Install X alongside Y_ too. This PR promotes it up in the project tree and adds a few more properties to make it more general purpose.