### PR TITLE
Fix keyboard layout selection

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -145,6 +145,13 @@ class SubiquityClient {
     await _receive('setKeyboard(${jsonEncode(setting.toJson())})', response);
   }
 
+  Future<void> setInputSource(KeyboardSetting setting) async {
+    final request = await _openUrl('POST', url('keyboard/input_source'));
+    request.write(jsonEncode(setting.toJson()));
+    final response = await request.close();
+    await _receive('setInputSource(${jsonEncode(setting.toJson())})', response);
+  }
+
   Future<String> proxy() async {
     final request = await _openUrl('GET', url('proxy'));
     final response = await request.close();

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -150,6 +150,11 @@ void main() {
       expect(kb.layouts, isNotEmpty);
     });
 
+    test('input source', () async {
+      const ks = KeyboardSetting(layout: 'fr', variant: 'latin9');
+      await expectLater(client.setInputSource(ks), completes);
+    });
+
     test('has rst', () async {
       var rst = await client.hasRst();
       expect(rst, isFalse);

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
@@ -51,7 +51,7 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
     _selectedVariantIndex = _selectedLayout!.variants.isNotEmpty ? variant : -1;
     log.info(
         'Selected ${_selectedLayout?.code} (${_selectedVariant?.code}) keyboard layout');
-    await applyKeyboardSettings();
+    await updateInputSource();
     notifyListeners();
   }
 
@@ -92,7 +92,7 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
     _selectedVariantIndex = index;
     log.info(
         'Selected ${_selectedLayout?.code} (${_selectedVariant?.code}) keyboard layout');
-    await applyKeyboardSettings();
+    await updateInputSource();
     notifyListeners();
   }
 
@@ -120,12 +120,23 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  /// Applies the selected keyboard layout and variant to the system.
-  Future<void> applyKeyboardSettings() {
+  /// Updates the system's input source to match the selected keyboard layout
+  /// and variant.
+  Future<void> updateInputSource() async {
+    if (_selectedLayout == null) return;
     final layout = _selectedLayout!.code;
     final variant = _selectedVariant?.code;
     final keyboard = KeyboardSetting(layout: layout, variant: variant ?? '');
-    log.info('Set $layout ($variant) as system keyboard layout');
+    log.info('Updated $layout ($variant) input source');
+    return _client.setInputSource(keyboard);
+  }
+
+  /// Saves the selected keyboard layout and variant.
+  Future<void> save() {
+    final layout = _selectedLayout!.code;
+    final variant = _selectedVariant?.code;
+    final keyboard = KeyboardSetting(layout: layout, variant: variant ?? '');
+    log.info('Saved $layout ($variant) keyboard layout');
     return _client.setKeyboard(keyboard);
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -40,6 +40,7 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
     model.init().then((_) {
       _scrollToLayout(model.selectedLayoutIndex);
       _scrollToVariant(model.selectedVariantIndex);
+      model.updateInputSource();
     });
 
     model.onLayoutSelected.listen(_scrollToLayout);
@@ -152,7 +153,7 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
         WizardAction.next(
           context,
           enabled: model.isValid,
-          onNext: model.applyKeyboardSettings,
+          onNext: model.save,
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
@@ -164,16 +164,18 @@ void main() {
       expect(wasNotified, isFalse);
     });
 
-    test('selection applies keyboard settings', () async {
+    test('selection updates input source', () async {
       await model.selectLayout(0);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'bar'))).called(1);
+      verify(client.setInputSource(KeyboardSetting(layout: 'bar'))).called(1);
 
       await model.selectLayout(1);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'baz')))
+      verify(client
+              .setInputSource(KeyboardSetting(layout: 'foo', variant: 'baz')))
           .called(1);
 
       await model.selectVariant(1);
-      verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'qux')))
+      verify(client
+              .setInputSource(KeyboardSetting(layout: 'foo', variant: 'qux')))
           .called(1);
     });
 
@@ -230,7 +232,7 @@ void main() {
     await model.selectVariant(1);
     reset(client);
 
-    await model.applyKeyboardSettings();
+    await model.save();
     verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'qux')))
         .called(1);
   });

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
@@ -55,10 +55,11 @@ void main() {
     );
   }
 
-  testWidgets('initializes the model', (tester) async {
+  testWidgets('initializes the model & input source', (tester) async {
     final model = buildModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
     verify(model.init()).called(1);
+    verify(model.updateInputSource()).called(1);
   });
 
   testWidgets('select keyboard layout', (tester) async {
@@ -156,7 +157,7 @@ void main() {
     await tester.tap(continueButton);
     await tester.pumpAndSettle();
 
-    verify(model.applyKeyboardSettings()).called(1);
+    verify(model.updateInputSource()).called(1);
     expect(find.text('Next page'), findsOneWidget);
   });
 
@@ -164,6 +165,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.keyboard()).thenAnswer((_) async =>
         KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
+    when(client.setInputSource(KeyboardSetting(layout: '')))
+        .thenAnswer((_) async {});
     registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(tester.buildApp(KeyboardLayoutPage.create));

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
@@ -97,8 +97,12 @@ class MockKeyboardLayoutModel extends _i1.Mock
       returnValue: _i3.Future<void>.value(),
       returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
   @override
-  _i3.Future<void> applyKeyboardSettings() => (super.noSuchMethod(
-      Invocation.method(#applyKeyboardSettings, []),
+  _i3.Future<void> updateInputSource() => (super.noSuchMethod(
+      Invocation.method(#updateInputSource, []),
+      returnValue: _i3.Future<void>.value(),
+      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  @override
+  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
       returnValue: _i3.Future<void>.value(),
       returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
   @override

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -232,6 +232,12 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
               returnValueForMissingStub: _i6.Future<void>.value())
           as _i6.Future<void>);
   @override
+  _i6.Future<void> setInputSource(_i3.KeyboardSetting? setting) =>
+      (super.noSuchMethod(Invocation.method(#setInputSource, [setting]),
+              returnValue: _i6.Future<void>.value(),
+              returnValueForMissingStub: _i6.Future<void>.value())
+          as _i6.Future<void>);
+  @override
   _i6.Future<String> proxy() =>
       (super.noSuchMethod(Invocation.method(#proxy, []),
           returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);


### PR DESCRIPTION
Make use of Subiquity's new input-source API (https://github.com/canonical/subiquity/pull/1388) to sync the system's input-source setting with the selection in the installer GUI.

![image](https://user-images.githubusercontent.com/140617/186192737-287c6ab4-6019-47bd-b6cf-2ba72167568d.png)