### PR TITLE
Installation slides: clean up unused installation "steps"

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -30,26 +30,11 @@ class InstallationSlidesModel extends SafeChangeNotifier with SystemShutdown {
   /// Whether the installation state is ERROR.
   bool get hasError => state == ApplicationState.ERROR;
 
-  /// Whether the installation process is being prepared [STARTING_UP,RUNNING).
-  bool get isPreparing =>
-      state != null &&
-      state!.index >= ApplicationState.STARTING_UP.index &&
-      state!.index < ApplicationState.RUNNING.index;
-
   /// Whether the installation process is active [RUNNING,DONE).
   bool get isInstalling =>
       state != null &&
       state!.index >= ApplicationState.RUNNING.index &&
       state!.index < ApplicationState.DONE.index;
-
-  /// The current installation step between [RUNNING,DONE], or -1 if the
-  /// installation process is not active.
-  int get installationStep =>
-      isInstalling ? state!.index - ApplicationState.RUNNING.index : -1;
-
-  /// The total number of installation steps between [RUNNING,DONE].
-  int get installationStepCount =>
-      ApplicationState.DONE.index - ApplicationState.RUNNING.index;
 
   void _updateStatus(ApplicationStatus? status) {
     if (state == status?.state) return;

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -64,7 +64,6 @@ void main() async {
     final model = InstallationSlidesModel(client, journal);
 
     expect(model.state, isNull);
-    expect(model.isPreparing, isFalse);
     expect(model.isInstalling, isFalse);
     expect(model.isDone, isFalse);
 
@@ -81,17 +80,14 @@ void main() async {
     await model.init();
 
     expect(model.state, ApplicationState.STARTING_UP);
-    expect(model.isPreparing, isTrue);
     expect(model.isInstalling, isFalse);
     expect(model.isDone, isFalse);
 
     await waitForState(ApplicationState.RUNNING);
-    expect(model.isPreparing, isFalse);
     expect(model.isInstalling, isTrue);
     expect(model.isDone, isFalse);
 
     await waitForState(ApplicationState.DONE);
-    expect(model.isPreparing, isFalse);
     expect(model.isInstalling, isFalse);
     expect(model.isDone, isTrue);
   });
@@ -148,28 +144,6 @@ void main() async {
     model.toggleLogVisibility();
     expect(model.isLogVisible, isFalse);
     expect(wasNotified, equals(2));
-  });
-
-  test('installation steps', () async {
-    final client = MockSubiquityClient();
-    when(client.status(current: anyNamed('current'))).thenAnswer(
-      (_) async => testStatus(ApplicationState.RUNNING),
-    );
-
-    final journal = MockJournalService();
-    final model = InstallationSlidesModel(client, journal);
-    expect(model.installationStep, equals(-1));
-    expect(model.installationStepCount, equals(5));
-
-    await model.init();
-    expect(model.installationStep, equals(0));
-
-    when(client.status(current: anyNamed('current'))).thenAnswer(
-      (_) async => testStatus(ApplicationState.POST_RUNNING),
-    );
-
-    await model.init();
-    expect(model.installationStep, equals(2));
   });
 }
 

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -26,10 +26,7 @@ void main() {
     ApplicationState? state,
     bool? isDone,
     bool? hasError,
-    bool? isPreparing,
     bool? isInstalling,
-    int? installationStep,
-    int? installationStepCount,
     Stream<String>? journal,
     bool? isLogVisible,
   }) {
@@ -37,10 +34,7 @@ void main() {
     when(model.state).thenReturn(state);
     when(model.isDone).thenReturn(isDone ?? false);
     when(model.hasError).thenReturn(hasError ?? false);
-    when(model.isPreparing).thenReturn(isPreparing ?? false);
     when(model.isInstalling).thenReturn(isInstalling ?? false);
-    when(model.installationStep).thenReturn(installationStep ?? 1);
-    when(model.installationStepCount).thenReturn(installationStepCount ?? 1);
     when(model.journal).thenAnswer((_) => journal ?? Stream<String>.empty());
     when(model.isLogVisible).thenReturn(isLogVisible ?? false);
     return model;

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -46,21 +46,9 @@ class MockInstallationSlidesModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasError), returnValue: false)
           as bool);
   @override
-  bool get isPreparing =>
-      (super.noSuchMethod(Invocation.getter(#isPreparing), returnValue: false)
-          as bool);
-  @override
   bool get isInstalling =>
       (super.noSuchMethod(Invocation.getter(#isInstalling), returnValue: false)
           as bool);
-  @override
-  int get installationStep =>
-      (super.noSuchMethod(Invocation.getter(#installationStep), returnValue: 0)
-          as int);
-  @override
-  int get installationStepCount =>
-      (super.noSuchMethod(Invocation.getter(#installationStepCount),
-          returnValue: 0) as int);
   @override
   _i4.Stream<String> get journal =>
       (super.noSuchMethod(Invocation.getter(#journal),


### PR DESCRIPTION
The temporary installation slides page added in #186 used to show a text
label e.g. "3/5" to indicate installation progress. The label has not
been there for a good while anymore so the logic is not needed either.
Some of the application statuses used for implementing the unused logic
are being removed from Subiquity.