### PR TITLE
Partition edit dialog: fix the "format" checkbox 

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -198,9 +198,14 @@ Future<void> showEditPartitionDialog(
             ],
             <Widget>[
               const SizedBox.shrink(),
-              _PartitionWipeCheckbox(
-                canWipe: partition.canWipe,
-                wipe: partitionWipe,
+              ValueListenableBuilder(
+                valueListenable: partitionFormat,
+                builder: (context, value, child) {
+                  return _PartitionWipeCheckbox(
+                    canWipe: partitionFormat.value?.canWipe == true,
+                    wipe: partitionWipe,
+                  );
+                },
               ),
             ],
             <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -5,6 +5,7 @@ import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 
 import '../../services.dart';
+import 'storage_types.dart';
 
 /// The default mount points for auto-completion.
 const kDefaultMountPoints = <String>[
@@ -18,63 +19,6 @@ const kDefaultMountPoints = <String>[
   '/opt',
   '/usr/local',
 ];
-
-/// Available partition formats.
-class PartitionFormat {
-  const PartitionFormat._(this.type);
-
-  /// The type of the partition format (e.g. 'ext4').
-  final String type;
-
-  @override
-  String toString() => type;
-
-  static const btrfs = PartitionFormat._('btrfs');
-  static const ext2 = PartitionFormat._('ext2');
-  static const ext3 = PartitionFormat._('ext3');
-  static const ext4 = PartitionFormat._('ext4');
-  static const fat = PartitionFormat._('fat');
-  static const fat12 = PartitionFormat._('fat12');
-  static const fat16 = PartitionFormat._('fat16');
-  static const fat32 = PartitionFormat._('fat32');
-  static const iso9660 = PartitionFormat._('iso9660');
-  static const vfat = PartitionFormat._('vfat');
-  static const jfs = PartitionFormat._('jfs');
-  static const ntfs = PartitionFormat._('ntfs');
-  static const reiserfs = PartitionFormat._('reiserfs');
-  static const swap = PartitionFormat._('swap');
-  static const xfs = PartitionFormat._('xfs');
-  static const zfsroot = PartitionFormat._('zfsroot');
-
-  /// The default partition format.
-  static PartitionFormat get defaultValue => _formats['ext4']!;
-
-  /// Converts a Partition object to a PartitionFormat enum value.
-  static PartitionFormat? fromPartition(Partition partition) =>
-      _formats[partition.format];
-
-  /// Available partition formats.
-  static List<PartitionFormat> get values => _formats.values.toList();
-
-  static const _formats = <String, PartitionFormat>{
-    'btrfs': btrfs,
-    'ext2': ext2,
-    'ext3': ext3,
-    'ext4': ext4,
-    'fat': fat,
-    'fat12': fat12,
-    'fat16': fat16,
-    'fat32': fat32,
-    'iso9660': iso9660,
-    'vfat': vfat,
-    'jfs': jfs,
-    'ntfs': ntfs,
-    'reiserfs': reiserfs,
-    'swap': swap,
-    'xfs': xfs,
-    'zfsroot': zfsroot,
-  };
-}
 
 /// The location of the partition within to the available space around.
 enum PartitionLocation {

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -9,7 +9,7 @@ extension DiskExtension on Disk {
 }
 
 extension PartitionExtension on Partition {
-  bool get canWipe => mount != null;
+  bool get canWipe => PartitionFormat.fromPartition(this)?.canWipe == true;
   bool get isWiped => wipe == 'superblock';
   String get prettySize => filesize(size ?? 0);
 }
@@ -20,6 +20,9 @@ class PartitionFormat {
 
   /// The type of the partition format (e.g. 'ext4').
   final String type;
+
+  /// Whether a partition with this format can be wiped.
+  bool get canWipe => type != 'swap';
 
   @override
   String toString() => type;

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -13,3 +13,60 @@ extension PartitionExtension on Partition {
   bool get isWiped => wipe == 'superblock';
   String get prettySize => filesize(size ?? 0);
 }
+
+/// Available partition formats.
+class PartitionFormat {
+  const PartitionFormat._(this.type);
+
+  /// The type of the partition format (e.g. 'ext4').
+  final String type;
+
+  @override
+  String toString() => type;
+
+  static const btrfs = PartitionFormat._('btrfs');
+  static const ext2 = PartitionFormat._('ext2');
+  static const ext3 = PartitionFormat._('ext3');
+  static const ext4 = PartitionFormat._('ext4');
+  static const fat = PartitionFormat._('fat');
+  static const fat12 = PartitionFormat._('fat12');
+  static const fat16 = PartitionFormat._('fat16');
+  static const fat32 = PartitionFormat._('fat32');
+  static const iso9660 = PartitionFormat._('iso9660');
+  static const vfat = PartitionFormat._('vfat');
+  static const jfs = PartitionFormat._('jfs');
+  static const ntfs = PartitionFormat._('ntfs');
+  static const reiserfs = PartitionFormat._('reiserfs');
+  static const swap = PartitionFormat._('swap');
+  static const xfs = PartitionFormat._('xfs');
+  static const zfsroot = PartitionFormat._('zfsroot');
+
+  /// The default partition format.
+  static PartitionFormat get defaultValue => _formats['ext4']!;
+
+  /// Converts a Partition object to a PartitionFormat enum value.
+  static PartitionFormat? fromPartition(Partition partition) =>
+      _formats[partition.format];
+
+  /// Available partition formats.
+  static List<PartitionFormat> get values => _formats.values.toList();
+
+  static const _formats = <String, PartitionFormat>{
+    'btrfs': btrfs,
+    'ext2': ext2,
+    'ext3': ext3,
+    'ext4': ext4,
+    'fat': fat,
+    'fat12': fat12,
+    'fat16': fat16,
+    'fat32': fat32,
+    'iso9660': iso9660,
+    'vfat': vfat,
+    'jfs': jfs,
+    'ntfs': ntfs,
+    'reiserfs': reiserfs,
+    'swap': swap,
+    'xfs': xfs,
+    'zfsroot': zfsroot,
+  };
+}

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
@@ -186,8 +186,8 @@ void main() {
         testDisk(partitions: [Gap(offset: 0, size: 1, usable: GapUsable.YES)]);
     final fullDisk = testDisk();
     final normalDisk = emptyDisk.copyWith(partitions: [Partition()]);
-    final mountedPartition =
-        emptyDisk.copyWith(partitions: [Partition(mount: '/')]);
+    final formattedPartition =
+        emptyDisk.copyWith(partitions: [Partition(format: 'ext4')]);
 
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer(
@@ -195,7 +195,7 @@ void main() {
         emptyDisk,
         fullDisk,
         normalDisk,
-        mountedPartition,
+        formattedPartition,
       ],
     );
 
@@ -255,7 +255,7 @@ void main() {
     expect(model.canReformatDisk, isFalse);
 
     model.selectStorage(3, 0);
-    expect(model.selectedDisk, equals(mountedPartition));
+    expect(model.selectedDisk, equals(formattedPartition));
     expect(model.selectedPartition, isNotNull);
     expect(model.selectedPartition!.canWipe, isTrue);
     expect(model.selectedGap, isNull);

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -28,7 +28,7 @@ final testDisks = <Disk>[
         number: 1,
         size: 11,
         mount: '/mnt/1',
-        format: 'ext',
+        format: 'btrfs',
         preserve: true,
       ),
       Partition(

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
@@ -4,12 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:ui' as _i6;
+import 'dart:ui' as _i7;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/subiquity_client.dart' as _i4;
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_model.dart'
     as _i3;
+import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_types.dart'
+    as _i6;
 import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 // ignore_for_file: type=lint
@@ -89,7 +91,7 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
           returnValue: false) as bool);
   @override
   _i5.Future<void> addPartition(_i4.Disk? disk, _i4.Gap? gap,
-          {int? size, _i3.PartitionFormat? format, String? mount}) =>
+          {int? size, _i6.PartitionFormat? format, String? mount}) =>
       (super.noSuchMethod(
               Invocation.method(#addPartition, [disk, gap],
                   {#size: size, #format: format, #mount: mount}),
@@ -98,7 +100,7 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
           as _i5.Future<void>);
   @override
   _i5.Future<void> editPartition(_i4.Disk? disk, _i4.Partition? partition,
-          {_i3.PartitionFormat? format, bool? wipe, String? mount}) =>
+          {_i6.PartitionFormat? format, bool? wipe, String? mount}) =>
       (super.noSuchMethod(
               Invocation.method(#editPartition, [disk, partition],
                   {#format: format, #wipe: wipe, #mount: mount}),
@@ -153,11 +155,11 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
       super.noSuchMethod(Invocation.method(#notifyListeners, []),
           returnValueForMissingStub: null);
   @override
-  void addListener(_i6.VoidCallback? listener) =>
+  void addListener(_i7.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#addListener, [listener]),
           returnValueForMissingStub: null);
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
+  void removeListener(_i7.VoidCallback? listener) =>
       super.noSuchMethod(Invocation.method(#removeListener, [listener]),
           returnValueForMissingStub: null);
 }


### PR DESCRIPTION
Whether the "Format" checkbox is enabled should not be bound to `Partition.canWipe` which is the original partition object without modifications. Bind it to `PartitionFormat.canWipe` instead and use the currently selected value from the edit dialog.