### PR TITLE
WSL: remove references to POST_WAIT AND POST_RUNNING in tests

### DIFF
--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
@@ -15,7 +15,6 @@ void main() {
     final statuses = <ApplicationStatus>[
       testStatus(ApplicationState.WAITING),
       testStatus(ApplicationState.RUNNING),
-      testStatus(ApplicationState.POST_RUNNING),
       last,
     ];
     final monitor = MockSubiquityStatusMonitor();
@@ -33,7 +32,6 @@ void main() {
     final statuses = <ApplicationStatus>[
       testStatus(ApplicationState.WAITING),
       testStatus(ApplicationState.RUNNING),
-      testStatus(ApplicationState.POST_RUNNING),
       last,
       last,
       last,
@@ -53,7 +51,6 @@ void main() {
     final statuses = <ApplicationStatus>[
       testStatus(ApplicationState.WAITING),
       testStatus(ApplicationState.RUNNING),
-      testStatus(ApplicationState.POST_RUNNING),
       last,
     ];
     final monitor = MockSubiquityStatusMonitor();
@@ -68,10 +65,9 @@ void main() {
   });
   test('Would never call back if subiquity never finishes or crashes',
       () async {
-    final last = testStatus(ApplicationState.POST_RUNNING);
+    final last = testStatus(ApplicationState.RUNNING);
     final statuses = <ApplicationStatus>[
       testStatus(ApplicationState.WAITING),
-      testStatus(ApplicationState.POST_WAIT),
       testStatus(ApplicationState.RUNNING),
       last,
     ];


### PR DESCRIPTION
POST_WAIT and POST_RUNNING are being removed in canonical/subiquity#1362.