### PR TITLE
[WSL] Let the launcher request graceful window close

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -37,6 +37,10 @@ Future<void> main(List<String> args) async {
   final registrationEvent = NamedEvent(
     'Local\\${options["distro-name"]}-registered',
   );
+  final closeOobeEvent = NamedEvent(
+    'Local\\${options["distro-name"]}-close-oobe',
+  );
+  closeOobeEvent.future.then((_) => closeWindow());
 
   // TODO: Handle the null case.
   // That would mean port exhaustion and the simplest way to solve it is by


### PR DESCRIPTION
Since the WSL launcher program is parent of the OOBE, it can terminate the process at any moment, but that is too dramatic.
There are situations where the launcher may request the OOBE to gracefully exit.
Listening to that `NamedEvent ('Local\\${options["distro-name"]}-close-oobe')` and closing the Window when set is enough for that purpose, since `closeWindow()` takes care of the server.