### PR TITLE
[WSL] Only defer server initialization in setup

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -56,7 +56,7 @@ Future<void> main(List<String> args) async {
       '--server-only',
       '--tcp-port=${socketHolder.port}'
     ],
-    defer: options['reconfigure'] ? null : registrationEvent.future,
+    defer: options['reconfigure'] == true ? null : registrationEvent.future,
     onProcessStart: socketHolder.close,
   );
 

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -56,7 +56,7 @@ Future<void> main(List<String> args) async {
       '--server-only',
       '--tcp-port=${socketHolder.port}'
     ],
-    defer: registrationEvent.future,
+    defer: options['reconfigure'] ? null : registrationEvent.future,
     onProcessStart: socketHolder.close,
   );
 


### PR DESCRIPTION
If the command line '--reconfigure' is explicitely set, then we should not defer subiquity initialization.
This makes the WSL launcher side simpler.
Deferring is meant only for setup, when we need to wait for registration completion before attempting to run any Linux process. For reconfiguration we don't need to wait for anything, since the GUI is responsible for starting the server.