### PR TITLE
Partition edit: remove incorrect fallback format

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -316,7 +316,7 @@ class _PartitionFormatSelector extends StatelessWidget {
       valueListenable: partitionFormat,
       builder: (context, type, child) {
         return DropdownBuilder<PartitionFormat>(
-          selected: type ?? PartitionFormat.defaultValue,
+          selected: type,
           values: PartitionFormat.values,
           itemBuilder: (context, format, _) {
             return Text(


### PR DESCRIPTION
Don't claim that an unformatted existing partition has ext4 which is the default for new partitions.