### PR TITLE
Upgrade to split_view 3.2.1

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -33,11 +33,7 @@ dependencies:
   provider: ^6.0.0
   safe_change_notifier: ^0.1.0
   scroll_to_index: ^3.0.0
-  split_view: # TODO: ^3.2.x
-    git:
-      # https://github.com/canonical/ubuntu-desktop-installer/issues/1031
-      url: https://github.com/jpnurmi/split_view.git
-      ref: controller-weights
+  split_view: ^3.2.1
   stdlibc: ^0.0.1
   subiquity_client:
     path: ../subiquity_client


### PR DESCRIPTION
The blocker issue in the retracted 3.2.0 version was fixed by toshiaki-h/split_view#20.

Close: #1031