### PR TITLE
Sort translated keyboard layout names

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dartx/dartx.dart';
+import 'package:diacritic/diacritic.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -101,7 +102,9 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
   /// Initializes the model and detects the current system keyboard layout and
   /// variant.
   Future<void> init() async {
-    _layouts = (await _client.keyboard()).layouts;
+    _layouts = await _client.keyboard().then((keyboard) {
+      return keyboard.layouts.sortedBy((a) => removeDiacritics(a.name));
+    });
     log.info('Loaded ${_layouts.length} keyboard layouts');
     final keyboard = await _client.keyboard();
     _selectedLayoutIndex = _layouts.indexWhere((layout) {

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
@@ -99,8 +99,8 @@ void main() {
       client = MockSubiquityClient();
       when(client.keyboard()).thenAnswer((_) async {
         return testSetup([
-          KeyboardLayout(code: 'foo', name: 'Foo', variants: []),
-          KeyboardLayout(code: 'bar', name: 'Bar', variants: [
+          KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
+          KeyboardLayout(code: 'foo', name: 'Foo', variants: [
             KeyboardVariant(code: 'baz', name: 'Baz'),
             KeyboardVariant(code: 'qux', name: 'Qux'),
           ]),
@@ -113,8 +113,8 @@ void main() {
 
     test('names are correct', () async {
       expect(model.layoutCount, equals(2));
-      expect(model.layoutName(0), equals('Foo'));
-      expect(model.layoutName(1), equals('Bar'));
+      expect(model.layoutName(0), equals('Bar'));
+      expect(model.layoutName(1), equals('Foo'));
       expect(model.variantCount, equals(0));
 
       expect(model.selectedLayoutIndex, equals(-1));
@@ -166,14 +166,14 @@ void main() {
 
     test('selection applies keyboard settings', () async {
       await model.selectLayout(0);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'foo'))).called(1);
+      verify(client.setKeyboard(KeyboardSetting(layout: 'bar'))).called(1);
 
       await model.selectLayout(1);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'bar', variant: 'baz')))
+      verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'baz')))
           .called(1);
 
       await model.selectVariant(1);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'bar', variant: 'qux')))
+      verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'qux')))
           .called(1);
     });
 
@@ -198,7 +198,7 @@ void main() {
     });
 
     test('try selecting by codes', () async {
-      await model.trySelectLayoutVariant('bar', 'qux');
+      await model.trySelectLayoutVariant('foo', 'qux');
       expect(model.selectedLayoutIndex, equals(1));
       expect(model.selectedVariantIndex, equals(1));
       await expectLater(model.onLayoutSelected, emits(1));
@@ -215,8 +215,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.keyboard()).thenAnswer((_) async {
       return testSetup([
-        KeyboardLayout(code: 'foo', name: 'Foo', variants: []),
-        KeyboardLayout(code: 'bar', name: 'Bar', variants: [
+        KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
+        KeyboardLayout(code: 'foo', name: 'Foo', variants: [
           KeyboardVariant(code: 'baz', name: 'Baz'),
           KeyboardVariant(code: 'qux', name: 'Qux'),
         ]),
@@ -231,7 +231,26 @@ void main() {
     reset(client);
 
     await model.applyKeyboardSettings();
-    verify(client.setKeyboard(KeyboardSetting(layout: 'bar', variant: 'qux')))
+    verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'qux')))
         .called(1);
+  });
+
+  test('sort layouts', () async {
+    final client = MockSubiquityClient();
+    when(client.keyboard()).thenAnswer((_) async {
+      return testSetup([
+        KeyboardLayout(code: 'bbb', name: 'BBB', variants: []),
+        KeyboardLayout(code: 'aaa', name: 'AAA', variants: []),
+        KeyboardLayout(code: 'äää', name: 'ÄÄÄ', variants: []),
+      ], layout: '', variant: '');
+    });
+
+    final model = KeyboardLayoutModel(client);
+
+    await model.init();
+    expect(model.layoutCount, equals(3));
+    expect(model.layoutName(0), equals('AAA'));
+    expect(model.layoutName(1), equals('ÄÄÄ'));
+    expect(model.layoutName(2), equals('BBB'));
   });
 }


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Screenshot from 2022-08-11 16-34-49](https://user-images.githubusercontent.com/140617/184163835-c472c20d-2bde-4283-b4d9-c505c60fe2dc.png) | ![Screenshot from 2022-08-11 16-33-48](https://user-images.githubusercontent.com/140617/184163850-37b97889-59f5-4890-a1d9-a1bd5bbdb518.png) |