### PR TITLE
Update subiquity

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -413,11 +413,12 @@ class StorageResponse with _$StorageResponse {
 @freezed
 class StorageResponseV2 with _$StorageResponseV2 {
   const factory StorageResponseV2({
-    required List<Disk> disks,
-    required bool needRoot,
-    required bool needBoot,
-    required int installMinimumSize,
+    required ProbeStatus status,
     ErrorReportRef? errorReport,
+    @Default([]) List<Disk> disks,
+    bool? needRoot,
+    bool? needBoot,
+    int? installMinimumSize,
   }) = _StorageResponseV2;
 
   factory StorageResponseV2.fromJson(Map<String, dynamic> json) =>
@@ -479,6 +480,8 @@ class GuidedChoiceV2 with _$GuidedChoiceV2 {
 @freezed
 class GuidedStorageResponseV2 with _$GuidedStorageResponseV2 {
   const factory GuidedStorageResponseV2({
+    required ProbeStatus status,
+    ErrorReportRef? errorReport,
     GuidedChoiceV2? configured,
     @Default([]) List<GuidedStorageTarget> possible,
   }) = _GuidedStorageResponseV2;

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -5427,11 +5427,12 @@ StorageResponseV2 _$StorageResponseV2FromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$StorageResponseV2 {
-  List<Disk> get disks => throw _privateConstructorUsedError;
-  bool get needRoot => throw _privateConstructorUsedError;
-  bool get needBoot => throw _privateConstructorUsedError;
-  int get installMinimumSize => throw _privateConstructorUsedError;
+  ProbeStatus get status => throw _privateConstructorUsedError;
   ErrorReportRef? get errorReport => throw _privateConstructorUsedError;
+  List<Disk> get disks => throw _privateConstructorUsedError;
+  bool? get needRoot => throw _privateConstructorUsedError;
+  bool? get needBoot => throw _privateConstructorUsedError;
+  int? get installMinimumSize => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -5445,11 +5446,12 @@ abstract class $StorageResponseV2CopyWith<$Res> {
           StorageResponseV2 value, $Res Function(StorageResponseV2) then) =
       _$StorageResponseV2CopyWithImpl<$Res>;
   $Res call(
-      {List<Disk> disks,
-      bool needRoot,
-      bool needBoot,
-      int installMinimumSize,
-      ErrorReportRef? errorReport});
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      List<Disk> disks,
+      bool? needRoot,
+      bool? needBoot,
+      int? installMinimumSize});
 
   $ErrorReportRefCopyWith<$Res>? get errorReport;
 }
@@ -5465,13 +5467,22 @@ class _$StorageResponseV2CopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? status = freezed,
+    Object? errorReport = freezed,
     Object? disks = freezed,
     Object? needRoot = freezed,
     Object? needBoot = freezed,
     Object? installMinimumSize = freezed,
-    Object? errorReport = freezed,
   }) {
     return _then(_value.copyWith(
+      status: status == freezed
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ProbeStatus,
+      errorReport: errorReport == freezed
+          ? _value.errorReport
+          : errorReport // ignore: cast_nullable_to_non_nullable
+              as ErrorReportRef?,
       disks: disks == freezed
           ? _value.disks
           : disks // ignore: cast_nullable_to_non_nullable
@@ -5479,19 +5490,15 @@ class _$StorageResponseV2CopyWithImpl<$Res>
       needRoot: needRoot == freezed
           ? _value.needRoot
           : needRoot // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       needBoot: needBoot == freezed
           ? _value.needBoot
           : needBoot // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       installMinimumSize: installMinimumSize == freezed
           ? _value.installMinimumSize
           : installMinimumSize // ignore: cast_nullable_to_non_nullable
-              as int,
-      errorReport: errorReport == freezed
-          ? _value.errorReport
-          : errorReport // ignore: cast_nullable_to_non_nullable
-              as ErrorReportRef?,
+              as int?,
     ));
   }
 
@@ -5515,11 +5522,12 @@ abstract class _$$_StorageResponseV2CopyWith<$Res>
       __$$_StorageResponseV2CopyWithImpl<$Res>;
   @override
   $Res call(
-      {List<Disk> disks,
-      bool needRoot,
-      bool needBoot,
-      int installMinimumSize,
-      ErrorReportRef? errorReport});
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      List<Disk> disks,
+      bool? needRoot,
+      bool? needBoot,
+      int? installMinimumSize});
 
   @override
   $ErrorReportRefCopyWith<$Res>? get errorReport;
@@ -5538,13 +5546,22 @@ class __$$_StorageResponseV2CopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? status = freezed,
+    Object? errorReport = freezed,
     Object? disks = freezed,
     Object? needRoot = freezed,
     Object? needBoot = freezed,
     Object? installMinimumSize = freezed,
-    Object? errorReport = freezed,
   }) {
     return _then(_$_StorageResponseV2(
+      status: status == freezed
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ProbeStatus,
+      errorReport: errorReport == freezed
+          ? _value.errorReport
+          : errorReport // ignore: cast_nullable_to_non_nullable
+              as ErrorReportRef?,
       disks: disks == freezed
           ? _value._disks
           : disks // ignore: cast_nullable_to_non_nullable
@@ -5552,19 +5569,15 @@ class __$$_StorageResponseV2CopyWithImpl<$Res>
       needRoot: needRoot == freezed
           ? _value.needRoot
           : needRoot // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       needBoot: needBoot == freezed
           ? _value.needBoot
           : needBoot // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       installMinimumSize: installMinimumSize == freezed
           ? _value.installMinimumSize
           : installMinimumSize // ignore: cast_nullable_to_non_nullable
-              as int,
-      errorReport: errorReport == freezed
-          ? _value.errorReport
-          : errorReport // ignore: cast_nullable_to_non_nullable
-              as ErrorReportRef?,
+              as int?,
     ));
   }
 }
@@ -5573,35 +5586,39 @@ class __$$_StorageResponseV2CopyWithImpl<$Res>
 @JsonSerializable()
 class _$_StorageResponseV2 implements _StorageResponseV2 {
   const _$_StorageResponseV2(
-      {required final List<Disk> disks,
-      required this.needRoot,
-      required this.needBoot,
-      required this.installMinimumSize,
-      this.errorReport})
+      {required this.status,
+      this.errorReport,
+      final List<Disk> disks = const [],
+      this.needRoot,
+      this.needBoot,
+      this.installMinimumSize})
       : _disks = disks;
 
   factory _$_StorageResponseV2.fromJson(Map<String, dynamic> json) =>
       _$$_StorageResponseV2FromJson(json);
 
+  @override
+  final ProbeStatus status;
+  @override
+  final ErrorReportRef? errorReport;
   final List<Disk> _disks;
   @override
+  @JsonKey()
   List<Disk> get disks {
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_disks);
   }
 
   @override
-  final bool needRoot;
+  final bool? needRoot;
   @override
-  final bool needBoot;
+  final bool? needBoot;
   @override
-  final int installMinimumSize;
-  @override
-  final ErrorReportRef? errorReport;
+  final int? installMinimumSize;
 
   @override
   String toString() {
-    return 'StorageResponseV2(disks: $disks, needRoot: $needRoot, needBoot: $needBoot, installMinimumSize: $installMinimumSize, errorReport: $errorReport)';
+    return 'StorageResponseV2(status: $status, errorReport: $errorReport, disks: $disks, needRoot: $needRoot, needBoot: $needBoot, installMinimumSize: $installMinimumSize)';
   }
 
   @override
@@ -5609,24 +5626,26 @@ class _$_StorageResponseV2 implements _StorageResponseV2 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_StorageResponseV2 &&
+            const DeepCollectionEquality().equals(other.status, status) &&
+            const DeepCollectionEquality()
+                .equals(other.errorReport, errorReport) &&
             const DeepCollectionEquality().equals(other._disks, _disks) &&
             const DeepCollectionEquality().equals(other.needRoot, needRoot) &&
             const DeepCollectionEquality().equals(other.needBoot, needBoot) &&
             const DeepCollectionEquality()
-                .equals(other.installMinimumSize, installMinimumSize) &&
-            const DeepCollectionEquality()
-                .equals(other.errorReport, errorReport));
+                .equals(other.installMinimumSize, installMinimumSize));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(status),
+      const DeepCollectionEquality().hash(errorReport),
       const DeepCollectionEquality().hash(_disks),
       const DeepCollectionEquality().hash(needRoot),
       const DeepCollectionEquality().hash(needBoot),
-      const DeepCollectionEquality().hash(installMinimumSize),
-      const DeepCollectionEquality().hash(errorReport));
+      const DeepCollectionEquality().hash(installMinimumSize));
 
   @JsonKey(ignore: true)
   @override
@@ -5644,25 +5663,28 @@ class _$_StorageResponseV2 implements _StorageResponseV2 {
 
 abstract class _StorageResponseV2 implements StorageResponseV2 {
   const factory _StorageResponseV2(
-      {required final List<Disk> disks,
-      required final bool needRoot,
-      required final bool needBoot,
-      required final int installMinimumSize,
-      final ErrorReportRef? errorReport}) = _$_StorageResponseV2;
+      {required final ProbeStatus status,
+      final ErrorReportRef? errorReport,
+      final List<Disk> disks,
+      final bool? needRoot,
+      final bool? needBoot,
+      final int? installMinimumSize}) = _$_StorageResponseV2;
 
   factory _StorageResponseV2.fromJson(Map<String, dynamic> json) =
       _$_StorageResponseV2.fromJson;
 
   @override
-  List<Disk> get disks;
-  @override
-  bool get needRoot;
-  @override
-  bool get needBoot;
-  @override
-  int get installMinimumSize;
+  ProbeStatus get status;
   @override
   ErrorReportRef? get errorReport;
+  @override
+  List<Disk> get disks;
+  @override
+  bool? get needRoot;
+  @override
+  bool? get needBoot;
+  @override
+  int? get installMinimumSize;
   @override
   @JsonKey(ignore: true)
   _$$_StorageResponseV2CopyWith<_$_StorageResponseV2> get copyWith =>
@@ -6768,6 +6790,8 @@ GuidedStorageResponseV2 _$GuidedStorageResponseV2FromJson(
 
 /// @nodoc
 mixin _$GuidedStorageResponseV2 {
+  ProbeStatus get status => throw _privateConstructorUsedError;
+  ErrorReportRef? get errorReport => throw _privateConstructorUsedError;
   GuidedChoiceV2? get configured => throw _privateConstructorUsedError;
   List<GuidedStorageTarget> get possible => throw _privateConstructorUsedError;
 
@@ -6782,8 +6806,13 @@ abstract class $GuidedStorageResponseV2CopyWith<$Res> {
   factory $GuidedStorageResponseV2CopyWith(GuidedStorageResponseV2 value,
           $Res Function(GuidedStorageResponseV2) then) =
       _$GuidedStorageResponseV2CopyWithImpl<$Res>;
-  $Res call({GuidedChoiceV2? configured, List<GuidedStorageTarget> possible});
+  $Res call(
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      GuidedChoiceV2? configured,
+      List<GuidedStorageTarget> possible});
 
+  $ErrorReportRefCopyWith<$Res>? get errorReport;
   $GuidedChoiceV2CopyWith<$Res>? get configured;
 }
 
@@ -6798,10 +6827,20 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? status = freezed,
+    Object? errorReport = freezed,
     Object? configured = freezed,
     Object? possible = freezed,
   }) {
     return _then(_value.copyWith(
+      status: status == freezed
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ProbeStatus,
+      errorReport: errorReport == freezed
+          ? _value.errorReport
+          : errorReport // ignore: cast_nullable_to_non_nullable
+              as ErrorReportRef?,
       configured: configured == freezed
           ? _value.configured
           : configured // ignore: cast_nullable_to_non_nullable
@@ -6811,6 +6850,17 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res>
           : possible // ignore: cast_nullable_to_non_nullable
               as List<GuidedStorageTarget>,
     ));
+  }
+
+  @override
+  $ErrorReportRefCopyWith<$Res>? get errorReport {
+    if (_value.errorReport == null) {
+      return null;
+    }
+
+    return $ErrorReportRefCopyWith<$Res>(_value.errorReport!, (value) {
+      return _then(_value.copyWith(errorReport: value));
+    });
   }
 
   @override
@@ -6832,8 +6882,14 @@ abstract class _$$_GuidedStorageResponseV2CopyWith<$Res>
           $Res Function(_$_GuidedStorageResponseV2) then) =
       __$$_GuidedStorageResponseV2CopyWithImpl<$Res>;
   @override
-  $Res call({GuidedChoiceV2? configured, List<GuidedStorageTarget> possible});
+  $Res call(
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      GuidedChoiceV2? configured,
+      List<GuidedStorageTarget> possible});
 
+  @override
+  $ErrorReportRefCopyWith<$Res>? get errorReport;
   @override
   $GuidedChoiceV2CopyWith<$Res>? get configured;
 }
@@ -6852,10 +6908,20 @@ class __$$_GuidedStorageResponseV2CopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? status = freezed,
+    Object? errorReport = freezed,
     Object? configured = freezed,
     Object? possible = freezed,
   }) {
     return _then(_$_GuidedStorageResponseV2(
+      status: status == freezed
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ProbeStatus,
+      errorReport: errorReport == freezed
+          ? _value.errorReport
+          : errorReport // ignore: cast_nullable_to_non_nullable
+              as ErrorReportRef?,
       configured: configured == freezed
           ? _value.configured
           : configured // ignore: cast_nullable_to_non_nullable
@@ -6872,12 +6938,19 @@ class __$$_GuidedStorageResponseV2CopyWithImpl<$Res>
 @JsonSerializable()
 class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
   const _$_GuidedStorageResponseV2(
-      {this.configured, final List<GuidedStorageTarget> possible = const []})
+      {required this.status,
+      this.errorReport,
+      this.configured,
+      final List<GuidedStorageTarget> possible = const []})
       : _possible = possible;
 
   factory _$_GuidedStorageResponseV2.fromJson(Map<String, dynamic> json) =>
       _$$_GuidedStorageResponseV2FromJson(json);
 
+  @override
+  final ProbeStatus status;
+  @override
+  final ErrorReportRef? errorReport;
   @override
   final GuidedChoiceV2? configured;
   final List<GuidedStorageTarget> _possible;
@@ -6890,7 +6963,7 @@ class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
 
   @override
   String toString() {
-    return 'GuidedStorageResponseV2(configured: $configured, possible: $possible)';
+    return 'GuidedStorageResponseV2(status: $status, errorReport: $errorReport, configured: $configured, possible: $possible)';
   }
 
   @override
@@ -6898,6 +6971,9 @@ class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_GuidedStorageResponseV2 &&
+            const DeepCollectionEquality().equals(other.status, status) &&
+            const DeepCollectionEquality()
+                .equals(other.errorReport, errorReport) &&
             const DeepCollectionEquality()
                 .equals(other.configured, configured) &&
             const DeepCollectionEquality().equals(other._possible, _possible));
@@ -6907,6 +6983,8 @@ class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(status),
+      const DeepCollectionEquality().hash(errorReport),
       const DeepCollectionEquality().hash(configured),
       const DeepCollectionEquality().hash(_possible));
 
@@ -6927,12 +7005,18 @@ class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
 
 abstract class _GuidedStorageResponseV2 implements GuidedStorageResponseV2 {
   const factory _GuidedStorageResponseV2(
-      {final GuidedChoiceV2? configured,
+      {required final ProbeStatus status,
+      final ErrorReportRef? errorReport,
+      final GuidedChoiceV2? configured,
       final List<GuidedStorageTarget> possible}) = _$_GuidedStorageResponseV2;
 
   factory _GuidedStorageResponseV2.fromJson(Map<String, dynamic> json) =
       _$_GuidedStorageResponseV2.fromJson;
 
+  @override
+  ProbeStatus get status;
+  @override
+  ErrorReportRef? get errorReport;
   @override
   GuidedChoiceV2? get configured;
   @override

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -529,26 +529,29 @@ const _$BootloaderEnumMap = {
 
 _$_StorageResponseV2 _$$_StorageResponseV2FromJson(Map<String, dynamic> json) =>
     _$_StorageResponseV2(
-      disks: (json['disks'] as List<dynamic>)
-          .map((e) => Disk.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      needRoot: json['need_root'] as bool,
-      needBoot: json['need_boot'] as bool,
-      installMinimumSize: json['install_minimum_size'] as int,
+      status: $enumDecode(_$ProbeStatusEnumMap, json['status']),
       errorReport: json['error_report'] == null
           ? null
           : ErrorReportRef.fromJson(
               json['error_report'] as Map<String, dynamic>),
+      disks: (json['disks'] as List<dynamic>?)
+              ?.map((e) => Disk.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      needRoot: json['need_root'] as bool?,
+      needBoot: json['need_boot'] as bool?,
+      installMinimumSize: json['install_minimum_size'] as int?,
     );
 
 Map<String, dynamic> _$$_StorageResponseV2ToJson(
         _$_StorageResponseV2 instance) =>
     <String, dynamic>{
+      'status': _$ProbeStatusEnumMap[instance.status]!,
+      'error_report': instance.errorReport?.toJson(),
       'disks': instance.disks.map((e) => e.toJson()).toList(),
       'need_root': instance.needRoot,
       'need_boot': instance.needBoot,
       'install_minimum_size': instance.installMinimumSize,
-      'error_report': instance.errorReport?.toJson(),
     };
 
 _$_GuidedResizeValues _$$_GuidedResizeValuesFromJson(
@@ -641,6 +644,11 @@ Map<String, dynamic> _$$_GuidedChoiceV2ToJson(_$_GuidedChoiceV2 instance) =>
 _$_GuidedStorageResponseV2 _$$_GuidedStorageResponseV2FromJson(
         Map<String, dynamic> json) =>
     _$_GuidedStorageResponseV2(
+      status: $enumDecode(_$ProbeStatusEnumMap, json['status']),
+      errorReport: json['error_report'] == null
+          ? null
+          : ErrorReportRef.fromJson(
+              json['error_report'] as Map<String, dynamic>),
       configured: json['configured'] == null
           ? null
           : GuidedChoiceV2.fromJson(json['configured'] as Map<String, dynamic>),
@@ -654,6 +662,8 @@ _$_GuidedStorageResponseV2 _$$_GuidedStorageResponseV2FromJson(
 Map<String, dynamic> _$$_GuidedStorageResponseV2ToJson(
         _$_GuidedStorageResponseV2 instance) =>
     <String, dynamic>{
+      'status': _$ProbeStatusEnumMap[instance.status]!,
+      'error_report': instance.errorReport?.toJson(),
       'configured': instance.configured?.toJson(),
       'possible': instance.possible.map((e) => e.toJson()).toList(),
     };

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.dart
@@ -34,8 +34,8 @@ void main() {
   test('init guided storage', () async {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [testDisk()]);
-    when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [testResizeStorage()]));
+    when(service.getGuidedStorage()).thenAnswer((_) async =>
+        testGuidedStorageResponse(possible: [testResizeStorage()]));
 
     final model = InstallAlongsideModel(service);
     expect(model.selectedIndex, isNull);
@@ -58,9 +58,9 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [disk]);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [resize1, resize2]));
+        (_) async => testGuidedStorageResponse(possible: [resize1, resize2]));
     when(service.setGuidedStorage(any)).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [resize1, resize2]));
+        (_) async => testGuidedStorageResponse(possible: [resize1, resize2]));
 
     final model = InstallAlongsideModel(service);
     await model.init();
@@ -77,7 +77,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.resetStorage()).thenAnswer((_) async => []);
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => const GuidedStorageResponseV2(possible: []));
+        .thenAnswer((_) async => testGuidedStorageResponse());
 
     final model = InstallAlongsideModel(service);
     await model.reset();
@@ -111,7 +111,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [sda, sdb]);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [storage1, storage2]));
+        (_) async => testGuidedStorageResponse(possible: [storage1, storage2]));
 
     final model = InstallAlongsideModel(service);
     expect(model.storageCount, isZero);
@@ -150,7 +150,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [sda, sdb]);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [storage1, storage2]));
+        (_) async => testGuidedStorageResponse(possible: [storage1, storage2]));
 
     final model = InstallAlongsideModel(service);
     expect(model.storageCount, isZero);
@@ -215,8 +215,8 @@ void main() {
 
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [disk]);
-    when(service.getGuidedStorage()).thenAnswer((_) async =>
-        const GuidedStorageResponseV2(possible: [storage1, storage2]));
+    when(service.getGuidedStorage()).thenAnswer(
+        (_) async => testGuidedStorageResponse(possible: [storage1, storage2]));
 
     final model = InstallAlongsideModel(service);
     await model.init();

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.dart
@@ -205,7 +205,7 @@ void main() {
     when(storage.existingOS).thenReturn([]);
     when(storage.getStorage()).thenAnswer((_) async => []);
     when(storage.getGuidedStorage())
-        .thenAnswer((_) async => const GuidedStorageResponseV2());
+        .thenAnswer((_) async => testGuidedStorageResponse());
     registerMockService<DiskStorageService>(storage);
 
     await tester.pumpWidget(tester.buildApp(InstallAlongsidePage.create));

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -5,6 +5,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
+import '../test_utils.dart';
 import 'installation_type_model_test.mocks.dart';
 
 // ignore_for_file: type=lint
@@ -136,10 +137,10 @@ void main() {
 
     final service = MockDiskStorageService();
     when(service.hasEncryption).thenReturn(false);
-    when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [reformat]));
+    when(service.getGuidedStorage()).thenAnswer(
+        (_) async => testGuidedStorageResponse(possible: [reformat]));
     when(service.setGuidedStorage(reformat))
-        .thenAnswer((_) async => GuidedStorageResponseV2(configured: choice));
+        .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final model = InstallationTypeModel(service, MockTelemetryService());
 
@@ -155,14 +156,14 @@ void main() {
 
     // none
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: []));
+        .thenAnswer((_) async => testGuidedStorageResponse());
     await model.init();
     expect(model.canInstallAlongside, isFalse);
 
     // reformat
     final reformat = GuidedStorageTargetReformat(diskId: '');
-    when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [reformat]));
+    when(service.getGuidedStorage()).thenAnswer(
+        (_) async => testGuidedStorageResponse(possible: [reformat]));
     await model.init();
     expect(model.canInstallAlongside, isFalse);
 
@@ -175,7 +176,7 @@ void main() {
         minimum: 0,
         recommended: 0);
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [resize]));
+        .thenAnswer((_) async => testGuidedStorageResponse(possible: [resize]));
     await model.init();
     expect(model.canInstallAlongside, isTrue);
 
@@ -183,13 +184,13 @@ void main() {
     final gap = GuidedStorageTargetUseGap(
         diskId: '', gap: Gap(offset: 0, size: 0, usable: GapUsable.YES));
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [gap]));
+        .thenAnswer((_) async => testGuidedStorageResponse(possible: [gap]));
     await model.init();
     expect(model.canInstallAlongside, isTrue);
 
     // all
     when(service.getGuidedStorage()).thenAnswer((_) async =>
-        GuidedStorageResponseV2(possible: [reformat, resize, gap]));
+        testGuidedStorageResponse(possible: [reformat, resize, gap]));
     await model.init();
     expect(model.canInstallAlongside, isTrue);
   });
@@ -200,7 +201,7 @@ void main() {
 
     // none
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: []));
+        .thenAnswer((_) async => testGuidedStorageResponse());
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
@@ -209,8 +210,8 @@ void main() {
 
     // reformat
     final reformat = GuidedStorageTargetReformat(diskId: '');
-    when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [reformat]));
+    when(service.getGuidedStorage()).thenAnswer(
+        (_) async => testGuidedStorageResponse(possible: [reformat]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), reformat);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
@@ -219,7 +220,7 @@ void main() {
 
     // multiple reformats
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [reformat, reformat]));
+        (_) async => testGuidedStorageResponse(possible: [reformat, reformat]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
@@ -235,7 +236,7 @@ void main() {
         minimum: 0,
         recommended: 0);
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [resize]));
+        .thenAnswer((_) async => testGuidedStorageResponse(possible: [resize]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
@@ -246,7 +247,7 @@ void main() {
     final gap = GuidedStorageTargetUseGap(
         diskId: '', gap: Gap(offset: 0, size: 1, usable: GapUsable.YES));
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2(possible: [gap]));
+        .thenAnswer((_) async => testGuidedStorageResponse(possible: [gap]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), gap);
@@ -259,7 +260,7 @@ void main() {
     final gap3 = GuidedStorageTargetUseGap(
         diskId: '', gap: Gap(offset: 0, size: 3, usable: GapUsable.YES));
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: [gap, gap3, gap2]));
+        (_) async => testGuidedStorageResponse(possible: [gap, gap3, gap2]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), gap3);
@@ -268,7 +269,7 @@ void main() {
 
     // all
     when(service.getGuidedStorage()).thenAnswer((_) async =>
-        GuidedStorageResponseV2(possible: [reformat, resize, gap]));
+        testGuidedStorageResponse(possible: [reformat, resize, gap]));
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), reformat);
     expect(model.preselectTarget(InstallationType.alongside), gap);

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -316,9 +316,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.isOpen).thenAnswer((_) async => true);
     when(client.getGuidedStorageV2())
-        .thenAnswer((_) async => GuidedStorageResponseV2());
-    when(client.getStorageV2()).thenAnswer((_) async => StorageResponseV2(
-        disks: [], installMinimumSize: 0, needBoot: false, needRoot: false));
+        .thenAnswer((_) async => testGuidedStorageResponse());
+    when(client.getStorageV2()).thenAnswer((_) async => testStorageResponse());
     when(client.hasRst()).thenAnswer((_) async => false);
     when(client.hasBitLocker()).thenAnswer((_) async => false);
     registerMockService<SubiquityClient>(client);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
@@ -19,7 +19,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: testTargets));
+        (_) async => testGuidedStorageResponse(possible: testTargets));
 
     final model = SelectGuidedStorageModel(service);
     await model.loadGuidedStorage();
@@ -32,9 +32,9 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: testTargets));
+        (_) async => testGuidedStorageResponse(possible: testTargets));
     when(service.setGuidedStorage(any)).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: testTargets));
+        (_) async => testGuidedStorageResponse(possible: testTargets));
 
     final model = SelectGuidedStorageModel(service);
     await model.loadGuidedStorage();
@@ -61,8 +61,8 @@ void main() {
 
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => [sda, sdb]);
-    when(service.getGuidedStorage()).thenAnswer((_) async =>
-        const GuidedStorageResponseV2(possible: [storage0, storage1]));
+    when(service.getGuidedStorage()).thenAnswer(
+        (_) async => testGuidedStorageResponse(possible: [storage0, storage1]));
 
     final model = SelectGuidedStorageModel(service);
     expect(model.getStorage(0), isNull);
@@ -84,7 +84,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getGuidedStorage()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: testTargets));
+        (_) async => testGuidedStorageResponse(possible: testTargets));
 
     final model = SelectGuidedStorageModel(service);
     expect(model.selectedIndex, isZero);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -124,7 +124,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => []);
     when(service.getGuidedStorage())
-        .thenAnswer((_) async => GuidedStorageResponseV2());
+        .thenAnswer((_) async => testGuidedStorageResponse());
     registerMockService<DiskStorageService>(service);
 
     await tester.pumpWidget(tester.buildApp(SelectGuidedStoragePage.create));

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -20,12 +20,9 @@ void main() {
     client = MockSubiquityClient();
     when(client.isOpen).thenAnswer((_) async => true);
     when(client.getGuidedStorageV2()).thenAnswer(
-        (_) async => GuidedStorageResponseV2(possible: testTargets));
-    when(client.getStorageV2()).thenAnswer((_) async => StorageResponseV2(
-        disks: testDisks,
-        needBoot: false,
-        needRoot: false,
-        installMinimumSize: 0));
+        (_) async => testGuidedStorageResponse(possible: testTargets));
+    when(client.getStorageV2())
+        .thenAnswer((_) async => testStorageResponse(disks: testDisks));
     when(client.hasRst()).thenAnswer((_) async => false);
     when(client.hasBitLocker()).thenAnswer((_) async => false);
   });
@@ -33,7 +30,7 @@ void main() {
   test('get guided storage', () async {
     final service = DiskStorageService(client);
     expect(await service.getGuidedStorage(),
-        equals(GuidedStorageResponseV2(possible: testTargets)));
+        equals(testGuidedStorageResponse(possible: testTargets)));
     verify(client.getGuidedStorageV2()).called(1);
   });
 
@@ -41,7 +38,7 @@ void main() {
     final target = GuidedStorageTargetReformat(diskId: testDisks.last.id);
     final choice = GuidedChoiceV2(target: target, useLvm: false);
     when(client.setGuidedStorageV2(choice))
-        .thenAnswer((_) async => GuidedStorageResponseV2(configured: choice));
+        .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final service = DiskStorageService(client);
     await service.setGuidedStorage(target);
@@ -52,7 +49,7 @@ void main() {
     final target = GuidedStorageTargetReformat(diskId: testDisks.last.id);
     final choice = GuidedChoiceV2(target: target, useLvm: true);
     when(client.setGuidedStorageV2(choice))
-        .thenAnswer((_) async => GuidedStorageResponseV2(configured: choice));
+        .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final service = DiskStorageService(client);
     service.useLvm = true;
@@ -227,7 +224,7 @@ void main() {
     );
 
     when(client.getStorageV2()).thenAnswer(
-      (_) async => StorageResponseV2(
+      (_) async => testStorageResponse(
         disks: [
           testDisk(
             partitions: [
@@ -241,9 +238,6 @@ void main() {
             ],
           ),
         ],
-        needRoot: false,
-        needBoot: false,
-        installMinimumSize: 0,
       ),
     );
 
@@ -257,7 +251,7 @@ void main() {
     final target = GuidedStorageTargetReformat(diskId: testDisks.last.id);
     final choice = GuidedChoiceV2(target: target, useLvm: false);
     when(client.setGuidedStorageV2(choice))
-        .thenAnswer((_) async => GuidedStorageResponseV2(configured: choice));
+        .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
     when(client.resetStorageV2())
         .thenAnswer((_) async => testStorageResponse());
 
@@ -303,18 +297,4 @@ void main() {
     expect(service.largestDiskSize, 456);
     expect(service.hasEnoughDiskSpace, isFalse);
   });
-}
-
-StorageResponseV2 testStorageResponse({
-  List<Disk> disks = const [],
-  bool needBoot = false,
-  bool needRoot = false,
-  int installMinimumSize = 0,
-}) {
-  return StorageResponseV2(
-    disks: disks,
-    needBoot: needBoot,
-    needRoot: needRoot,
-    installMinimumSize: installMinimumSize,
-  );
 }

--- a/packages/ubuntu_desktop_installer/test/test_utils.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.dart
@@ -101,6 +101,34 @@ Disk testDisk({
   );
 }
 
+GuidedStorageResponseV2 testGuidedStorageResponse({
+  ProbeStatus status = ProbeStatus.DONE,
+  GuidedChoiceV2? configured,
+  List<GuidedStorageTarget> possible = const [],
+}) {
+  return GuidedStorageResponseV2(
+    status: status,
+    configured: configured,
+    possible: possible,
+  );
+}
+
+StorageResponseV2 testStorageResponse({
+  ProbeStatus status = ProbeStatus.DONE,
+  List<Disk> disks = const [],
+  bool needBoot = false,
+  bool needRoot = false,
+  int installMinimumSize = 0,
+}) {
+  return StorageResponseV2(
+    status: status,
+    disks: disks,
+    needBoot: needBoot,
+    needRoot: needRoot,
+    installMinimumSize: installMinimumSize,
+  );
+}
+
 extension UbuntuFinders on CommonFinders {
   Finder asset(String assetName) {
     return find.byWidgetPredicate((widget) {

--- a/packages/ubuntu_desktop_installer/test/widget_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_test.dart
@@ -16,6 +16,8 @@ import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/settings.dart';
 import 'package:ubuntu_test/mocks.dart';
 
+import 'test_utils.dart';
+
 // ignore_for_file: type=lint
 
 void main() {
@@ -29,8 +31,7 @@ void main() {
     when(client.hasBitLocker()).thenAnswer((_) async => false);
     when(client.keyboard()).thenAnswer((_) async =>
         KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
-    when(client.getStorageV2()).thenAnswer((_) async => StorageResponseV2(
-        disks: [], installMinimumSize: 0, needBoot: false, needRoot: false));
+    when(client.getStorageV2()).thenAnswer((_) async => testStorageResponse());
     when(client.isOpen).thenAnswer((_) async => true);
     registerMockService<SubiquityClient>(client);
     registerMockService<DiskStorageService>(DiskStorageService(client));


### PR DESCRIPTION
And adapt to changes: the status-field is now required for `(Guided)StorageResponseV2`.