### PR TITLE
Per entry point language blocklist

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'app.dart';
 import 'args_common.dart';
 import 'installing_state.dart';
+import 'services/language_fallback.dart';
 
 Future<void> main(List<String> args) async {
   final options = parseCommandLine(args, onPopulateOptions: (parser) {
@@ -31,6 +32,7 @@ Future<void> main(List<String> args) async {
   final subiquityClient = SubiquityClient();
   final subiquityMonitor = SubiquityStatusMonitor();
   registerService(UrlLauncher.new);
+  registerService(LanguageFallbackService.linux);
   await runWizardApp(
     ValueListenableBuilder<Variant?>(
       valueListenable: variant,

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -6,6 +6,7 @@ import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 import 'package:ubuntu_wsl_setup/services/tcp_socket.dart';
 
 import 'app.dart';
@@ -68,6 +69,7 @@ Future<void> main(List<String> args) async {
   final subiquityClient = SubiquityClient();
   final subiquityMonitor = SubiquityStatusMonitor();
   registerService(UrlLauncher.new);
+  registerService(LanguageFallbackService.win);
   registerService(() => JournalService(source: decode(stdin)));
 
   String? initialRoute;

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -5,6 +5,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
 import '../../l10n.dart';
 import '../../locale.dart';
@@ -17,8 +18,9 @@ class SelectLanguagePage extends StatefulWidget {
 
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();
+    final languageFallbackService = getService<LanguageFallbackService>();
     return ChangeNotifierProvider(
-      create: (_) => SelectLanguageModel(client),
+      create: (_) => SelectLanguageModel(client, languageFallbackService),
       child: const SelectLanguagePage(),
     );
   }

--- a/packages/ubuntu_wsl_setup/lib/services/language_fallback.dart
+++ b/packages/ubuntu_wsl_setup/lib/services/language_fallback.dart
@@ -1,0 +1,66 @@
+import 'dart:ui';
+
+import 'package:ubuntu_wsl_setup/l10n.dart';
+
+const kDefaultLocale = Locale('en', 'US');
+
+// Languages we won't invest in shipping fonts in our rootfs for just yet.
+// If users select one of those, we will submit it to Subiquity, but won't
+// update the UI.
+const _languagesLackingFontSupportForWslG = {
+  'am': 'Amharic',
+  'ar': 'Arabic',
+  'bn': 'Bangla',
+  'bo': 'Tibetan',
+  'dz': 'Dzongkha',
+  'fa': 'Persian',
+  'gu': 'Gujarati',
+  'he': 'Hebrew',
+  'hi': 'Hindi',
+  'ja': 'Japanese',
+  'ka': 'Georgian',
+  'km': 'Khmer',
+  'kn': 'Kannada',
+  'ko': 'Korean',
+  'lo': 'Lao',
+  'ml': 'Malayalam',
+  'mr': 'Marathi',
+  'my': 'Burmese',
+  'ne': 'Nepali',
+  'pa': 'Punjabi',
+  'si': 'Sinhala',
+  'ta': 'Tamil',
+  'te': 'Telugu',
+  'th': 'Thai',
+  'ug': 'Uyghur',
+  'vi': 'Vietnamese',
+  'zh': 'Chinese',
+};
+
+/// Provide fallback logic for operations sensitive to languages we don't support.
+class LanguageFallbackService {
+  const LanguageFallbackService(this._langblockList);
+  factory LanguageFallbackService.linux() =>
+      const LanguageFallbackService(_languagesLackingFontSupportForWslG);
+  factory LanguageFallbackService.win() => const LanguageFallbackService({});
+
+  /// Locales and their display names for which we should not translate the UI.
+  Map<String, String> get blocklist => _langblockList;
+  final Map<String, String> _langblockList;
+
+  String displayNameFor(LocalizedLanguage lang) {
+    if (blocklist.isEmpty) {
+      return lang.name;
+    }
+
+    final altName = blocklist[lang.locale.languageCode];
+    if (altName != null) {
+      return altName;
+    }
+
+    return lang.name;
+  }
+
+  bool isLocaleBlocked(Locale locale) =>
+      blocklist.isNotEmpty && null != blocklist[locale.languageCode];
+}

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -5,12 +5,14 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/app.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
 void main() {
   testWidgets('create an app instance', (tester) async {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en');
     registerMockService<SubiquityClient>(client);
+    registerService(LanguageFallbackService.linux);
 
     await tester.pumpWidget(
       const UbuntuWslSetupApp(variant: Variant.WSL_SETUP),

--- a/packages/ubuntu_wsl_setup/test/language_fallback_test.dart
+++ b/packages/ubuntu_wsl_setup/test/language_fallback_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wsl_setup/l10n.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
+
+void main() {
+  const locale = Locale('ja');
+  final l10n = lookupUbuntuLocalizations(locale);
+  final lang = LocalizedLanguage(l10n.languageName, locale);
+
+  test('blocked language', () {
+    const service = LanguageFallbackService({'ja': 'Japanese'});
+    expect(service.isLocaleBlocked(locale), isTrue);
+  });
+
+  test('non-blocked language', () {
+    const service = LanguageFallbackService({'pt': 'Portuguese'});
+    expect(service.isLocaleBlocked(locale), isFalse);
+  });
+  test('display name of blocked language', () {
+    const service = LanguageFallbackService({'ja': 'Japanese'});
+    expect(service.displayNameFor(lang), equals('Japanese'));
+  });
+
+  test('display name of non-blocked language', () {
+    const service = LanguageFallbackService({'pt': 'Portuguese'});
+    expect(service.displayNameFor(lang), isNot(equals('Japanese')));
+  });
+
+  test('linux', () {
+    final service = LanguageFallbackService.linux();
+    expect(service.isLocaleBlocked(locale), isTrue);
+    expect(service.displayNameFor(lang), equals('Japanese'));
+  });
+
+  test('windows', () {
+    final service = LanguageFallbackService.win();
+    expect(service.isLocaleBlocked(locale), isFalse);
+    expect(service.displayNameFor(lang), isNot(equals('Japanese')));
+  });
+}

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -5,18 +5,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wsl_setup/pages/select_language/select_language_model.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
 // ignore_for_file: type=lint
 
 void main() {
   test('load languages', () async {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService({}),
+    );
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
   });
 
   test('sort languages', () async {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService({}),
+    );
     await model.loadLanguages();
 
     final languages = List.generate(model.languageCount, model.language);
@@ -28,7 +35,10 @@ void main() {
   });
 
   test('select locale', () async {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService({}),
+    );
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
     expect(model.selectedLanguageIndex, equals(0));
@@ -50,7 +60,7 @@ void main() {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'fr_FR.UTF-8');
 
-    final model = SelectLanguageModel(client);
+    final model = SelectLanguageModel(client, LanguageFallbackService({}));
     final locale = await model.getServerLocale();
     verify(client.locale()).called(1);
     expect(locale, equals(Locale('fr', 'FR')));
@@ -58,13 +68,16 @@ void main() {
 
   test('set locale', () {
     final client = MockSubiquityClient();
-    final model = SelectLanguageModel(client);
+    final model = SelectLanguageModel(client, LanguageFallbackService({}));
     model.applyLocale(Locale('fr', 'CA'));
     verify(client.setLocale('fr_CA.UTF-8')).called(1);
   });
 
   test('selected language', () {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService({}),
+    );
 
     var wasNotified = false;
     model.addListener(() => wasNotified = true);
@@ -80,7 +93,10 @@ void main() {
   });
 
   test('uiLocale returns default for unsupported langs', () async {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService.linux(),
+    );
     await model.loadLanguages();
     final languages = List.generate(model.languageCount, model.language);
     expect(model.uiLocale(languages.indexOf('Uyghur')), kDefaultLocale);
@@ -88,7 +104,10 @@ void main() {
   });
 
   test('language wont return unsupported chars', () async {
-    final model = SelectLanguageModel(MockSubiquityClient());
+    final model = SelectLanguageModel(
+      MockSubiquityClient(),
+      LanguageFallbackService.linux(),
+    );
     await model.loadLanguages();
     final languages = List.generate(model.languageCount, model.language);
     expect(languages.any((e) => e.contains('\u{0626}')), isFalse);

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -11,6 +11,7 @@ import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/locale.dart';
 import 'package:ubuntu_wsl_setup/pages/select_language/select_language_model.dart';
 import 'package:ubuntu_wsl_setup/pages/select_language/select_language_page.dart';
+import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
 import 'select_language_page_test.mocks.dart';
 import 'test_utils.dart';
@@ -98,6 +99,7 @@ void main() {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en_US.UTF-8');
     registerMockService<SubiquityClient>(client);
+    registerService(LanguageFallbackService.linux);
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: localizationsDelegates,


### PR DESCRIPTION
In #829 we added a blocklist for languages we needed to avoid translating the UI into due lack of fonts in the root filesystem.
By moving the OOBE into Windows that restriction is now dependent on the entry point.

So, this PR moves out of the `SelectLanguageModel` the code that enforces that restriction into a service class that can be instantiated with different restrictions from `main()`.

Shall other restrictions related to language support arise, that class would be extended to accomodate those.