### PR TITLE
Enables generating full PDB for the WSL app.

### DIFF
--- a/packages/ubuntu_wsl_setup/windows/runner/CMakeLists.txt
+++ b/packages/ubuntu_wsl_setup/windows/runner/CMakeLists.txt
@@ -24,6 +24,9 @@ apply_standard_settings(${BINARY_NAME})
 # Disable Windows macros that collide with C++ standard library functions.
 target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 
+# Enable full PDB generation
+target_link_options(${BINARY_NAME} PUBLIC /DEBUG:FULL)
+
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)


### PR DESCRIPTION
By default debug symbols are not exported for the Flutter application runner. Per instructions found in [this comment](https://github.com/flutter/flutter/issues/98863#issuecomment-1047178402) on the Flutter framework repository, this one-liner enables exporting the debug symbols in a program debug database (.pdb) file.

The WSL launcher will be prepared to collect such artifact as part of the release process, providing us with a better crash analysis capabilities, shall we need it.

Ideally we should also collect those files for the plugins as well (those that generate `dll`s). [Per this comment](https://github.com/flutter/flutter/issues/105997#issuecomment-1179230032) it seems we lack a way to propagate that option from the app to the required plugins. So, for now, let's focus on the app.