### PR TITLE
Installation slides: show Subiquity status & revise journal logs 

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -24,8 +24,6 @@ import 'slides.dart';
 export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
 export 'slides.dart';
 
-const _kSystemdUnit = 'snap.ubuntu-desktop-installer.subiquity-server.service';
-
 final assetBundle =
     ProxyAssetBundle(rootBundle, package: 'ubuntu_desktop_installer');
 
@@ -74,14 +72,12 @@ Future<void> runInstallerApp(
     setWindowClosable(status?.state.isInstalling != true);
   });
 
-  final journalUnit = liveRun ? _kSystemdUnit : null;
-
   final geodata = Geodata.asset();
   final geoname = Geoname.ubuntu(geodata: geodata);
 
   registerService(() => DiskStorageService(subiquityClient));
   registerService(() => GeoService(sources: [geodata, geoname]));
-  registerService(() => JournalService(journalUnit));
+  registerService(JournalService.new);
   registerService(NetworkService.new);
   registerService(PowerService.new);
   registerService(TelemetryService.new);

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
@@ -510,6 +510,8 @@
   "availableSoftware": "Available software",
   "supportedSoftware": "Supported software",
   "copyingFiles": "Copying files...",
+  "installingSystem": "Installing system...",
+  "configuringSystem": "Configuring system...",
   "installationFailed": "Installation failed",
   "notEnoughDiskSpaceTitle": "Sorry",
   "notEnoughDiskSpaceHeader": "You need at least {SIZE} disk space to install {RELEASE}.",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1695,6 +1695,18 @@ abstract class AppLocalizations {
   /// **'Copying files...'**
   String get copyingFiles;
 
+  /// No description provided for @installingSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'Installing system...'**
+  String get installingSystem;
+
+  /// No description provided for @configuringSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'Configuring system...'**
+  String get configuringSystem;
+
   /// No description provided for @installationFailed.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -819,6 +819,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -819,6 +819,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -819,6 +819,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -819,6 +819,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -819,6 +819,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -819,6 +819,12 @@ class AppLocalizationsBo extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -819,6 +819,12 @@ class AppLocalizationsBs extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -819,6 +819,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get copyingFiles => 'S’estan copiant els fitxers…';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Ha fallat la instal·lació';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -819,6 +819,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get copyingFiles => 'Kopírování souborů…';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Instalace se nezdařila';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -819,6 +819,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -819,6 +819,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -819,6 +819,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get copyingFiles => 'Dateien werden kopiert ...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation fehlgeschlagen';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -819,6 +819,12 @@ class AppLocalizationsDz extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get copyingFiles => 'Kopiante dosierojn...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Instalado fiaskis';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get copyingFiles => 'Copiando archivos…';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Falló la instalación';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -819,6 +819,12 @@ class AppLocalizationsEu extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -819,6 +819,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -819,6 +819,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -819,6 +819,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get copyingFiles => 'Copie des fichiers...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Échec de l\'installation';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -819,6 +819,12 @@ class AppLocalizationsGa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -819,6 +819,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -819,6 +819,12 @@ class AppLocalizationsGu extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -819,6 +819,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get copyingFiles => 'קבצים מועתקים…';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'ההתקנה נכשלה';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -819,6 +819,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -819,6 +819,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -819,6 +819,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get copyingFiles => 'Fájlok másolása...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'A telepítés sikertelen';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -819,6 +819,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -819,6 +819,12 @@ class AppLocalizationsIs extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -819,6 +819,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -819,6 +819,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get copyingFiles => 'ファイルをコピーしています...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'インストールに失敗しました';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKm extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get copyingFiles => '파일 복사 중...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => '설치 실패';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -819,6 +819,12 @@ class AppLocalizationsKu extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -819,6 +819,12 @@ class AppLocalizationsLo extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -819,6 +819,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -819,6 +819,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -819,6 +819,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -819,6 +819,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -819,6 +819,12 @@ class AppLocalizationsMr extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -819,6 +819,12 @@ class AppLocalizationsMy extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -819,6 +819,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -819,6 +819,12 @@ class AppLocalizationsNe extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -819,6 +819,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -819,6 +819,12 @@ class AppLocalizationsNn extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -819,6 +819,12 @@ class AppLocalizationsOc extends AppLocalizations {
   String get copyingFiles => 'Còpia dels fichièrs...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Fracàs de l’installacion';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -819,6 +819,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -819,6 +819,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get copyingFiles => 'Kopiowanie plików...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Instalacja nieudana';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -819,6 +819,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -819,6 +819,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -819,6 +819,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get copyingFiles => 'Копирование файлов...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Ошибка установки';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSe extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -819,6 +819,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get copyingFiles => 'Kopierar filer...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installationen misslyckades';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTg extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -819,6 +819,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -819,6 +819,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -819,6 +819,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -819,6 +819,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get copyingFiles => 'Copying files...';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => 'Installation failed';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -819,6 +819,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get copyingFiles => '复制文件……';
 
   @override
+  String get installingSystem => 'Installing system...';
+
+  @override
+  String get configuringSystem => 'Configuring system...';
+
+  @override
   String get installationFailed => '安装失败';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -51,6 +51,18 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
     });
   }
 
+  String _formatEvent(InstallationEvent? event) {
+    final lang = AppLocalizations.of(context);
+    switch (event?.action) {
+      case 'installing system':
+        return lang.installingSystem;
+      case 'final system configuration':
+        return lang.configuringSystem;
+      default:
+        return lang.copyingFiles;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
@@ -80,7 +92,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                         left: kContentSpacing,
                         right: kContentSpacing,
                       ),
-                      child: _JournalView(journal: model.journal),
+                      child: _JournalView(journal: model.log),
                     ),
                   ),
                 )
@@ -98,7 +110,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                     Text(
                       model.hasError
                           ? lang.installationFailed
-                          : lang.copyingFiles,
+                          : _formatEvent(model.event),
                       style: Theme.of(context).textTheme.bodyText2!.copyWith(
                           color: model.hasError
                               ? Theme.of(context).errorColor

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
+  async: ^2.8.2
   collection: ^1.15.0
   dartx: ^0.8.0
   dbus: ^0.7.3

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
@@ -28,14 +28,8 @@ class MockJournalService extends _i1.Mock implements _i2.JournalService {
   }
 
   @override
-  _i3.Stream<String> get stream =>
-      (super.noSuchMethod(Invocation.getter(#stream),
+  _i3.Stream<String> start(String? id,
+          {_i2.JournalOutput? output = _i2.JournalOutput.short}) =>
+      (super.noSuchMethod(Invocation.method(#start, [id], {#output: output}),
           returnValue: _i3.Stream<String>.empty()) as _i3.Stream<String>);
-  @override
-  _i3.Future<void> start() => (super.noSuchMethod(Invocation.method(#start, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
-  @override
-  void stop() => super.noSuchMethod(Invocation.method(#stop, []),
-      returnValueForMissingStub: null);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -57,9 +57,8 @@ class MockInstallationSlidesModel extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#isInstalling), returnValue: false)
           as bool);
   @override
-  _i4.Stream<String> get journal =>
-      (super.noSuchMethod(Invocation.getter(#journal),
-          returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
+  _i4.Stream<String> get log => (super.noSuchMethod(Invocation.getter(#log),
+      returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
   @override
   bool get isLogVisible =>
       (super.noSuchMethod(Invocation.getter(#isLogVisible), returnValue: false)
@@ -122,14 +121,8 @@ class MockJournalService extends _i1.Mock implements _i7.JournalService {
   }
 
   @override
-  _i4.Stream<String> get stream =>
-      (super.noSuchMethod(Invocation.getter(#stream),
+  _i4.Stream<String> start(String? id,
+          {_i7.JournalOutput? output = _i7.JournalOutput.short}) =>
+      (super.noSuchMethod(Invocation.method(#start, [id], {#output: output}),
           returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
-  @override
-  _i4.Future<void> start() => (super.noSuchMethod(Invocation.method(#start, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
-  @override
-  void stop() => super.noSuchMethod(Invocation.method(#stop, []),
-      returnValueForMissingStub: null);
 }


### PR DESCRIPTION
Instead of showing "Copying files..." from the beginning to the end, show a more descriptive status based on subiquity's syslog events:

- "Copying files..."
- "Installing system..."
- "Configuring system..."

For logs, use the provided syslog ID instead of showing anything from the snap which would include e.g. previous runs if the installer had been restarted.