### PR TITLE
Write changes to disk: summarize all partition changes

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
@@ -347,10 +347,20 @@
       "path": {}
     }
   },
-  "writeChangesPartitionsHeader": "The following partitions are going to be formatted:",
-  "writeChangesPartitionEntryMounted": "partition #{disk}{partition} as {format} used for {mount}",
-  "@writeChangesPartitionEntryMounted": {
-    "description": "A mounted partition entry",
+  "writeChangesPartitionsHeader": "The following partition changes are going to be applied:",
+  "writeChangesPartitionResized": "partition #{disk}{partition} resized from {oldsize} to {newsize}",
+  "@writeChangesPartitionResized": {
+    "description": "A resized partition entry",
+    "placeholders": {
+      "disk": {},
+      "partition": {},
+      "oldsize": {},
+      "newsize": {}
+    }
+  },
+  "writeChangesPartitionFormattedMounted": "partition #{disk}{partition} formatted as {format} used for {mount}",
+  "@writeChangesPartitionFormattedMounted": {
+    "description": "A formatted and mounted partition entry",
     "placeholders": {
       "disk": {},
       "partition": {},
@@ -358,13 +368,30 @@
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "partition #{disk}{partition} as {format}",
-  "@writeChangesPartitionEntryUnmounted": {
-    "description": "An unmounted partition entry",
+  "writeChangesPartitionFormatted": "partition #{disk}{partition} formatted as {format}",
+  "@writeChangesPartitionFormatted": {
+    "description": "A formatted partition entry",
     "placeholders": {
       "disk": {},
       "partition": {},
       "format": {}
+    }
+  },
+  "writeChangesPartitionMounted": "partition #{disk}{partition} used for {mount}",
+  "@writeChangesPartitionMounted": {
+    "description": "A mounted partition entry",
+    "placeholders": {
+      "disk": {},
+      "partition": {},
+      "mount": {}
+    }
+  },
+  "writeChangesPartitionCreated": "partition #{disk}{partition} created",
+  "@writeChangesPartitionCreated": {
+    "description": "A created partition entry",
+    "placeholders": {
+      "disk": {},
+      "partition": {}
     }
   },
   "chooseYourLookPageTitle": "Choose your look",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1326,20 +1326,38 @@ abstract class AppLocalizations {
   /// No description provided for @writeChangesPartitionsHeader.
   ///
   /// In en, this message translates to:
-  /// **'The following partitions are going to be formatted:'**
+  /// **'The following partition changes are going to be applied:'**
   String get writeChangesPartitionsHeader;
+
+  /// A resized partition entry
+  ///
+  /// In en, this message translates to:
+  /// **'partition #{disk}{partition} resized from {oldsize} to {newsize}'**
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize);
+
+  /// A formatted and mounted partition entry
+  ///
+  /// In en, this message translates to:
+  /// **'partition #{disk}{partition} formatted as {format} used for {mount}'**
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount);
+
+  /// A formatted partition entry
+  ///
+  /// In en, this message translates to:
+  /// **'partition #{disk}{partition} formatted as {format}'**
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format);
 
   /// A mounted partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition #{disk}{partition} as {format} used for {mount}'**
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount);
+  /// **'partition #{disk}{partition} used for {mount}'**
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount);
 
-  /// An unmounted partition entry
+  /// A created partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition #{disk}{partition} as {format}'**
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format);
+  /// **'partition #{disk}{partition} created'**
+  String writeChangesPartitionCreated(Object disk, Object partition);
 
   /// No description provided for @chooseYourLookPageTitle.
   ///

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -603,16 +603,31 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -603,16 +603,31 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -603,16 +603,31 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -603,16 +603,31 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -603,16 +603,31 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -603,16 +603,31 @@ class AppLocalizationsBo extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -603,16 +603,31 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -603,16 +603,31 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -606,13 +606,28 @@ class AppLocalizationsCs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Následující oddíly budou zformátovány:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'oddíl č. $disk${partition} jako $format, použitý pro $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'oddíl č. $disk${partition} jako $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -603,16 +603,31 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -603,16 +603,31 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -606,13 +606,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Die folgenden Partitionen werden formatiert:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'Partition #$disk${partition} als $format benutzt für $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'Partition #$disk${partition} als $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -603,16 +603,31 @@ class AppLocalizationsDz extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -603,16 +603,31 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -603,16 +603,31 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -606,13 +606,28 @@ class AppLocalizationsEo extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'La jenaj subdiskoj estas repreparigotaj:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'subdisko #$disk${partition} kiel $format ĉe $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'subdisko #$disk${partition} kiel $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -606,13 +606,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Las particiones siguientes se van a formatear:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -603,16 +603,31 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -603,16 +603,31 @@ class AppLocalizationsEu extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -603,16 +603,31 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -606,13 +606,28 @@ class AppLocalizationsFi extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Seuraaviin levyosioihin luodaan uusi tiedostojärjestelmä:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'osio #$disk${partition} tiedostojärjestelmänä $format liitetty kohtaan $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'osio #$disk${partition} tiedostojärjestelmänä $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -606,13 +606,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Les partitions suivantes seront formattées :';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'la partition #$disk${partition} en $format est utilisée pour $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} en $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -603,16 +603,31 @@ class AppLocalizationsGa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -603,16 +603,31 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -603,16 +603,31 @@ class AppLocalizationsGu extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -606,13 +606,28 @@ class AppLocalizationsHe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'המחיצות הבאות מועמדות לפרמוט:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'מחיצה מס׳ $disk${partition} בתור $format משמשת עבור $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'מחיצה מס׳ $disk${partition} בתור $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -603,16 +603,31 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -603,16 +603,31 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -606,13 +606,28 @@ class AppLocalizationsHu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'A következő partíciókat fogjuk formázni:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return '#$disk${partition} partíció, mint $format a $mount esetében';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partíció #<$disk${partition} mint $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -606,13 +606,28 @@ class AppLocalizationsId extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Partisi berikut akan diformat:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partisi #$disk${partition} sebagai $format dipakai untuk $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partisi #$disk${partition} sebagai $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -603,16 +603,31 @@ class AppLocalizationsIs extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -603,16 +603,31 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -606,13 +606,28 @@ class AppLocalizationsJa extends AppLocalizations {
   String get writeChangesPartitionsHeader => '以下のパーティションがフォーマットされます:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'パーティション、#$disk${partition} は $format にフォーマットされ、 $mount に割り当てられます';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'パーティション、#$disk${partition} は $format にフォーマットされます';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -603,16 +603,31 @@ class AppLocalizationsKa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -603,16 +603,31 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -603,16 +603,31 @@ class AppLocalizationsKm extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -603,16 +603,31 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -606,13 +606,28 @@ class AppLocalizationsKo extends AppLocalizations {
   String get writeChangesPartitionsHeader => '다음과 같은 파티션이 포맷됩니다:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return '$mount 로 사용되는 $format 포맷의 #$disk${partition} 파티션';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return '#$disk${partition} 파티션을 $format 로 포맷';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -603,16 +603,31 @@ class AppLocalizationsKu extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -603,16 +603,31 @@ class AppLocalizationsLo extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -603,16 +603,31 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -603,16 +603,31 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -603,16 +603,31 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -606,13 +606,28 @@ class AppLocalizationsMl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'ഇനിപ്പറയുന്ന പാർട്ടീഷനുകൾ ഫോർമാറ്റ് ചെയ്യാൻ പോകുന്നു:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'പാർട്ടീഷൻ #$disk${partition} $format ആയി $mount ഉപയോഗിച്ചു';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'പാർട്ടീഷൻ #$disk${partition} $format ആയി';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -603,16 +603,31 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -603,16 +603,31 @@ class AppLocalizationsMy extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -603,16 +603,31 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -603,16 +603,31 @@ class AppLocalizationsNe extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -603,16 +603,31 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -603,16 +603,31 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -606,13 +606,28 @@ class AppLocalizationsOc extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Las particions seguentas seràn formatadas :';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'la particion #$disk${partition} en $format utilizada per $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'particion #$disk${partition} en $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -603,16 +603,31 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -606,13 +606,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Sformatowane zostaną następujące partycje:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partycja #$disk${partition} jako $format używana do $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partycja #$disk${partition} jako $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -606,13 +606,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'As seguintes partições serão formatadas:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partição #$disk${partition} como $format usada para $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partição #$disk${partition} como $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override
@@ -1364,16 +1379,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get writeChangesPartitionsHeader => 'As seguintes partições serão formatadas:';
-
-  @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partição #$disk${partition} como $format usada para $mount';
-  }
-
-  @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partição #$disk${partition} como $format';
-  }
 
   @override
   String get chooseYourLookPageTitle => 'Escolha seu estilo';

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -603,16 +603,31 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -606,13 +606,28 @@ class AppLocalizationsRu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Следующие разделы будут отформатированы:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'раздел #$disk${partition} как $format используется для $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'раздел #$disk${partition} как $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSe extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -603,16 +603,31 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -606,13 +606,28 @@ class AppLocalizationsSv extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Följande partitioner kommer att formateras:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} som $format används för $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} som $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -603,16 +603,31 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -603,16 +603,31 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -603,16 +603,31 @@ class AppLocalizationsTg extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -603,16 +603,31 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -603,16 +603,31 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -606,13 +606,28 @@ class AppLocalizationsTr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Aşağıdaki bölümler biçimlendirilecek:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -603,16 +603,31 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -603,16 +603,31 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -603,16 +603,31 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get writeChangesPartitionsHeader => 'The following partitions are going to be formatted:';
+  String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition #$disk${partition} as $format used for $mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return 'partition #$disk${partition} as $format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -606,13 +606,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get writeChangesPartitionsHeader => '以下分区将被格式化：';
 
   @override
-  String writeChangesPartitionEntryMounted(Object disk, Object partition, Object format, Object mount) {
-    return '分区#$disk${partition}作为$format用于$mount';
+  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
+    return 'partition #$disk${partition} resized from $oldsize to $newsize';
   }
 
   @override
-  String writeChangesPartitionEntryUnmounted(Object disk, Object partition, Object format) {
-    return '分区#$disk${partition}作为$format';
+  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
+    return 'partition #$disk${partition} formatted as $format used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
+    return 'partition #$disk${partition} formatted as $format';
+  }
+
+  @override
+  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
+    return 'partition #$disk${partition} used for $mount';
+  }
+
+  @override
+  String writeChangesPartitionCreated(Object disk, Object partition) {
+    return 'partition #$disk${partition} created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -94,6 +94,11 @@ class DiskStorageService {
     return _client.getStorageV2().then(_updateStorage);
   }
 
+  /// Fetches the original storage configuration.
+  Future<List<Disk>> getOriginalStorage() {
+    return _client.getOriginalStorageV2().then((r) => r.disks);
+  }
+
   /// Adds a [partition] in the specified [gap] on the [disk], and returns the
   /// new storage configuration.
   ///

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -94,6 +94,11 @@ class MockDiskStorageService extends _i1.Mock
               returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
           as _i4.Future<List<_i2.Disk>>);
   @override
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
+      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
+              returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
+          as _i4.Future<List<_i2.Disk>>);
+  @override
   _i4.Future<List<_i2.Disk>> addPartition(
           _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -94,6 +94,11 @@ class MockDiskStorageService extends _i1.Mock
               returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
           as _i4.Future<List<_i2.Disk>>);
   @override
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
+      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
+              returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
+          as _i4.Future<List<_i2.Disk>>);
+  @override
   _i4.Future<List<_i2.Disk>> addPartition(
           _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -98,6 +98,11 @@ class MockDiskStorageService extends _i1.Mock
               returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
           as _i4.Future<List<_i2.Disk>>);
   @override
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
+      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
+              returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
+          as _i4.Future<List<_i2.Disk>>);
+  @override
   _i4.Future<List<_i2.Disk>> addPartition(
           _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -94,6 +94,11 @@ class MockDiskStorageService extends _i1.Mock
               returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
           as _i4.Future<List<_i2.Disk>>);
   @override
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
+      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
+              returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
+          as _i4.Future<List<_i2.Disk>>);
+  @override
   _i4.Future<List<_i2.Disk>> addPartition(
           _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -79,6 +79,8 @@ void main() {
   test('get storage', () async {
     when(client.getStorageV2())
         .thenAnswer((_) async => testStorageResponse(disks: testDisks));
+    when(client.getOriginalStorageV2()).thenAnswer(
+        (_) async => testStorageResponse(disks: testDisks.reversed.toList()));
 
     final service = DiskStorageService(client);
     await untilCalled(client.getStorageV2());
@@ -86,6 +88,9 @@ void main() {
 
     expect(await service.getStorage(), equals(testDisks));
     verify(client.getStorageV2()).called(1);
+
+    expect(await service.getOriginalStorage(), equals(testDisks.reversed));
+    verify(client.getOriginalStorageV2()).called(1);
   });
 
   test('set storage', () async {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -94,6 +94,11 @@ class MockDiskStorageService extends _i1.Mock
               returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
           as _i4.Future<List<_i2.Disk>>);
   @override
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
+      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
+              returnValue: Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
+          as _i4.Future<List<_i2.Disk>>);
+  @override
   _i4.Future<List<_i2.Disk>> addPartition(
           _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
@@ -85,6 +85,11 @@ class MockWriteChangesToDiskModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
+  _i4.Partition? getOriginalPartition(String? sysname, int? number) =>
+      (super.noSuchMethod(
+              Invocation.method(#getOriginalPartition, [sysname, number]))
+          as _i4.Partition?);
+  @override
   _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);


### PR DESCRIPTION
This PR makes the partition change summary a bit more elaborate to give the user a better understanding of the changes being written. Furthermore, the changes are formatted with bullet points to make the summary easier to glance through.

Previously, we would list all partitions with `preserved=false` and phrase it as being "formatted". This proposal takes all the following partition attributes into account:
- `bool resize`
- `String wipe`
- `String mount`
- `bool preserve`

The proposal is to format the summary as such:

> "The following partition changes are going to be applied:"
>
> - "partition #{disk}{partition} resized from {oldsize} to ${newsize}" (`resize` is true)
> - "partition #{disk}{partition} formatted as {format} used for {mount}" (`wipe` and `mount` are non-empty)
> - "partition #{disk}{partition} formatted as {format}" (`wipe` is non-empty)
> - "partition #{disk}{partition} used for {mount}" (`mount` is non-empty)
> - "partition #{disk}{partition} created" (`preserve` is false)

![Screenshot from 2022-07-19 13-59-00](https://user-images.githubusercontent.com/140617/179755575-f4660dd5-472a-4a69-8369-a785b4ed5bc7.png)