### PR TITLE
Fix telemetry report location

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -4,5 +4,5 @@ export 'services/disk_storage_service.dart' hide log;
 export 'services/journal_service.dart';
 export 'services/network_service.dart';
 export 'services/power_service.dart';
-export 'services/telemetry_service.dart';
+export 'services/telemetry_service.dart' hide log;
 export 'services/udev_service.dart';


### PR DESCRIPTION
Write the report to `/var/log` instead of `/target/var/log` because the GUI
has no permission to write to the latter. The report will be copied to
its final place on the target system by the upcoming post-install script.
Furthermore, in debug/dry-run mode, write to the app dir similarly to
the logs.