### PR TITLE
[WSL] Request reboot on Applying changes page

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
 import '../../installing_state.dart';
 
@@ -10,11 +11,14 @@ import '../../installing_state.dart';
 ///
 /// See also:
 ///  * [ApplyingChangesPage]
-class ApplyingChangesModel extends SafeChangeNotifier {
+class ApplyingChangesModel extends SafeChangeNotifier with SystemShutdown {
   /// Creates a model for the 'applying changes' page.
-  ApplyingChangesModel(this._monitor);
+  ApplyingChangesModel(this.client, this._monitor);
 
   final SubiquityStatusMonitor _monitor;
+
+  @override
+  final SubiquityClient client;
   StreamSubscription<ApplicationStatus?>? _sub;
   bool _previousState = true;
 

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -16,8 +16,8 @@ class ApplyingChangesPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const ApplyingChangesPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Creates an instance with [AdvancedSetupModel].
   static Widget create(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/constants.dart';
-import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n/app_localizations.dart';
@@ -17,14 +16,15 @@ class ApplyingChangesPage extends StatefulWidget {
   /// Use [create] instead.
   @visibleForTesting
   const ApplyingChangesPage({
-    super.key,
-  });
+    Key? key,
+  }) : super(key: key);
 
   /// Creates an instance with [AdvancedSetupModel].
   static Widget create(BuildContext context) {
     final monitor = getService<SubiquityStatusMonitor>();
+    final client = getService<SubiquityClient>();
     return ChangeNotifierProvider(
-      create: (_) => ApplyingChangesModel(monitor),
+      create: (_) => ApplyingChangesModel(client, monitor),
       child: const ApplyingChangesPage(),
     );
   }
@@ -42,7 +42,7 @@ class _ApplyingChangesPageState extends State<ApplyingChangesPage> {
       if (Wizard.of(context).hasNext) {
         Wizard.of(context).next();
       } else {
-        closeWindow();
+        model.reboot(immediate: false);
       }
     });
   }

--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.dart';
 
 import 'applying_changes_model_test.mocks.dart';
@@ -18,10 +19,11 @@ void main() {
       testStatus(ApplicationState.POST_RUNNING),
       last,
     ];
+    final client = MockSubiquityClient();
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
-    final model = ApplyingChangesModel(monitor);
+    final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
     model.init(onDoneTransition: () => calledBack = true);
     // Forces the stream to emit.
@@ -38,10 +40,11 @@ void main() {
       last,
       last,
     ];
+    final client = MockSubiquityClient();
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
-    final model = ApplyingChangesModel(monitor);
+    final model = ApplyingChangesModel(client, monitor);
     var calledBackCount = 0;
     model.init(onDoneTransition: () => calledBackCount++);
     // Forces the stream to emit.
@@ -59,7 +62,8 @@ void main() {
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
-    final model = ApplyingChangesModel(monitor);
+    final client = MockSubiquityClient();
+    final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
     model.init(onDoneTransition: () => calledBack = true);
     // Forces the stream to emit.
@@ -75,10 +79,11 @@ void main() {
       testStatus(ApplicationState.RUNNING),
       last,
     ];
+    final client = MockSubiquityClient();
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((_) => Stream.fromIterable(statuses));
-    final model = ApplyingChangesModel(monitor);
+    final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
     model.init(onDoneTransition: () => calledBack = true);
     // Forces the stream to emit.

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -3,6 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages.dart';
@@ -13,7 +16,7 @@ import 'test_utils.dart';
 
 // ignore_for_file: type=lint
 
-@GenerateMocks([ApplyingChangesModel])
+@GenerateMocks([ApplyingChangesModel, SubiquityStatusMonitor])
 void main() {
   const theEnd = 'The end';
   LangTester.type = ApplyingChangesModel;
@@ -25,13 +28,16 @@ void main() {
     );
   }
 
-  Widget buildApp(ApplyingChangesModel model, {bool hasNext = false}) {
+  Widget buildApp({
+    required Widget Function(BuildContext) builder,
+    bool hasNext = false,
+  }) {
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
         routes: {
           '/': WizardRoute(
-            builder: (_) => buildPage(model),
+            builder: builder,
             onNext: (settings) => '/end',
           ),
           if (hasNext)
@@ -54,7 +60,10 @@ void main() {
         realInvocation.namedArguments[Symbol('onDoneTransition')]();
       });
     });
-    await tester.pumpWidget(buildApp(model, hasNext: true));
+    await tester.pumpWidget(buildApp(
+      builder: (_) => buildPage(model),
+      hasNext: true,
+    ));
     expect(find.text(theEnd), findsNothing);
     await tester.pumpAndSettle();
     expect(find.text(theEnd), findsOneWidget);
@@ -69,7 +78,10 @@ void main() {
       });
     });
 
-    await tester.pumpWidget(buildApp(model, hasNext: false));
+    await tester.pumpWidget(buildApp(
+      builder: (_) => buildPage(model),
+      hasNext: false,
+    ));
     verify(model.reboot(immediate: false)).called(1);
   });
 
@@ -77,11 +89,32 @@ void main() {
     final model = MockApplyingChangesModel();
     when(model.init(onDoneTransition: captureAnyNamed('onDoneTransition')))
         .thenAnswer((realInvocation) {});
-    await tester.pumpWidget(buildApp(model));
+    await tester.pumpWidget(buildApp(
+      builder: (_) => buildPage(model),
+      hasNext: true,
+    ));
     expect(find.text(theEnd), findsNothing);
     await tester.pump(Duration.zero);
     expect(find.text(theEnd), findsNothing);
     await tester.pump(Duration.zero);
     expect(find.text(theEnd), findsNothing);
+  });
+
+  testWidgets('creates a model', (tester) async {
+    final client = MockSubiquityClient();
+    final monitor = MockSubiquityStatusMonitor();
+    when(monitor.onStatusChanged).thenAnswer((_) => Stream.value(null));
+    registerMockService<SubiquityClient>(client);
+    registerMockService<SubiquityStatusMonitor>(monitor);
+    await tester.pumpWidget(buildApp(
+      builder: ApplyingChangesPage.create,
+      hasNext: true,
+    ));
+    final page = find.byType(ApplyingChangesPage);
+    expect(page, findsOneWidget);
+
+    final context = tester.element(page);
+    final model = Provider.of<ApplyingChangesModel>(context, listen: false);
+    expect(model, isNotNull);
   });
 }

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -72,15 +72,8 @@ void main() {
       });
     });
 
-    final windowClosed = Completer();
-    final methodChannel = MethodChannel('window_manager');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed.complete();
-    });
-
     await tester.pumpWidget(buildApp(model, hasNext: false));
-    expect(windowClosed.future, completes);
+    verify(model.reboot(immediate: false)).called(1);
   });
 
   testWidgets('won\'t go next while still installing', (tester) async {

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
@@ -73,3 +73,27 @@ class MockApplyingChangesModel extends _i1.Mock
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
 }
+
+/// A class which mocks [SubiquityStatusMonitor].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockSubiquityStatusMonitor extends _i1.Mock
+    implements _i2.SubiquityStatusMonitor {
+  MockSubiquityStatusMonitor() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Stream<_i2.ApplicationStatus?> get onStatusChanged =>
+      (super.noSuchMethod(Invocation.getter(#onStatusChanged),
+              returnValue: Stream<_i2.ApplicationStatus?>.empty())
+          as _i5.Stream<_i2.ApplicationStatus?>);
+  @override
+  _i5.Future<bool> start(_i2.Endpoint? endpoint) =>
+      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
+          returnValue: Future<bool>.value(false)) as _i5.Future<bool>);
+  @override
+  _i5.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+}

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
@@ -2,11 +2,13 @@
 // in ubuntu_wsl_setup/test/applying_changes_page_test.dart.
 // Do not manually edit this file.
 
-import 'dart:ui' as _i3;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.dart'
-    as _i2;
+    as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -18,15 +20,21 @@ import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.d
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
+class _FakeSubiquityClient_0 extends _i1.Fake implements _i2.SubiquityClient {}
+
 /// A class which mocks [ApplyingChangesModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockApplyingChangesModel extends _i1.Mock
-    implements _i2.ApplyingChangesModel {
+    implements _i3.ApplyingChangesModel {
   MockApplyingChangesModel() {
     _i1.throwOnMissingStub(this);
   }
 
+  @override
+  _i2.SubiquityClient get client =>
+      (super.noSuchMethod(Invocation.getter(#client),
+          returnValue: _FakeSubiquityClient_0()) as _i2.SubiquityClient);
   @override
   bool get isDisposed =>
       (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
@@ -36,7 +44,7 @@ class MockApplyingChangesModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
   @override
-  void init({_i3.VoidCallback? onDoneTransition}) => super.noSuchMethod(
+  void init({_i4.VoidCallback? onDoneTransition}) => super.noSuchMethod(
       Invocation.method(#init, [], {#onDoneTransition: onDoneTransition}),
       returnValueForMissingStub: null);
   @override
@@ -47,11 +55,21 @@ class MockApplyingChangesModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
   @override
-  void addListener(_i3.VoidCallback? listener) =>
+  void addListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i3.VoidCallback? listener) =>
+  void removeListener(_i4.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
+  @override
+  _i5.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
+      Invocation.method(#reboot, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+  @override
+  _i5.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
+      Invocation.method(#shutdown, [], {#immediate: immediate}),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
 }


### PR DESCRIPTION
Instead of just closing the window. `SystemShutdown.reboot` itself closes the window after talking to the server.

When running the OOBE on windows this prevents the server to stay alive after the GUI exits.
When running on Linux it might help with the intermittent CI failure due a future that never completes (could the application exit and kill the server at some improper moment?).

Consider that the server doesn't have the power to reboot the distro under WSL, instead it leaves some breadcrumbs guiding the launcher to "reboot" the distro, action taken on the Windows side.