### PR TITLE
Fix SubiquityProcess.start() to log all args

### DIFF
--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -197,9 +197,10 @@ class SubiquityProcess {
       await deferStart;
     }
 
+    final allArgs = [...args, ...?additionalArgs];
     _serverProcess = await Process.start(
       command,
-      [...args, ...?additionalArgs],
+      allArgs,
       workingDirectory: workingDirectory,
       environment: {...?environment, ...?additionalEnv},
     ).then((process) {
@@ -207,7 +208,8 @@ class SubiquityProcess {
       stderr.addStream(process.stderr);
       return process;
     });
-    log.info('Starting server (PID: ${_serverProcess!.pid}) with args: $args');
+    log.info(
+        'Starting server (PID: ${_serverProcess!.pid}) with args: $allArgs');
 
     await onProcessStart?.call();
     await writePidFile(_serverProcess!.pid);


### PR DESCRIPTION
Before:
``` 
INFO subiquity_server: Starting server (PID: 415601) with args: [-m, subiquity.cmd.server, --dry-run]
```
After:
```
INFO subiquity_server: Starting server (PID: 416620) with args: [-m, subiquity.cmd.server, --dry-run, --machine-config, examples/win10.json, --storage-version=2]
```