### PR TITLE
Restore the Choose your look page

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -74,6 +74,9 @@ void main() {
       identity: identity,
       password: 'password',
     );
+    await tester.pumpAndSettle();
+
+    await testChooseYourLookPage(tester);
     await tester.pump();
 
     await testInstallationSlidesPage(tester);
@@ -136,6 +139,9 @@ void main() {
       identity: IdentityData(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
     );
+    await tester.pumpAndSettle();
+
+    await testChooseYourLookPage(tester);
     await tester.pump();
 
     await testInstallationSlidesPage(tester);
@@ -186,6 +192,9 @@ void main() {
       identity: IdentityData(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
     );
+    await tester.pumpAndSettle();
+
+    await testChooseYourLookPage(tester);
     await tester.pump();
 
     await testInstallationSlidesPage(tester);
@@ -494,6 +503,23 @@ Future<void> testWhoAreYouPage(
       label: tester.lang.whoAreYouPageConfirmPasswordLabel,
       value: password,
     );
+  }
+  await tester.pumpAndSettle();
+
+  await tester.tapContinue();
+}
+
+Future<void> testChooseYourLookPage(
+  WidgetTester tester, {
+  Brightness? theme,
+}) async {
+  await expectPage(
+      tester, ChooseYourLookPage, (lang) => lang.chooseYourLookPageTitle);
+
+  if (theme != null) {
+    final asset = find.asset('assets/choose_your_look/${theme.name}-theme.png');
+    expect(asset, findsOneWidget);
+    await tester.tap(asset);
   }
   await tester.pumpAndSettle();
 

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -328,10 +328,8 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
         Routes.whereAreYou: const WizardRoute(
           builder: WhereAreYouPage.create,
         ),
-        Routes.whoAreYou: WizardRoute(
+        Routes.whoAreYou: const WizardRoute(
           builder: WhoAreYouPage.create,
-          // skip Routes.chooseYourLook (https://github.com/canonical/ubuntu-desktop-installer/issues/373)
-          onNext: (_) => Routes.installationSlides,
         ),
         // https://github.com/canonical/ubuntu-desktop-installer/issues/41
         // Routes.configureActiveDirectory: const WizardRoute(

--- a/packages/ubuntu_desktop_installer/lib/settings.dart
+++ b/packages/ubuntu_desktop_installer/lib/settings.dart
@@ -24,9 +24,11 @@ class Settings extends SafeChangeNotifier {
   void applyTheme(Brightness brightness) {
     switch (brightness) {
       case Brightness.dark:
+        _gsettings.set('gtk-theme', const DBusString('Yaru-dark'));
         _gsettings.set('color-scheme', const DBusString('prefer-dark'));
         break;
       case Brightness.light:
+        _gsettings.set('gtk-theme', const DBusString('Yaru'));
         _gsettings.set('color-scheme', const DBusString('prefer-light'));
         break;
     }


### PR DESCRIPTION
Flutter 3.3 has GNOME 42 color-scheme support (https://github.com/flutter/engine/pull/33100).