### PR TITLE
[WSL] Prevents starting the server in autoinstall mode in reconfiguration

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/args_common.dart
+++ b/packages/ubuntu_wsl_setup/lib/args_common.dart
@@ -16,6 +16,8 @@ screens, yet allowing user to overwrite any of those during setup.
 List<String>? serverArgsFromOptions(ArgResults options) {
   return <String>[
     if (options['prefill'] != null) ...['--prefill', options['prefill']],
+    // Prevents the server to go autoinstall if a previous run was.
+    // See https://github.com/canonical/ubuntu-desktop-installer/pull/1026
     if (options['reconfigure'] != null) '--autoinstall=',
   ];
 }

--- a/packages/ubuntu_wsl_setup/lib/args_common.dart
+++ b/packages/ubuntu_wsl_setup/lib/args_common.dart
@@ -14,9 +14,8 @@ screens, yet allowing user to overwrite any of those during setup.
 }
 
 List<String>? serverArgsFromOptions(ArgResults options) {
-  if (options['prefill'] == null) {
-    return null;
-  }
-
-  return ['--prefill', options['prefill']];
+  return <String>[
+    if (options['prefill'] != null) ...['--prefill', options['prefill']],
+    if (options['reconfigure'] != null) '--autoinstall=',
+  ];
 }


### PR DESCRIPTION
The server leaves the autoinstall configuration inside /cdrom. Later, running the server without the option still becomes autoinstall.
The server searches and finds the interesting file and decides to apply it. It seems to be a feature.
Applying the flag `--autoinstall=` is the way to prevent such.

It doesn't seem to be an issue for the desktop installer since the Subiquity snap won't stay in the target system after installation.

In WSL, though, we rely on Subiquity for the reconfiguration use case.