### PR TITLE
Nullable instead of late Endpoint.

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -42,18 +42,16 @@ class SubiquityException implements Exception {
 class SubiquityClient {
   final _client = HttpClient();
   Endpoint? _endpoint;
-  String? _host;
   final _isOpen = Completer<bool>();
 
   Future<bool> get isOpen => _isOpen.future;
 
   Uri url(String unencodedPath, [Map<String, dynamic>? queryParameters]) =>
-      Uri.http(_host!, unencodedPath, queryParameters);
+      Uri.http(_endpoint!.authority, unencodedPath, queryParameters);
 
   void open(Endpoint endpoint) {
     log.info('Opening socket to $endpoint');
     _endpoint = endpoint;
-    _host = endpoint.authority;
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
       return Socket.startConnect(endpoint.address, endpoint.port);
     };

--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -41,14 +41,14 @@ class SubiquityException implements Exception {
 
 class SubiquityClient {
   final _client = HttpClient();
-  late Endpoint _endpoint;
-  late String _host;
+  Endpoint? _endpoint;
+  String? _host;
   final _isOpen = Completer<bool>();
 
   Future<bool> get isOpen => _isOpen.future;
 
   Uri url(String unencodedPath, [Map<String, dynamic>? queryParameters]) =>
-      Uri.http(_host, unencodedPath, queryParameters);
+      Uri.http(_host!, unencodedPath, queryParameters);
 
   void open(Endpoint endpoint) {
     log.info('Opening socket to $endpoint');


### PR DESCRIPTION
Server may fail to start or the app be closed before the server starts (dryrun or WSL cases).
Without the server, endpoint will never be set, causing LateInitializationError to be thrown.
Making the fields nullable avoid such class of error.