### PR TITLE
[WSL] remove mark_configured(filesystem)

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -60,5 +60,4 @@ Future<void> main(List<String> args) async {
       });
     }
   });
-  await subiquityClient.markConfigured(['filesystem']);
 }

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -108,5 +108,4 @@ Future<void> main(List<String> args) async {
       });
     }
   });
-  await subiquityClient.markConfigured(['filesystem']);
 }


### PR DESCRIPTION
The WSL OOBE does not use the filesystem endpoint. The call was added in #644 but is no longer necessary.