### PR TITLE
UDI: mark network configured after it actually has been configured

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -78,7 +78,7 @@ Future<void> runInstallerApp(
   registerService(() => DiskStorageService(subiquityClient));
   registerService(() => GeoService(sources: [geodata, geoname]));
   registerService(JournalService.new);
-  registerService(NetworkService.new);
+  registerService(() => NetworkService(subiquityClient));
   registerService(PowerService.new);
   registerService(TelemetryService.new);
   registerService(UdevService.new);
@@ -130,7 +130,6 @@ Future<void> runInstallerApp(
     'drivers',
     'mirror',
     'proxy',
-    'network',
     'ssh',
     'snaplist',
     'ubuntu_pro',

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_model.dart
@@ -98,6 +98,8 @@ class ConnectToInternetModel extends SafeChangeNotifier
     }
   }
 
+  Future<void> markConfigured() => _service.markConfigured();
+
   @override
   Future<void> cleanup() async {
     for (final model in _connectModels.values) {

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -106,8 +106,11 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
           context,
           enabled: model.isEnabled && !model.isConnecting && model.isConnected,
           visible: !model.isEnabled || !model.canConnect,
-          // suspend network activity when proceeding on the next page
-          onNext: model.cleanup,
+          onNext: () => Future.wait([
+            // suspend network activity when proceeding on the next page
+            model.cleanup(),
+            model.markConfigured(),
+          ]),
           // resume network activity if/when returning back to this page
           onBack: model.init,
         ),

--- a/packages/ubuntu_desktop_installer/lib/services/network_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/network_service.dart
@@ -1,10 +1,15 @@
 import 'package:dbus/dbus.dart';
 import 'package:nm/nm.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 
 export 'package:nm/nm.dart';
 
 /// Extends [NetworkManagerClient] with convenience properties and methods.
 class NetworkService extends NetworkManagerClient {
+  NetworkService(this._subiquity);
+
+  final SubiquityClient _subiquity;
+
   /// `true` if there is a full network connection.
   bool get isConnected {
     return connectivity == NetworkManagerConnectivityState.full;
@@ -35,4 +40,7 @@ class NetworkService extends NetworkManagerClient {
       },
     };
   }
+
+  /// Marks network configured.
+  Future<void> markConfigured() => _subiquity.markConfigured(['network']);
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_model_test.dart
@@ -242,4 +242,11 @@ void main() {
     model.selectConnectMode();
     expect(model.connectMode, equals(ConnectMode.wifi));
   });
+
+  test('mark network configured', () async {
+    final service = MockNetworkService();
+    final model = ConnectToInternetModel(service);
+    await model.markConfigured();
+    verify(service.markConfigured()).called(1);
+  });
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
@@ -260,4 +260,27 @@ void main() {
     expect(Provider.of<WifiModel>(context, listen: false), isNotNull);
     expect(Provider.of<HiddenWifiModel>(context, listen: false), isNotNull);
   });
+
+  testWidgets('mark network configured', (tester) async {
+    final model = MockConnectToInternetModel();
+    when(model.connectMode).thenReturn(ConnectMode.none);
+    when(model.isConnecting).thenReturn(false);
+    when(model.canConnect).thenReturn(false);
+    when(model.isConnected).thenReturn(true);
+    when(model.isEnabled).thenReturn(true);
+
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model: model)));
+    await tester.pumpAndSettle();
+
+    verify(model.init()).called(1);
+    verifyNever(model.cleanup());
+
+    final continueButton =
+        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+    expect(continueButton, findsOneWidget);
+    await tester.tap(continueButton);
+    await tester.pumpAndSettle();
+
+    verify(model.markConfigured()).called(1);
+  });
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
@@ -230,6 +230,11 @@ class MockConnectToInternetModel extends _i1.Mock
       returnValue: _i5.Future<void>.value(),
       returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
   @override
+  _i5.Future<void> markConfigured() => (super.noSuchMethod(
+      Invocation.method(#markConfigured, []),
+      returnValue: _i5.Future<void>.value(),
+      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
       Invocation.method(#cleanup, []),
       returnValue: _i5.Future<void>.value(),
@@ -788,6 +793,11 @@ class MockNetworkService extends _i1.Mock implements _i2.NetworkService {
               Invocation.method(#getWifiSettings, [], {#ssid: ssid}),
               returnValue: <String, Map<String, _i10.DBusValue>>{})
           as Map<String, Map<String, _i10.DBusValue>>);
+  @override
+  _i5.Future<void> markConfigured() => (super.noSuchMethod(
+      Invocation.method(#markConfigured, []),
+      returnValue: _i5.Future<void>.value(),
+      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
       Invocation.method(#connect, []),

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
@@ -450,6 +450,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
               returnValue: <String, Map<String, _i4.DBusValue>>{})
           as Map<String, Map<String, _i4.DBusValue>>);
   @override
+  _i3.Future<void> markConfigured() => (super.noSuchMethod(
+      Invocation.method(#markConfigured, []),
+      returnValue: _i3.Future<void>.value(),
+      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  @override
   _i3.Future<void> connect() => (super.noSuchMethod(
       Invocation.method(#connect, []),
       returnValue: _i3.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
@@ -553,6 +553,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
               returnValue: <String, Map<String, _i4.DBusValue>>{})
           as Map<String, Map<String, _i4.DBusValue>>);
   @override
+  _i3.Future<void> markConfigured() => (super.noSuchMethod(
+      Invocation.method(#markConfigured, []),
+      returnValue: _i3.Future<void>.value(),
+      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  @override
   _i3.Future<void> connect() => (super.noSuchMethod(
       Invocation.method(#connect, []),
       returnValue: _i3.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/network_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/network_service_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/services/network_service.dart';
+import 'package:ubuntu_test/mocks.dart';
 
 void main() {
   test('mandatory wifi settings', () async {
-    final service = NetworkService();
+    final service = NetworkService(MockSubiquityClient());
     final settings = service.getWifiSettings(ssid: 'foo bar');
 
     final connection = settings['connection'];
@@ -18,5 +20,12 @@ void main() {
     final security = settings['802-11-wireless-security'];
     expect(security, isNotNull);
     expect(security, contains('key-mgmt'));
+  });
+
+  test('mark network configured', () async {
+    final client = MockSubiquityClient();
+    final service = NetworkService(client);
+    await service.markConfigured();
+    verify(client.markConfigured(['network'])).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
@@ -553,6 +553,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
               returnValue: <String, Map<String, _i4.DBusValue>>{})
           as Map<String, Map<String, _i4.DBusValue>>);
   @override
+  _i3.Future<void> markConfigured() => (super.noSuchMethod(
+      Invocation.method(#markConfigured, []),
+      returnValue: _i3.Future<void>.value(),
+      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  @override
   _i3.Future<void> connect() => (super.noSuchMethod(
       Invocation.method(#connect, []),
       returnValue: _i3.Future<void>.value(),


### PR DESCRIPTION
Subiquity does a connectivity check when network is marked as configured. The result of the connectivity check affects e.g. how `/etc/apt/sources.list` is setup. Therefore, it's important to mark network configured when pressing continue on the "Connect to internet" page instead of on startup.

- https://github.com/canonical/subiquity/blob/main/subiquity/server/controllers/network.py#L284
- https://github.com/canonical/subiquity/blob/main/subiquity/server/apt.py#L210