### PR TITLE
Use super parameters

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,3 +14,4 @@ linter:
     public_member_api_docs: false
     sort_pub_dependencies: true
     prefer_single_quotes: true
+    use_super_parameters: true

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -149,14 +149,13 @@ Future<void> runInstallerApp(
 
 class UbuntuDesktopInstallerApp extends StatelessWidget {
   UbuntuDesktopInstallerApp({
-    Key? key,
+    super.key,
     this.initialRoute,
     FlavorData? flavor,
     List<Slide>? slides,
     this.appStatus = AppStatus.ready,
   })  : flavor = flavor ?? defaultFlavor,
-        slides = slides ?? defaultSlides,
-        super(key: key);
+        slides = slides ?? defaultSlides;
 
   final String? initialRoute;
   final FlavorData flavor;
@@ -213,7 +212,7 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
 }
 
 class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
-  const _UbuntuDesktopInstallerLoadingPage({Key? key}) : super(key: key);
+  const _UbuntuDesktopInstallerLoadingPage();
 
   @override
   Widget build(BuildContext context) {
@@ -245,10 +244,7 @@ class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
 }
 
 class _UbuntuDesktopInstallerWizard extends StatelessWidget {
-  const _UbuntuDesktopInstallerWizard({
-    Key? key,
-    this.initialRoute,
-  }) : super(key: key);
+  const _UbuntuDesktopInstallerWizard({this.initialRoute});
 
   final String? initialRoute;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -240,11 +240,10 @@ Future<void> showEditPartitionDialog(
 
 class _PartitionMountField extends StatelessWidget {
   const _PartitionMountField({
-    Key? key,
     this.initialMount,
     required this.partitionFormat,
     required this.partitionMount,
-  }) : super(key: key);
+  });
 
   final String? initialMount;
   final ValueNotifier<PartitionFormat?> partitionFormat;
@@ -280,10 +279,9 @@ class _PartitionMountField extends StatelessWidget {
 
 class _PartitionWipeCheckbox extends StatelessWidget {
   const _PartitionWipeCheckbox({
-    Key? key,
     required this.canWipe,
     required this.wipe,
-  }) : super(key: key);
+  });
 
   final bool canWipe;
   final ValueNotifier<bool?> wipe;
@@ -306,9 +304,8 @@ class _PartitionWipeCheckbox extends StatelessWidget {
 
 class _PartitionFormatSelector extends StatelessWidget {
   const _PartitionFormatSelector({
-    Key? key,
     required this.partitionFormat,
-  }) : super(key: key);
+  });
 
   final ValueNotifier<PartitionFormat?> partitionFormat;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -14,8 +14,8 @@ import 'storage_selector.dart';
 
 class AllocateDiskSpacePage extends StatefulWidget {
   const AllocateDiskSpacePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     final service = getService<DiskStorageService>();

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -13,7 +13,7 @@ import 'storage_columns.dart';
 import 'storage_table.dart';
 
 class PartitionBar extends StatelessWidget {
-  const PartitionBar({Key? key}) : super(key: key);
+  const PartitionBar({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -75,7 +75,7 @@ class _PartitionPainter extends CustomPainter {
 }
 
 class PartitionLegend extends StatelessWidget {
-  const PartitionLegend({Key? key}) : super(key: key);
+  const PartitionLegend({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -116,12 +116,11 @@ class PartitionLegend extends StatelessWidget {
 
 class _PartitionLabel extends StatelessWidget {
   const _PartitionLabel({
-    Key? key,
     required this.title,
     required this.size,
     this.color = Colors.transparent,
     this.borderColor = Colors.transparent,
-  }) : super(key: key);
+  });
 
   final String title;
   final int size;
@@ -160,7 +159,7 @@ class _PartitionLabel extends StatelessWidget {
 }
 
 class PartitionTable extends StatelessWidget {
-  const PartitionTable({Key? key, required this.controller}) : super(key: key);
+  const PartitionTable({super.key, required this.controller});
 
   final AutoScrollController controller;
 
@@ -190,7 +189,7 @@ class PartitionTable extends StatelessWidget {
 }
 
 class PartitionButtonRow extends StatelessWidget {
-  const PartitionButtonRow({Key? key}) : super(key: key);
+  const PartitionButtonRow({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
@@ -5,12 +5,12 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 class StorageSelector extends StatelessWidget {
   const StorageSelector({
-    Key? key,
+    super.key,
     this.title,
     this.selected,
     required this.storages,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   final String? title;
   final int? selected;

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -11,14 +11,14 @@ typedef OnStorageSelected = void Function(int disk, [int object]);
 
 class StorageTable extends StatelessWidget {
   const StorageTable({
-    Key? key,
+    super.key,
     required this.storages,
     required this.columns,
     this.controller,
     this.canSelect,
     this.isSelected,
     this.onSelected,
-  }) : super(key: key);
+  });
 
   final List<Disk> storages;
   final List<StorageColumn> columns;

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -21,8 +21,8 @@ class ChooseSecurityKeyPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const ChooseSecurityKeyPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [ChooseSecurityKeyModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_widgets.dart
@@ -1,10 +1,7 @@
 part of 'choose_security_key_page.dart';
 
 class _SecurityKeyFormField extends StatelessWidget {
-  const _SecurityKeyFormField({
-    Key? key,
-    this.fieldWidth,
-  }) : super(key: key);
+  const _SecurityKeyFormField({this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -33,10 +30,7 @@ class _SecurityKeyFormField extends StatelessWidget {
 }
 
 class _ConfirmSecurityKeyFormField extends StatelessWidget {
-  const _ConfirmSecurityKeyFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _ConfirmSecurityKeyFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -6,7 +6,7 @@ import '../../l10n.dart';
 import '../../settings.dart';
 
 class ChooseYourLookPage extends StatelessWidget {
-  const ChooseYourLookPage({Key? key}) : super(key: key);
+  const ChooseYourLookPage({super.key});
 
   static Widget create(BuildContext context) => const ChooseYourLookPage();
 
@@ -56,13 +56,12 @@ class ChooseYourLookPage extends StatelessWidget {
 
 class _ThemeOptionCard extends StatelessWidget {
   const _ThemeOptionCard({
-    Key? key,
     required this.width,
     required this.assetName,
     required this.selected,
     required this.onTap,
     required this.preferenceName,
-  }) : super(key: key);
+  });
 
   final double width;
   final String assetName;

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
@@ -10,7 +10,7 @@ import 'configure_secure_boot_widgets.dart';
 
 class ConfigureSecureBootPage extends StatefulWidget {
   @visibleForTesting
-  const ConfigureSecureBootPage({Key? key}) : super(key: key);
+  const ConfigureSecureBootPage({super.key});
 
   @override
   State<ConfigureSecureBootPage> createState() =>

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_widgets.dart
@@ -8,9 +8,9 @@ import 'configure_secure_boot_model.dart';
 
 class SecurityKeyFormField extends StatelessWidget {
   const SecurityKeyFormField({
-    Key? key,
+    super.key,
     required this.fieldWidth,
-  }) : super(key: key);
+  });
 
   final double? fieldWidth;
 
@@ -38,9 +38,9 @@ class SecurityKeyFormField extends StatelessWidget {
 
 class SecurityKeyConfirmFormField extends StatelessWidget {
   const SecurityKeyConfirmFormField({
-    Key? key,
+    super.key,
     required this.fieldWidth,
-  }) : super(key: key);
+  });
 
   final double? fieldWidth;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -17,7 +17,7 @@ import 'wifi_view.dart';
 /// https://github.com/canonical/ubuntu-desktop-installer/issues/30
 class ConnectToInternetPage extends StatefulWidget {
   @visibleForTesting
-  const ConnectToInternetPage({Key? key}) : super(key: key);
+  const ConnectToInternetPage({super.key});
 
   static Widget create(BuildContext context) {
     final udev = getService<UdevService>();

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_model.dart
@@ -6,8 +6,7 @@ import 'network_model.dart';
 
 /// "Use wired connection"
 class EthernetModel extends NetworkModel<EthernetDevice> {
-  EthernetModel(NetworkService service, [UdevService? udev])
-      : super(service, udev);
+  EthernetModel(super.service, [super.udev]);
 
   @override
   bool get canConnect => false;
@@ -65,6 +64,5 @@ class EthernetModel extends NetworkModel<EthernetDevice> {
 }
 
 class EthernetDevice extends NetworkDevice {
-  EthernetDevice(NetworkManagerDevice device, UdevService? udev)
-      : super(device, udev);
+  EthernetDevice(super.device, super.udev);
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
@@ -10,10 +10,10 @@ import 'network_tile.dart';
 
 class EthernetRadioButton extends StatelessWidget {
   const EthernetRadioButton({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   final ConnectMode? value;
   final ValueChanged<ConnectMode?> onChanged;
@@ -43,10 +43,10 @@ class EthernetRadioButton extends StatelessWidget {
 
 class EthernetView extends StatelessWidget {
   const EthernetView({
-    Key? key,
+    super.key,
     required this.expanded,
     required this.onEnabled,
-  }) : super(key: key);
+  });
 
   final bool expanded;
   final VoidCallback onEnabled;

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/hidden_wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/hidden_wifi_model.dart
@@ -6,8 +6,7 @@ import 'network_model.dart';
 import 'wifi_model.dart';
 
 class HiddenWifiModel extends NetworkModel<WifiDevice> {
-  HiddenWifiModel(NetworkService service, [UdevService? udev])
-      : super(service, udev);
+  HiddenWifiModel(super.service, [super.udev]);
 
   @override
   bool get canConnect => _ssid.isNotEmpty && !isConnected;

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/hidden_wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/hidden_wifi_view.dart
@@ -12,10 +12,10 @@ import 'wifi_model.dart';
 
 class HiddenWifiRadioButton extends StatelessWidget {
   const HiddenWifiRadioButton({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   final ConnectMode? value;
   final ValueChanged<ConnectMode?> onChanged;
@@ -40,9 +40,9 @@ class HiddenWifiRadioButton extends StatelessWidget {
 
 class HiddenWifiView extends StatefulWidget {
   const HiddenWifiView({
-    Key? key,
+    super.key,
     required this.expanded,
-  }) : super(key: key);
+  });
 
   final bool expanded;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
@@ -3,8 +3,7 @@ import 'package:ubuntu_wizard/constants.dart';
 
 class NetworkTile extends StatelessWidget {
   const NetworkTile(
-      {Key? key, this.leading, this.title, this.subtitle, this.trailing})
-      : super(key: key);
+      {super.key, this.leading, this.title, this.subtitle, this.trailing});
 
   final Widget? leading;
   final Widget? title;

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_model.dart
@@ -18,7 +18,7 @@ const kWifiScanTimeout = Duration(seconds: 3);
 
 /// "Connect to Wi-Fi network"
 class WifiModel extends NetworkModel<WifiDevice> {
-  WifiModel(NetworkService service, [UdevService? udev]) : super(service, udev);
+  WifiModel(super.service, [super.udev]);
 
   @override
   bool get canConnect => selectedDevice?._isConnected == false;

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
@@ -17,10 +17,10 @@ typedef OnWifiSelected = void Function(
 
 class WifiRadioButton extends StatelessWidget {
   const WifiRadioButton({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   final ConnectMode? value;
   final ValueChanged<ConnectMode?>? onChanged;
@@ -51,11 +51,11 @@ class WifiRadioButton extends StatelessWidget {
 
 class WifiView extends StatefulWidget {
   const WifiView({
-    Key? key,
+    super.key,
     required this.expanded,
     required this.onEnabled,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   final bool expanded;
   final VoidCallback onEnabled;
@@ -112,9 +112,9 @@ class _WifiViewState extends State<WifiView> {
 
 class WifiListView extends StatelessWidget {
   const WifiListView({
-    Key? key,
+    super.key,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   final OnWifiSelected onSelected;
 
@@ -143,10 +143,10 @@ class WifiListView extends StatelessWidget {
 
 class WifiListTile extends StatelessWidget {
   const WifiListTile({
-    Key? key,
+    super.key,
     required this.selected,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   final bool selected;
   final OnWifiSelected onSelected;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -12,7 +12,7 @@ import 'installation_complete_model.dart';
 const _kAvatarBorder = Color(0xFFe5e5e5);
 
 class InstallationCompletePage extends StatelessWidget {
-  const InstallationCompletePage({Key? key}) : super(key: key);
+  const InstallationCompletePage({super.key});
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -15,8 +15,8 @@ class InstallationSlidesPage extends StatefulWidget {
   /// Use [InstallationPage.create] instead.
   @visibleForTesting
   const InstallationSlidesPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates a [InstallationSlidesPage] with [InstallationSlidesModel].
   static Widget create(BuildContext context) {
@@ -130,10 +130,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
 }
 
 class _SlidePage extends StatelessWidget {
-  const _SlidePage({
-    Key? key,
-    required this.slide,
-  }) : super(key: key);
+  const _SlidePage({required this.slide});
 
   final Slide slide;
 
@@ -153,10 +150,7 @@ class _SlidePage extends StatelessWidget {
 }
 
 class _JournalView extends StatelessWidget {
-  const _JournalView({
-    Key? key,
-    required this.journal,
-  }) : super(key: key);
+  const _JournalView({required this.journal});
 
   final Stream<String> journal;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -18,7 +18,7 @@ export 'installation_type_model.dart' show InstallationType;
 class InstallationTypePage extends StatefulWidget {
   /// Use [InstallationTypePage.create] instead.
   @visibleForTesting
-  const InstallationTypePage({Key? key}) : super(key: key);
+  const InstallationTypePage({super.key});
 
   /// Creates a [InstallationTypePage] with [InstallationTypeModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -14,8 +14,8 @@ const _kScrollDuration = Duration(milliseconds: 1);
 
 class KeyboardLayoutPage extends StatefulWidget {
   const KeyboardLayoutPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
@@ -7,7 +7,7 @@ import '../../l10n.dart';
 /// Asks the user to press one of keys.
 class PressKeyView extends StatelessWidget {
   /// Creates a view.
-  const PressKeyView(this._pressKey, {Key? key}) : super(key: key);
+  const PressKeyView(this._pressKey, {super.key});
 
   final List<String> _pressKey;
 
@@ -36,7 +36,7 @@ class PressKeyView extends StatelessWidget {
 /// Asks the user to confirm whether a key is present.
 class KeyPresentView extends StatelessWidget {
   /// Creates a view.
-  const KeyPresentView(this._keyPresent, {Key? key}) : super(key: key);
+  const KeyPresentView(this._keyPresent, {super.key});
 
   final String _keyPresent;
 
@@ -65,14 +65,13 @@ class KeyPresentView extends StatelessWidget {
 class DetectKeyboardLayoutView extends StatefulWidget {
   /// Creates a keyboard layout detection view.
   const DetectKeyboardLayoutView({
-    Key? key,
+    super.key,
     String? keyPresent,
     List<String>? pressKey,
     ValueChanged<int>? onKeyPress,
   })  : _keyPresent = keyPresent,
         _pressKey = pressKey,
-        _onKeyPress = onKeyPress,
-        super(key: key);
+        _onKeyPress = onKeyPress;
 
   final String? _keyPresent;
   final List<String>? _pressKey;

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -14,7 +14,7 @@ import 'select_guided_storage_model.dart';
 class SelectGuidedStoragePage extends StatefulWidget {
   /// Use [SelectGuidedStoragePage.create] instead.
   @visibleForTesting
-  const SelectGuidedStoragePage({Key? key}) : super(key: key);
+  const SelectGuidedStoragePage({super.key});
 
   /// Creates a [SelectGuidedStoragePage] with [SelectGuidedStorageModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -12,8 +12,8 @@ export 'try_or_install_model.dart' show Option;
 
 class TryOrInstallPage extends StatefulWidget {
   const TryOrInstallPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -12,7 +12,7 @@ import 'turn_off_bitlocker_model.dart';
 
 class TurnOffBitLockerPage extends StatelessWidget {
   @visibleForTesting
-  const TurnOffBitLockerPage({Key? key}) : super(key: key);
+  const TurnOffBitLockerPage({super.key});
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -12,8 +12,8 @@ import 'turn_off_rst_model.dart';
 
 class TurnOffRSTPage extends StatelessWidget {
   const TurnOffRSTPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -13,7 +13,7 @@ import 'updates_other_software_model.dart';
 
 class UpdatesOtherSoftwarePage extends StatefulWidget {
   @visibleForTesting
-  const UpdatesOtherSoftwarePage({Key? key}) : super(key: key);
+  const UpdatesOtherSoftwarePage({super.key});
 
   @override
   State<UpdatesOtherSoftwarePage> createState() =>

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -13,8 +13,8 @@ import 'welcome_model.dart';
 
 class WelcomePage extends StatefulWidget {
   const WelcomePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -12,7 +12,7 @@ import 'where_are_you_model.dart';
 class WhereAreYouPage extends StatefulWidget {
   /// Use [WhereAreYouPage.create] instead.
   @visibleForTesting
-  const WhereAreYouPage({Key? key}) : super(key: key);
+  const WhereAreYouPage({super.key});
 
   /// Creates a [WhereAreYouPage] with [WhereAreYouModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -20,7 +20,7 @@ part 'who_are_you_widgets.dart';
 /// It uses [WizardPage] and [WizardAction] to create an installer page.
 class WhoAreYouPage extends StatefulWidget {
   /// Creates a the installer page for setting up the user data.
-  const WhoAreYouPage({Key? key}) : super(key: key);
+  const WhoAreYouPage({super.key});
 
   /// Creates an instance with [WhoAreYouModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_widgets.dart
@@ -1,10 +1,7 @@
 part of 'who_are_you_page.dart';
 
 class _RealNameFormField extends StatelessWidget {
-  const _RealNameFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _RealNameFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -32,10 +29,7 @@ class _RealNameFormField extends StatelessWidget {
 }
 
 class _HostnameFormField extends StatelessWidget {
-  const _HostnameFormField({
-    Key? key,
-    this.fieldWidth,
-  }) : super(key: key);
+  const _HostnameFormField({this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -88,10 +82,7 @@ extension UsernameValidationL10n on UsernameValidation {
 }
 
 class _UsernameFormField extends StatelessWidget {
-  const _UsernameFormField({
-    Key? key,
-    this.fieldWidth,
-  }) : super(key: key);
+  const _UsernameFormField({this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -132,10 +123,7 @@ class _UsernameFormField extends StatelessWidget {
 }
 
 class _PasswordFormField extends StatelessWidget {
-  const _PasswordFormField({
-    Key? key,
-    this.fieldWidth,
-  }) : super(key: key);
+  const _PasswordFormField({this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -167,10 +155,7 @@ class _PasswordFormField extends StatelessWidget {
 }
 
 class _ConfirmPasswordFormField extends StatelessWidget {
-  const _ConfirmPasswordFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _ConfirmPasswordFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -204,7 +189,7 @@ class _ConfirmPasswordFormField extends StatelessWidget {
 }
 
 class _ShowPasswordCheckButton extends StatelessWidget {
-  const _ShowPasswordCheckButton({Key? key}) : super(key: key);
+  const _ShowPasswordCheckButton();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -14,8 +14,8 @@ final log = Logger('write_changes_to_disk');
 
 class WriteChangesToDiskPage extends StatefulWidget {
   const WriteChangesToDiskPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_desktop_installer/lib/slides/default_slides.dart
+++ b/packages/ubuntu_desktop_installer/lib/slides/default_slides.dart
@@ -325,8 +325,7 @@ final _supportSlide = Slide(
 );
 
 class _SlideColumn extends StatelessWidget {
-  const _SlideColumn({Key? key, required this.children, required this.spacing})
-      : super(key: key);
+  const _SlideColumn({required this.children, required this.spacing});
 
   final List<Widget> children;
   final double? spacing;
@@ -355,32 +354,26 @@ class _SlideLabel extends StatelessWidget {
   // A text-only label.
   const _SlideLabel(
     this.text, {
-    Key? key,
     double? width,
   })  : icon = null,
         _fontSize = FontSize.medium,
-        _width = width,
-        super(key: key);
+        _width = width;
 
   // A rich text label with a large font suitable for headers.
   const _SlideLabel.large(
     this.text, {
-    Key? key,
     double? width,
   })  : icon = null,
         _fontSize = FontSize.xLarge,
-        _width = width,
-        super(key: key);
+        _width = width;
 
   // A plain text label prefixed with an icon.
   const _SlideLabel.icon({
-    Key? key,
     required this.text,
     this.icon,
     double? width,
   })  : _fontSize = FontSize.medium,
-        _width = width,
-        super(key: key);
+        _width = width;
 
   final String? icon;
   final String text;
@@ -431,10 +424,10 @@ class _SlideLabel extends StatelessWidget {
 // A rounded card with a 50% translucent background for labels and lists.
 class SlideCard extends StatelessWidget {
   const SlideCard({
-    Key? key,
+    super.key,
     this.width,
     required this.child,
-  }) : super(key: key);
+  });
 
   final double? width;
   final Widget child;
@@ -458,14 +451,14 @@ class SlideCard extends StatelessWidget {
 // be specified.
 class SlideLayout extends StatelessWidget {
   const SlideLayout({
-    Key? key,
+    super.key,
     this.background,
     this.content,
     this.contentAlignment = Alignment.topLeft,
     this.image,
     this.imageAlignment = Alignment.bottomRight,
     this.padding = _kInsets,
-  }) : super(key: key);
+  });
 
   final Widget? background;
   final Widget? content;

--- a/packages/ubuntu_desktop_installer/lib/slides/slide_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/slides/slide_widgets.dart
@@ -17,10 +17,10 @@ class Slide {
 class SlidesContext extends InheritedWidget {
   /// Creates an inherited slide widget with the specified slides.
   const SlidesContext({
-    Key? key,
+    super.key,
     required this.slides,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The installation slides.
   final List<Slide> slides;

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -9,7 +9,7 @@ import '../l10n.dart';
 /// Storage size entry with a spinbox and a data size unit dropdown.
 class StorageSizeBox extends StatelessWidget {
   const StorageSizeBox({
-    Key? key,
+    super.key,
     required this.size,
     required this.unit,
     this.minimum = 0,
@@ -18,7 +18,7 @@ class StorageSizeBox extends StatelessWidget {
     required this.onUnitSelected,
     this.autofocus = false,
     this.spacing = kButtonBarSpacing,
-  }) : super(key: key);
+  });
 
   /// The current value in bytes.
   final int size;

--- a/packages/ubuntu_wizard/lib/src/widgets/animated_expanded.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/animated_expanded.dart
@@ -7,12 +7,12 @@ const _kDefaultDuration = Duration(milliseconds: 200);
 class AnimatedExpanded extends StatefulWidget {
   /// Control whether the given [child] is [expanded].
   const AnimatedExpanded({
-    Key? key,
+    super.key,
     required this.child,
     required this.expanded,
     this.curve = _kDefaultCurve,
     this.duration = _kDefaultDuration,
-  }) : super(key: key);
+  });
 
   /// The child that expands or collapses.
   final Widget child;

--- a/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/flavor.dart
@@ -64,10 +64,10 @@ class FlavorData {
 class Flavor extends InheritedWidget {
   /// Creates an inherited flavor widget with the specified flavor data.
   const Flavor({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The flavor configuration.
   final FlavorData data;

--- a/packages/ubuntu_wizard/lib/src/widgets/icons.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/icons.dart
@@ -7,7 +7,7 @@ import 'package:yaru/yaru.dart';
 ///  * [ValidatedFormField]
 class SuccessIcon extends StatelessWidget {
   /// Creates the icon.
-  const SuccessIcon({Key? key}) : super(key: key);
+  const SuccessIcon({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class SuccessIcon extends StatelessWidget {
 /// See also:
 ///  * [ValidatedFormField]
 class ErrorIcon extends StatelessWidget {
-  const ErrorIcon({Key? key}) : super(key: key);
+  const ErrorIcon({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
@@ -26,13 +26,13 @@ import 'package:flutter/material.dart';
 class OptionCard extends StatefulWidget {
   /// Creates an option card with the given properties.
   const OptionCard({
-    Key? key,
+    super.key,
     this.image,
     this.title,
     this.body,
     required this.selected,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   /// An image asset that illustrates the option.
   final Widget? image;

--- a/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
@@ -8,9 +8,9 @@ import '../../utils.dart';
 class PasswordStrengthLabel extends StatelessWidget {
   /// Creates a new label with the given [strength].
   const PasswordStrengthLabel({
-    Key? key,
+    super.key,
     required this.strength,
-  }) : super(key: key);
+  });
 
   /// The strength of the password.
   final PasswordStrength strength;

--- a/packages/ubuntu_wizard/lib/src/widgets/radio_icon_tile.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/radio_icon_tile.dart
@@ -9,13 +9,13 @@ const _kHorizontalSpacing = 8.0;
 class RadioIconTile extends StatelessWidget {
   /// Creates a radio icon tile.
   const RadioIconTile({
-    Key? key,
+    super.key,
     this.icon,
     this.title,
     this.subtitle,
     this.contentPadding,
     this.enabled = true,
-  }) : super(key: key);
+  });
 
   /// An icon shown centered within the bounding box of [RadioButton]'s radio
   /// indicator.

--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -66,7 +66,7 @@ class ValidatedFormField extends StatefulWidget {
   ///
   /// The `validator' helps to decide when to show the check mark.
   ValidatedFormField({
-    Key? key,
+    super.key,
     this.controller,
     this.initialValue,
     this.onChanged,
@@ -83,8 +83,7 @@ class ValidatedFormField extends StatefulWidget {
     this.enabled = true,
     this.suffixIcon,
   })  : validator = validator ?? _NoValidator(),
-        spacing = spacing ?? (successWidget != null ? _kIconSpacing : null),
-        super(key: key);
+        spacing = spacing ?? (successWidget != null ? _kIconSpacing : null);
 
   @override
   State<ValidatedFormField> createState() => _ValidatedFormFieldState();

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -13,7 +13,7 @@ export 'wizard_action.dart';
 class WizardPage extends StatefulWidget {
   /// Creates the wizard page.
   const WizardPage({
-    Key? key,
+    super.key,
     this.title,
     this.header,
     this.headerPadding = kHeaderPadding,
@@ -22,7 +22,7 @@ class WizardPage extends StatefulWidget {
     this.footer,
     this.footerPadding = kFooterPadding,
     this.actions = const <WizardAction>[],
-  }) : super(key: key);
+  });
 
   /// The title widget in the app bar.
   final Widget? title;

--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -10,10 +10,10 @@ import 'routes.dart';
 
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({
-    Key? key,
+    super.key,
     this.variant,
     this.initialRoute,
-  }) : super(key: key);
+  });
 
   final Variant? variant;
   final String? initialRoute;

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -19,8 +19,8 @@ class AdvancedSetupPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const AdvancedSetupPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [AdvancedSetupModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
@@ -1,8 +1,7 @@
 part of 'advanced_setup_page.dart';
 
 class _MountLocationFormField extends StatelessWidget {
-  const _MountLocationFormField({Key? key, required this.fieldWidth})
-      : super(key: key);
+  const _MountLocationFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -30,8 +29,7 @@ class _MountLocationFormField extends StatelessWidget {
 }
 
 class _MountOptionFormField extends StatelessWidget {
-  const _MountOptionFormField({Key? key, required this.fieldWidth})
-      : super(key: key);
+  const _MountOptionFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -55,7 +53,7 @@ class _MountOptionFormField extends StatelessWidget {
 }
 
 class _HostGenerationCheckButton extends StatelessWidget {
-  const _HostGenerationCheckButton({Key? key}) : super(key: key);
+  const _HostGenerationCheckButton();
 
   @override
   Widget build(BuildContext context) {
@@ -83,9 +81,7 @@ class _HostGenerationCheckButton extends StatelessWidget {
 }
 
 class _ResolvConfGenerationCheckButton extends StatelessWidget {
-  const _ResolvConfGenerationCheckButton({
-    Key? key,
-  }) : super(key: key);
+  const _ResolvConfGenerationCheckButton();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -17,8 +17,8 @@ class ApplyingChangesPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const ApplyingChangesPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [AdvancedSetupModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -14,8 +14,8 @@ class ConfigurationUIPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const ConfigurationUIPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [ConfigurationUIModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
@@ -35,7 +35,7 @@ import 'slides.dart';
 /// when WSL is still registering the distro).
 /// Control comes from the SlideShow widget from ubuntu_widgets package.
 class InstallationSlidesPage extends StatefulWidget {
-  const InstallationSlidesPage({Key? key}) : super(key: key);
+  const InstallationSlidesPage({super.key});
 
   @override
   State<InstallationSlidesPage> createState() => _InstallationSlidesPageState();
@@ -77,7 +77,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
 class _SlidesPage extends StatelessWidget {
   final List<Widget> slides;
 
-  const _SlidesPage(this.slides, {Key? key}) : super(key: key);
+  const _SlidesPage(this.slides);
 
   @override
   Widget build(BuildContext context) {
@@ -184,10 +184,7 @@ class _SlidesPage extends StatelessWidget {
 }
 
 class _JournalView extends StatelessWidget {
-  const _JournalView({
-    Key? key,
-    required this.journal,
-  }) : super(key: key);
+  const _JournalView({required this.journal});
   final Stream<String> journal;
   @override
   Widget build(BuildContext context) {
@@ -212,7 +209,7 @@ class _JournalView extends StatelessWidget {
 // TODO: Invest a new PR on more capable error handling and discrimination.
 // TODO: Work with design team on the real error screens design.
 class _ErrorScreen extends StatelessWidget {
-  const _ErrorScreen({Key? key}) : super(key: key);
+  const _ErrorScreen();
 
   @override
   Widget build(BuildContext context) {
@@ -244,7 +241,7 @@ class _ErrorScreen extends StatelessWidget {
 
 // TODO: Promote this widget to avoid code duplication.
 class _CodeLabel extends StatelessWidget {
-  const _CodeLabel(this.code, {Key? key}) : super(key: key);
+  const _CodeLabel(this.code);
 
   final String code;
 

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
@@ -28,22 +28,22 @@ class Slide extends StatelessWidget {
   static const kInSlideLeftSpacing = 1 * kContentSpacing;
   static const kInSlideSpacing = 6 * kContentSpacing;
   const Slide({
-    Key? key,
+    super.key,
     required this.image,
     required this.title,
     required this.subtitle,
     this.text,
     this.span,
-  }) : super(key: key);
+  });
 
   const Slide.withRichText({
-    Key? key,
+    super.key,
     required this.image,
     required this.title,
     required this.subtitle,
     required this.span,
     this.text,
-  }) : super(key: key);
+  });
 
   final Widget image;
   final String title;

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -20,7 +20,7 @@ part 'profile_setup_widgets.dart';
 class ProfileSetupPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
-  const ProfileSetupPage({Key? key}) : super(key: key);
+  const ProfileSetupPage({super.key});
 
   /// Creates an instance with [ProfileSetupModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
@@ -1,10 +1,7 @@
 part of 'profile_setup_page.dart';
 
 class _RealNameFormField extends StatelessWidget {
-  const _RealNameFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _RealNameFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -50,10 +47,7 @@ extension UsernameValidationL10n on UsernameValidation {
 }
 
 class _UsernameFormField extends StatelessWidget {
-  const _UsernameFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _UsernameFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -91,10 +85,7 @@ class _UsernameFormField extends StatelessWidget {
 }
 
 class _PasswordFormField extends StatelessWidget {
-  const _PasswordFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _PasswordFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -125,10 +116,7 @@ class _PasswordFormField extends StatelessWidget {
 }
 
 class _ConfirmPasswordFormField extends StatelessWidget {
-  const _ConfirmPasswordFormField({
-    Key? key,
-    required this.fieldWidth,
-  }) : super(key: key);
+  const _ConfirmPasswordFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -163,9 +151,7 @@ class _ConfirmPasswordFormField extends StatelessWidget {
 //       See [ProfileSetupModel.showAdvancedOptions] for more details.
 //
 // class _ShowAdvancedOptionsCheckButton extends StatelessWidget {
-//   const _ShowAdvancedOptionsCheckButton({
-//     Key? key,
-//   }) : super(key: key);
+//   const _ShowAdvancedOptionsCheckButton();
 
 //   @override
 //   Widget build(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -12,8 +12,8 @@ import 'select_language_model.dart';
 
 class SelectLanguagePage extends StatefulWidget {
   const SelectLanguagePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_page.dart
@@ -18,8 +18,8 @@ class SetupCompletePage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const SetupCompletePage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [SetupCompleteModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/setup_complete/setup_complete_widgets.dart
@@ -1,7 +1,7 @@
 part of 'setup_complete_page.dart';
 
 class _CodeLabel extends StatelessWidget {
-  const _CodeLabel(this.code, {Key? key}) : super(key: key);
+  const _CodeLabel(this.code);
 
   final String code;
 

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -6,9 +6,9 @@ import 'routes.dart';
 
 class UbuntuWslSetupWizard extends StatelessWidget {
   const UbuntuWslSetupWizard({
-    Key? key,
+    super.key,
     this.initialRoute,
-  }) : super(key: key);
+  });
 
   final String? initialRoute;
 


### PR DESCRIPTION
The language feature has been available since Dart 2.17 (https://github.com/dart-lang/language/issues/1855) in Flutter 3.0. The changes were automatically applied with `dart fix` besides unused elements that had to be removed by hand from private widgets.

This fixes the issue that mockito is currently a bit confused about: some recently added classes already use super parameters.
```
[SEVERE] mockito:mockBuilder on lib/pages/install_alongside/storage_size_dialog.dart:

This builder requires Dart inputs without syntax errors.
However, package:ubuntu_desktop_installer/pages/install_alongside/storage_size_dialog.dart (or an existing part) contains the following errors.
storage_size_dialog.dart:43:5: This requires the 'super-parameters' language feature to be enabled.

Try fixing the errors and re-running the build.
```