### PR TITLE
UDI: restore the "Try Ubuntu" option

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -48,9 +48,8 @@ void main() {
     await testWelcomePage(tester, language: language);
     await tester.pumpAndSettle();
 
-    // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-    // await testTryOrInstallPage(tester, option: Option.installUbuntu);
-    // await tester.pumpAndSettle();
+    await testTryOrInstallPage(tester, option: Option.installUbuntu);
+    await tester.pumpAndSettle();
 
     await testKeyboardLayoutPage(tester, keyboard: keyboardLayout);
     await tester.pumpAndSettle();
@@ -108,9 +107,8 @@ void main() {
     await testWelcomePage(tester);
     await tester.pumpAndSettle();
 
-    // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-    // await testTryOrInstallPage(tester, option: Option.installUbuntu);
-    // await tester.pumpAndSettle();
+    await testTryOrInstallPage(tester, option: Option.installUbuntu);
+    await tester.pumpAndSettle();
 
     await testKeyboardLayoutPage(tester);
     await tester.pumpAndSettle();
@@ -159,9 +157,8 @@ void main() {
     await testWelcomePage(tester);
     await tester.pumpAndSettle();
 
-    // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-    // await testTryOrInstallPage(tester, option: Option.installUbuntu);
-    // await tester.pumpAndSettle();
+    await testTryOrInstallPage(tester, option: Option.installUbuntu);
+    await tester.pumpAndSettle();
 
     await testKeyboardLayoutPage(tester);
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -245,12 +245,8 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
     return Wizard(
       initialRoute: initialRoute ?? Routes.initial,
       routes: <String, WizardRoute>{
-        Routes.welcome: WizardRoute(
+        Routes.welcome: const WizardRoute(
           builder: WelcomePage.create,
-          // skip Routes.tryOrInstall (https://github.com/canonical/ubuntu-desktop-installer/issues/373)
-          // onNext: (_) => !service.hasRst ? Routes.keyboardLayout : null,
-          onNext: (_) =>
-              !service.hasRst ? Routes.keyboardLayout : Routes.turnOffRST,
         ),
         Routes.tryOrInstall: WizardRoute(
           builder: TryOrInstallPage.create,
@@ -258,8 +254,6 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
             switch (settings.arguments as Option?) {
               case Option.repairUbuntu:
                 return Routes.repairUbuntu;
-              case Option.tryUbuntu:
-                return Routes.tryUbuntu;
               default:
                 if (service.hasRst) return Routes.turnOffRST;
                 return Routes.keyboardLayout;

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -3,6 +3,7 @@ import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
 /// @internal
 final log = Logger('try_or_install');
@@ -65,4 +66,7 @@ class TryOrInstallModel extends SafeChangeNotifier {
       return 'https://ubuntu.com/download/desktop';
     }
   }
+
+  /// Lets the user try the Ubuntu desktop by closing the installer window.
+  Future<void> tryUbuntu() => closeWindow();
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -34,20 +34,22 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
     final flavor = Flavor.of(context);
     return WizardPage(
       title: Text(lang.tryOrInstallPageTitle),
-      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 150),
+      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 100),
       content: Row(
         children: [
+          // Expanded(
+          //   child: OptionCard(
+          //     selected: model.option == Option.repairUbuntu,
+          //     image: Image.asset('assets/try_or_install/repair-wrench.png'),
+          //     title: Text(lang.repairInstallation),
+          //     body: Text(lang.repairInstallationDescription),
+          //     onSelected: () => model.selectOption(Option.repairUbuntu),
+          //   ),
+          // ),
+          // const SizedBox(width: 20),
+          const Spacer(),
           Expanded(
-            child: OptionCard(
-              selected: model.option == Option.repairUbuntu,
-              image: Image.asset('assets/try_or_install/repair-wrench.png'),
-              title: Text(lang.repairInstallation),
-              body: Text(lang.repairInstallationDescription),
-              onSelected: () => model.selectOption(Option.repairUbuntu),
-            ),
-          ),
-          const SizedBox(width: 20),
-          Expanded(
+            flex: 2,
             child: OptionCard(
               selected: model.option == Option.tryUbuntu,
               image: Image.asset('assets/try_or_install/steering-wheel.png'),
@@ -58,6 +60,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
           ),
           const SizedBox(width: 20),
           Expanded(
+            flex: 2,
             child: OptionCard(
               selected: model.option == Option.installUbuntu,
               image: Image.asset('assets/try_or_install/hard-drive.png'),
@@ -66,6 +69,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
               onSelected: () => model.selectOption(Option.installUbuntu),
             ),
           ),
+          const Spacer(),
         ],
       ),
       footer: Html(
@@ -75,8 +79,15 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
       ),
       actions: <WizardAction>[
         WizardAction.back(context),
+        WizardAction.done(
+          context,
+          label: UbuntuLocalizations.of(context).continueAction,
+          visible: model.option == Option.tryUbuntu,
+          onDone: model.tryUbuntu,
+        ),
         WizardAction.next(
           context,
+          visible: model.option != Option.tryUbuntu,
           enabled: model.option != Option.none,
           arguments: model.option,
         ),

--- a/packages/ubuntu_desktop_installer/lib/routes.dart
+++ b/packages/ubuntu_desktop_installer/lib/routes.dart
@@ -5,7 +5,6 @@ abstract class Routes {
   static const turnOffRST = '/turnoffrst';
   static const keyboardLayout = '/keyboardlayout';
   static const repairUbuntu = '/repairubuntu';
-  static const tryUbuntu = '/tryubuntu';
   static const connectToInternet = '/connecttointernet';
   static const allocateDiskSpace = '/allocatediskspace';
   static const configureSecureBoot = '/configuresecureboot';

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_model_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:file/memory.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/pages/try_or_install/try_or_install_model.dart';
 
@@ -59,5 +60,21 @@ version,codename,series,created,release,eol,eol-server,eol-esm
     final fs = MemoryFileSystem.test();
     final url = model.releaseNotesURL(Locale('en'), fs: fs);
     expect(url, equals('https://ubuntu.com/download/desktop'));
+  });
+
+  test('try ubuntu', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    var windowClosed = false;
+    final methodChannel = MethodChannel('window_manager');
+    methodChannel.setMockMethodCallHandler((call) async {
+      expect(call.method, equals('close'));
+      windowClosed = true;
+    });
+
+    final model = TryOrInstallModel();
+
+    await model.tryUbuntu();
+    expect(windowClosed, isTrue);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
@@ -14,6 +14,7 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
+import '../test_utils.dart';
 import 'try_or_install_page_test.mocks.dart';
 
 // ignore_for_file: type=lint
@@ -42,8 +43,6 @@ void main() {
                 switch (model.option) {
                   case Option.repairUbuntu:
                     return Routes.repairUbuntu;
-                  case Option.tryUbuntu:
-                    return Routes.tryUbuntu;
                   case Option.installUbuntu:
                     return Routes.keyboardLayout;
                   default:
@@ -53,9 +52,6 @@ void main() {
             ),
             Routes.repairUbuntu: WizardRoute(
               builder: (context) => Text(Routes.repairUbuntu),
-            ),
-            Routes.tryUbuntu: WizardRoute(
-              builder: (context) => Text(Routes.tryUbuntu),
             ),
             Routes.keyboardLayout: WizardRoute(
               builder: (context) => Text(Routes.keyboardLayout),
@@ -110,29 +106,40 @@ void main() {
         true);
   });
 
-  final options = {
-    Routes.repairUbuntu: 'Repair installation',
-    Routes.tryUbuntu: 'Try Ubuntu',
-    Routes.keyboardLayout: 'Install Ubuntu'
-  };
-  options.forEach((key, value) {
-    testWidgets('selecting option "$value"', (tester) async {
-      await setUpApp(tester);
+  testWidgets('install ubuntu', (tester) async {
+    await setUpApp(tester);
 
-      final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
-      expect(continueButton, findsOneWidget);
+    final option =
+        find.widgetWithText(OptionCard, tester.lang.installUbuntu('Ubuntu'));
+    expect(option, findsOneWidget);
 
-      final option = find.widgetWithText(OptionCard, value);
-      expect(option, findsOneWidget);
+    await tester.tap(option);
+    await tester.pump();
 
-      await tester.tap(option);
-      await tester.pump();
+    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    expect(continueButton, findsOneWidget);
 
-      await tester.tap(continueButton);
-      await tester.pumpAndSettle();
+    await tester.tap(continueButton);
+    await tester.pumpAndSettle();
 
-      expect(find.byType(TryOrInstallPage), findsNothing);
-      expect(find.text(key), findsOneWidget);
-    });
+    expect(find.byType(TryOrInstallPage), findsNothing);
+    expect(find.text(Routes.keyboardLayout), findsOneWidget);
+  });
+
+  testWidgets('try ubuntu', (tester) async {
+    await setUpApp(tester);
+
+    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    expect(continueButton, findsOneWidget);
+    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+
+    final option =
+        find.widgetWithText(OptionCard, tester.lang.tryUbuntu('Ubuntu'));
+    expect(option, findsOneWidget);
+
+    await tester.tap(option);
+    await tester.pump();
+
+    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
   });
 }


### PR DESCRIPTION
It simply closes the window which now does the right thing (restores the dock etc.) in the live session. We don't have repair functionality available at this point, so the "Repair Ubuntu" option was commented out. Also, there's no such route as "/tryubuntu" so it was cleaned up. :)

![Screenshot from 2022-08-26 17-11-22](https://user-images.githubusercontent.com/140617/186941326-9350e18d-d28a-4085-846e-e9ed5d5f64f4.png)
