### PR TITLE
Revert "Upgrade to split_view 3.2.0"

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -33,9 +33,9 @@ dependencies:
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
   scroll_to_index: ^3.0.0
-  split_view: # TODO: ^3.2.0
+  split_view: # TODO: ^3.2.x
     git:
-      # https://github.com/toshiaki-h/split_view/pull/18
+      # https://github.com/canonical/ubuntu-desktop-installer/issues/1031
       url: https://github.com/jpnurmi/split_view.git
       ref: controller-weights
   stdlibc: ^0.0.1

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -33,7 +33,11 @@ dependencies:
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
   scroll_to_index: ^3.0.0
-  split_view: ^3.2.0
+  split_view: # TODO: ^3.2.0
+    git:
+      # https://github.com/toshiaki-h/split_view/pull/18
+      url: https://github.com/jpnurmi/split_view.git
+      ref: controller-weights
   stdlibc: ^0.0.1
   subiquity_client:
     path: ../subiquity_client


### PR DESCRIPTION
Reverts canonical/ubuntu-desktop-installer#1016.

Version 3.2.0 of the `split_view` package has been temporarily removed from pub.dev due [a bug report](https://github.com/toshiaki-h/split_view/issues/19), and since there is no such version CI keeps failing.

This temporarily reverts back to [JP's branch of split_view](https://github.com/jpnurmi/split_view/tree/controller-weights) until the upstream is settled.