### PR TITLE
Write changes to disk: include preserved disks with non-preserved partitions

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -15,7 +15,8 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
   List<Disk>? _disks;
   Map<String, List<Partition>>? _partitions;
 
-  /// The list of non-preserved disks.
+  /// The list of non-preserved disks, and preserved disks with any non-preserved
+  /// partitions.
   List<Disk> get disks => _disks ?? [];
 
   /// A map of non-preserved partitions per each disk (sysname).
@@ -31,7 +32,11 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
   }
 
   void _updateDisks(List<Disk> disks) {
-    _disks = disks.where((d) => d.preserve == false).toList();
+    _disks = disks
+        .where((d) =>
+            d.preserve == false ||
+            d.partitions.whereType<Partition>().any((p) => p.preserve == false))
+        .toList();
     _partitions = Map.fromEntries(
       disks.map((disk) {
         final partitions = disk.partitions

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -34,9 +34,14 @@ void main() {
         Partition(number: 4, grubDevice: false),
       ],
     ),
+    testDisk(
+      path: '/dev/sdd',
+      preserve: true,
+      partitions: [Partition(number: 1, preserve: true)],
+    ),
   ];
 
-  final nonPreservedDisks = <Disk>[testDisks.first, testDisks.last];
+  final nonPreservedDisks = <Disk>[testDisks[0], testDisks[1], testDisks[2]];
 
   test('get storage', () async {
     final client = MockSubiquityClient();


### PR DESCRIPTION
This fixes the issue that the list of disks in the partition table change summary was empty when installing alongside other OSes.

| Before | After |
|---|---|
| ![Screenshot from 2022-07-15 08-11-00](https://user-images.githubusercontent.com/140617/179166428-f787b05b-5af6-44bb-b3b1-4f3f7b515f9c.png) | ![Screenshot from 2022-07-15 08-15-31](https://user-images.githubusercontent.com/140617/179166510-b8670bcb-4ee4-4f7f-8284-d59cb6fc5235.png) |