### PR TITLE
Installation type: multiple operating systems

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -51,7 +51,9 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
       case 1:
         return lang.installationTypeOSDetected(os.single.long);
       case 2:
+        if (os.hasDuplicates) continue duplicates;
         return lang.installationTypeDualOSDetected(os.first.long, os.last.long);
+      duplicates:
       default:
         return lang.installationTypeMultiOSDetected;
     }
@@ -66,8 +68,10 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
       case 1:
         return lang.installationTypeAlongside(product, os.single.long);
       case 2:
+        if (os.hasDuplicates) continue duplicates;
         return lang.installationTypeAlongsideDual(
             product, os.first.long, os.last.long);
+      duplicates:
       default:
         return lang.installationTypeAlongsideMulti(product);
     }
@@ -164,4 +168,10 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
       ],
     );
   }
+}
+
+extension _OsProberList on List<OsProber> {
+  /// Whether the system has any OS installed multiple times.
+  bool get hasDuplicates =>
+      length > 1 && length != map((os) => os.long).toSet().length;
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -51,9 +51,9 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
       case 1:
         return lang.installationTypeOSDetected(os.single.long);
       case 2:
-        if (os.hasDuplicates) continue duplicates;
-        return lang.installationTypeDualOSDetected(os.first.long, os.last.long);
-      duplicates:
+        return os.hasDuplicates
+            ? lang.installationTypeMultiOSDetected
+            : lang.installationTypeDualOSDetected(os.first.long, os.last.long);
       default:
         return lang.installationTypeMultiOSDetected;
     }
@@ -68,10 +68,10 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
       case 1:
         return lang.installationTypeAlongside(product, os.single.long);
       case 2:
-        if (os.hasDuplicates) continue duplicates;
-        return lang.installationTypeAlongsideDual(
-            product, os.first.long, os.last.long);
-      duplicates:
+        return os.hasDuplicates
+            ? lang.installationTypeAlongsideMulti(product)
+            : lang.installationTypeAlongsideDual(
+                product, os.first.long, os.last.long);
       default:
         return lang.installationTypeAlongsideMulti(product);
     }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -215,6 +215,34 @@ void main() {
     verify(model.installationType = InstallationType.alongside).called(1);
   });
 
+  testWidgets('alongside duplicate os', (tester) async {
+    final model = buildModel(
+      productInfo: ProductInfo(name: 'Ubuntu 22.10'),
+      existingOS: [
+        OsProber(
+          long: 'Ubuntu 20.04 LTS',
+          label: 'Ubuntu1',
+          version: '20.04 LTS',
+          type: 'ext4',
+        ),
+        OsProber(
+          long: 'Ubuntu 20.04 LTS',
+          label: 'Ubuntu2',
+          version: '20.04 LTS',
+          type: 'ext4',
+        ),
+      ],
+      canInstallAlongside: true,
+    );
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final radio = find.widgetWithText(RadioButton<InstallationType>,
+        tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10'));
+    expect(radio, findsOneWidget);
+    await tester.tap(radio);
+    verify(model.installationType = InstallationType.alongside).called(1);
+  });
+
   testWidgets('alongside multi os', (tester) async {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -94,6 +94,19 @@ void main() {
     );
   });
 
+  testWidgets('duplicate existing OSes', (tester) async {
+    final model = buildModel(existingOS: [
+      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4'),
+      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
+    ]);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    expect(
+      find.text(tester.lang.installationTypeMultiOSDetected),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('reinstall', (tester) async {
     final model = buildModel(existingOS: [
       OsProber(


### PR DESCRIPTION
Take into account that one may have the same OS installed multiple times. In this case, select:

> This computer currently has multiple operating systems on it.

instead of for example:

> This computer currently has Ubuntu 22.04 and Ubuntu 22.04 on it.

Fixes: #1046