### PR TITLE
Fix SelectGuidedStorageModel.getDisk(index)

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -34,7 +34,7 @@ class SelectGuidedStorageModel extends SafeChangeNotifier {
       _storages.elementAtOrNull(index);
 
   /// Returns the disk of the guided storage target at the given index.
-  Disk? getDisk(int index) => _disks[selectedStorage?.diskId ?? ''];
+  Disk? getDisk(int index) => _disks[getStorage(index)?.diskId ?? ''];
 
   /// Selects a guided storage.
   void selectStorage(int index) {


### PR DESCRIPTION
This PR fixes a typo that slipped in in #978. Instead of using the specified index, it would always use the currently selected one, which resulted in the currently selected drive being repeated in the dropdown:

| Before | After |
|---|---|
| ![Screenshot from 2022-07-19 13-46-30](https://user-images.githubusercontent.com/140617/179743085-a5e0f683-18a3-4dc8-807d-1875cb5f2fb9.png) | ![Screenshot from 2022-07-19 13-46-15](https://user-images.githubusercontent.com/140617/179743094-14667b86-7431-4a2a-bce7-191409c478f2.png) |