### PR TITLE
[WSL] Adds an opt-out option for installing language packs

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -448,6 +448,22 @@ class SubiquityClient {
     } on HttpException catch (_) {}
   }
 
+  Future<WSLSetupOptions> wslSetupOptions() async {
+    final request = await _openUrl('GET', url('wslsetupoptions'));
+    final response = await request.close();
+
+    final json = await _receiveJson('wslsetupoptions()', response);
+    return WSLSetupOptions.fromJson(json);
+  }
+
+  Future<void> setWslSetupOptions(WSLSetupOptions options) async {
+    final request = await _openUrl('POST', url('wslsetupoptions'));
+    request.write(jsonEncode(options.toJson()));
+    final response = await request.close();
+    await _receive(
+        'setWslSetupOptions(${jsonEncode(options.toJson())})', response);
+  }
+
   Future<WSLConfigurationBase> wslConfigurationBase() async {
     final request = await _openUrl('GET', url('wslconfbase'));
     final response = await request.close();

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -776,3 +776,13 @@ class WSLConfigurationAdvanced with _$WSLConfigurationAdvanced {
   factory WSLConfigurationAdvanced.fromJson(Map<String, dynamic> json) =>
       _$WSLConfigurationAdvancedFromJson(json);
 }
+
+@freezed
+class WSLSetupOptions with _$WSLSetupOptions {
+  const factory WSLSetupOptions({
+    @Default(true) bool installLanguageSupportPackages,
+  }) = _WSLSetupOptions;
+
+  factory WSLSetupOptions.fromJson(Map<String, dynamic> json) =>
+      _$WSLSetupOptionsFromJson(json);
+}

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -10943,3 +10943,141 @@ abstract class _WSLConfigurationAdvanced implements WSLConfigurationAdvanced {
   _$$_WSLConfigurationAdvancedCopyWith<_$_WSLConfigurationAdvanced>
       get copyWith => throw _privateConstructorUsedError;
 }
+
+WSLSetupOptions _$WSLSetupOptionsFromJson(Map<String, dynamic> json) {
+  return _WSLSetupOptions.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WSLSetupOptions {
+  bool get installLanguageSupportPackages => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WSLSetupOptionsCopyWith<WSLSetupOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WSLSetupOptionsCopyWith<$Res> {
+  factory $WSLSetupOptionsCopyWith(
+          WSLSetupOptions value, $Res Function(WSLSetupOptions) then) =
+      _$WSLSetupOptionsCopyWithImpl<$Res>;
+  $Res call({bool installLanguageSupportPackages});
+}
+
+/// @nodoc
+class _$WSLSetupOptionsCopyWithImpl<$Res>
+    implements $WSLSetupOptionsCopyWith<$Res> {
+  _$WSLSetupOptionsCopyWithImpl(this._value, this._then);
+
+  final WSLSetupOptions _value;
+  // ignore: unused_field
+  final $Res Function(WSLSetupOptions) _then;
+
+  @override
+  $Res call({
+    Object? installLanguageSupportPackages = freezed,
+  }) {
+    return _then(_value.copyWith(
+      installLanguageSupportPackages: installLanguageSupportPackages == freezed
+          ? _value.installLanguageSupportPackages
+          : installLanguageSupportPackages // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_WSLSetupOptionsCopyWith<$Res>
+    implements $WSLSetupOptionsCopyWith<$Res> {
+  factory _$$_WSLSetupOptionsCopyWith(
+          _$_WSLSetupOptions value, $Res Function(_$_WSLSetupOptions) then) =
+      __$$_WSLSetupOptionsCopyWithImpl<$Res>;
+  @override
+  $Res call({bool installLanguageSupportPackages});
+}
+
+/// @nodoc
+class __$$_WSLSetupOptionsCopyWithImpl<$Res>
+    extends _$WSLSetupOptionsCopyWithImpl<$Res>
+    implements _$$_WSLSetupOptionsCopyWith<$Res> {
+  __$$_WSLSetupOptionsCopyWithImpl(
+      _$_WSLSetupOptions _value, $Res Function(_$_WSLSetupOptions) _then)
+      : super(_value, (v) => _then(v as _$_WSLSetupOptions));
+
+  @override
+  _$_WSLSetupOptions get _value => super._value as _$_WSLSetupOptions;
+
+  @override
+  $Res call({
+    Object? installLanguageSupportPackages = freezed,
+  }) {
+    return _then(_$_WSLSetupOptions(
+      installLanguageSupportPackages: installLanguageSupportPackages == freezed
+          ? _value.installLanguageSupportPackages
+          : installLanguageSupportPackages // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_WSLSetupOptions implements _WSLSetupOptions {
+  const _$_WSLSetupOptions({this.installLanguageSupportPackages = true});
+
+  factory _$_WSLSetupOptions.fromJson(Map<String, dynamic> json) =>
+      _$$_WSLSetupOptionsFromJson(json);
+
+  @override
+  @JsonKey()
+  final bool installLanguageSupportPackages;
+
+  @override
+  String toString() {
+    return 'WSLSetupOptions(installLanguageSupportPackages: $installLanguageSupportPackages)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_WSLSetupOptions &&
+            const DeepCollectionEquality().equals(
+                other.installLanguageSupportPackages,
+                installLanguageSupportPackages));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(installLanguageSupportPackages));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_WSLSetupOptionsCopyWith<_$_WSLSetupOptions> get copyWith =>
+      __$$_WSLSetupOptionsCopyWithImpl<_$_WSLSetupOptions>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WSLSetupOptionsToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WSLSetupOptions implements WSLSetupOptions {
+  const factory _WSLSetupOptions({final bool installLanguageSupportPackages}) =
+      _$_WSLSetupOptions;
+
+  factory _WSLSetupOptions.fromJson(Map<String, dynamic> json) =
+      _$_WSLSetupOptions.fromJson;
+
+  @override
+  bool get installLanguageSupportPackages;
+  @override
+  @JsonKey(ignore: true)
+  _$$_WSLSetupOptionsCopyWith<_$_WSLSetupOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -1017,3 +1017,15 @@ Map<String, dynamic> _$$_WSLConfigurationAdvancedToJson(
       'interop_appendwindowspath': instance.interopAppendwindowspath,
       'systemd_enabled': instance.systemdEnabled,
     };
+
+_$_WSLSetupOptions _$$_WSLSetupOptionsFromJson(Map<String, dynamic> json) =>
+    _$_WSLSetupOptions(
+      installLanguageSupportPackages:
+          json['install_language_support_packages'] as bool? ?? true,
+    );
+
+Map<String, dynamic> _$$_WSLSetupOptionsToJson(_$_WSLSetupOptions instance) =>
+    <String, dynamic>{
+      'install_language_support_packages':
+          instance.installLanguageSupportPackages,
+    };

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -523,6 +523,26 @@ void main() {
       expect(await client.variant(), equals(Variant.WSL_CONFIGURATION));
     });
 
+    test('wslsetupoptions', () async {
+      var newConf = WSLSetupOptions(
+        installLanguageSupportPackages: false,
+      );
+
+      await client.setWslSetupOptions(newConf);
+
+      var conf = await client.wslSetupOptions();
+      expect(conf.installLanguageSupportPackages, false);
+
+      newConf = WSLSetupOptions(
+        installLanguageSupportPackages: true,
+      );
+
+      await client.setWslSetupOptions(newConf);
+
+      conf = await client.wslSetupOptions();
+      expect(conf.installLanguageSupportPackages, true);
+    });
+
     test('wslconfbase', () async {
       var newConf = WSLConfigurationBase(
         automountRoot: '/mnt/',

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -79,25 +79,31 @@ class _FakeStorageResponseV2_9 extends _i1.SmartFake
       : super(parent, parentInvocation);
 }
 
-class _FakeWSLConfigurationBase_10 extends _i1.SmartFake
+class _FakeWSLSetupOptions_10 extends _i1.SmartFake
+    implements _i3.WSLSetupOptions {
+  _FakeWSLSetupOptions_10(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeWSLConfigurationBase_11 extends _i1.SmartFake
     implements _i3.WSLConfigurationBase {
-  _FakeWSLConfigurationBase_10(Object parent, Invocation parentInvocation)
+  _FakeWSLConfigurationBase_11(Object parent, Invocation parentInvocation)
       : super(parent, parentInvocation);
 }
 
-class _FakeWSLConfigurationAdvanced_11 extends _i1.SmartFake
+class _FakeWSLConfigurationAdvanced_12 extends _i1.SmartFake
     implements _i3.WSLConfigurationAdvanced {
-  _FakeWSLConfigurationAdvanced_11(Object parent, Invocation parentInvocation)
+  _FakeWSLConfigurationAdvanced_12(Object parent, Invocation parentInvocation)
       : super(parent, parentInvocation);
 }
 
-class _FakeAnyStep_12 extends _i1.SmartFake implements _i3.AnyStep {
-  _FakeAnyStep_12(Object parent, Invocation parentInvocation)
+class _FakeAnyStep_13 extends _i1.SmartFake implements _i3.AnyStep {
+  _FakeAnyStep_13(Object parent, Invocation parentInvocation)
       : super(parent, parentInvocation);
 }
 
-class _FakeEndpoint_13 extends _i1.SmartFake implements _i4.Endpoint {
-  _FakeEndpoint_13(Object parent, Invocation parentInvocation)
+class _FakeEndpoint_14 extends _i1.SmartFake implements _i4.Endpoint {
+  _FakeEndpoint_14(Object parent, Invocation parentInvocation)
       : super(parent, parentInvocation);
 }
 
@@ -433,10 +439,23 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
       returnValue: _i6.Future<void>.value(),
       returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
   @override
+  _i6.Future<_i3.WSLSetupOptions> wslSetupOptions() =>
+      (super.noSuchMethod(Invocation.method(#wslSetupOptions, []),
+              returnValue: _i6.Future<_i3.WSLSetupOptions>.value(
+                  _FakeWSLSetupOptions_10(
+                      this, Invocation.method(#wslSetupOptions, []))))
+          as _i6.Future<_i3.WSLSetupOptions>);
+  @override
+  _i6.Future<void> setWslSetupOptions(_i3.WSLSetupOptions? options) =>
+      (super.noSuchMethod(Invocation.method(#setWslSetupOptions, [options]),
+              returnValue: _i6.Future<void>.value(),
+              returnValueForMissingStub: _i6.Future<void>.value())
+          as _i6.Future<void>);
+  @override
   _i6.Future<_i3.WSLConfigurationBase> wslConfigurationBase() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationBase, []),
               returnValue: _i6.Future<_i3.WSLConfigurationBase>.value(
-                  _FakeWSLConfigurationBase_10(
+                  _FakeWSLConfigurationBase_11(
                       this, Invocation.method(#wslConfigurationBase, []))))
           as _i6.Future<_i3.WSLConfigurationBase>);
   @override
@@ -449,7 +468,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   _i6.Future<_i3.WSLConfigurationAdvanced> wslConfigurationAdvanced() =>
       (super.noSuchMethod(Invocation.method(#wslConfigurationAdvanced, []),
               returnValue: _i6.Future<_i3.WSLConfigurationAdvanced>.value(
-                  _FakeWSLConfigurationAdvanced_11(
+                  _FakeWSLConfigurationAdvanced_12(
                       this, Invocation.method(#wslConfigurationAdvanced, []))))
           as _i6.Future<_i3.WSLConfigurationAdvanced>);
   @override
@@ -463,7 +482,7 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   @override
   _i6.Future<_i3.AnyStep> getKeyboardStep([String? step = r'0']) =>
       (super.noSuchMethod(Invocation.method(#getKeyboardStep, [step]),
-              returnValue: _i6.Future<_i3.AnyStep>.value(_FakeAnyStep_12(
+              returnValue: _i6.Future<_i3.AnyStep>.value(_FakeAnyStep_13(
                   this, Invocation.method(#getKeyboardStep, [step]))))
           as _i6.Future<_i3.AnyStep>);
 }
@@ -482,7 +501,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
           returnValueForMissingStub: null);
   @override
   _i4.Endpoint get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint),
-          returnValue: _FakeEndpoint_13(this, Invocation.getter(#endpoint)))
+          returnValue: _FakeEndpoint_14(this, Invocation.getter(#endpoint)))
       as _i4.Endpoint);
   @override
   _i6.Future<_i4.Endpoint> start(
@@ -490,7 +509,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
       (super.noSuchMethod(
               Invocation.method(
                   #start, [], {#args: args, #environment: environment}),
-              returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_13(this,
+              returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_14(this,
                   Invocation.method(#start, [], {#args: args, #environment: environment}))))
           as _i6.Future<_i4.Endpoint>);
   @override

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -116,6 +116,12 @@ Future<void> testSelectYourLanguagePage(
   }
   await tester.pumpAndSettle();
 
+  // For now toggling this check box won't cause any noticeable behavior change in dry-run.
+  await tester.toggleCheckbox(
+    label: tester.lang.installLangPacksTitle(language ?? ''),
+    value: false,
+  );
+
   await tester.tapContinue();
 }
 

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_en.arb
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_en.arb
@@ -14,6 +14,16 @@
   "@setupButton": {},
   "selectLanguageTitle": "Select your language",
   "@selectLanguageTitle": {},
+  "installLangPacksTitle": "Install packages for better {lang} language support",
+  "@installLangPacksTitle": {
+      "type": "text",
+      "placeholders": {
+          "lang": {
+            "type": "String"
+          }
+      }
+  },
+  "installLangPacksSubtitle": "Not recommended for slow connections.",
   "profileSetupTitle": "Profile setup",
   "@profileSetupTitle": {},
   "profileSetupHeader": "Please create a default UNIX user account. For more information visit: <a href=\"https://aka.ms/wslusers\">https://aka.ms/wslusers</a>",

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
@@ -277,6 +277,18 @@ abstract class AppLocalizations {
   /// **'Select your language'**
   String get selectLanguageTitle;
 
+  /// No description provided for @installLangPacksTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Install packages for better {lang} language support'**
+  String installLangPacksTitle(String lang);
+
+  /// No description provided for @installLangPacksSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Not recommended for slow connections.'**
+  String get installLangPacksSubtitle;
+
   /// No description provided for @profileSetupTitle.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
@@ -29,6 +29,14 @@ class AppLocalizationsAm extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
@@ -29,6 +29,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
@@ -29,6 +29,14 @@ class AppLocalizationsBe extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
@@ -29,6 +29,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
@@ -29,6 +29,14 @@ class AppLocalizationsBn extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
@@ -29,6 +29,14 @@ class AppLocalizationsBo extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
@@ -29,6 +29,14 @@ class AppLocalizationsBs extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
@@ -29,6 +29,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
@@ -29,6 +29,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get selectLanguageTitle => 'Vyberte svůj jazyk';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Nastavení profilu';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
@@ -29,6 +29,14 @@ class AppLocalizationsCy extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
@@ -29,6 +29,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get selectLanguageTitle => 'Vælg dit sprog';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profil setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
@@ -29,6 +29,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectLanguageTitle => 'Wählen Sie Ihre Sprache aus';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profileinrichtung';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
@@ -29,6 +29,14 @@ class AppLocalizationsDz extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEo extends AppLocalizations {
   String get selectLanguageTitle => 'Elektu vian lingvon';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Agordi profilon';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get selectLanguageTitle => 'Seleccione su idioma';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Preparación del perfil';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
@@ -29,6 +29,14 @@ class AppLocalizationsEu extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
@@ -29,6 +29,14 @@ class AppLocalizationsFa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
@@ -29,6 +29,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String get selectLanguageTitle => 'Valitse kieli';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profiilin luonti';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
@@ -29,6 +29,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectLanguageTitle => 'Sélectionnez votre langue';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Configuration du profil';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
@@ -29,6 +29,14 @@ class AppLocalizationsGa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
@@ -29,6 +29,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
@@ -29,6 +29,14 @@ class AppLocalizationsGu extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
@@ -29,6 +29,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get selectLanguageTitle => 'נא לבחור את השפה שלך';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'הקמת פרופיל';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
@@ -29,6 +29,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get selectLanguageTitle => 'अपनी भाषा का चयन करें';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'प्रोफ़ाइल सेटअप';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
@@ -29,6 +29,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
@@ -29,6 +29,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get selectLanguageTitle => 'Válassza ki a nyelvet';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profil beállítása';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
@@ -29,6 +29,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
@@ -29,6 +29,14 @@ class AppLocalizationsIs extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
@@ -29,6 +29,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get selectLanguageTitle => 'Seleziona la tua lingua';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
@@ -29,6 +29,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get selectLanguageTitle => 'あなたが使う言語を選んでください';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'プロファイルの設定';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKm extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get selectLanguageTitle => '언어를 선택하십시오';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => '프로필 구성';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
@@ -29,6 +29,14 @@ class AppLocalizationsKu extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
@@ -29,6 +29,14 @@ class AppLocalizationsLo extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
@@ -29,6 +29,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get selectLanguageTitle => 'Pasirinkite kalbą';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profilio sąranka';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
@@ -29,6 +29,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
@@ -29,6 +29,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
@@ -29,6 +29,14 @@ class AppLocalizationsMl extends AppLocalizations {
   String get selectLanguageTitle => 'നിങ്ങളുടെ ഭാഷ തിരഞ്ഞെടുക്കുക';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'പ്രൊഫൈൽ സജ്ജീകരണം';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
@@ -29,6 +29,14 @@ class AppLocalizationsMr extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
@@ -29,6 +29,14 @@ class AppLocalizationsMy extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
@@ -29,6 +29,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get selectLanguageTitle => 'Velg ditt språk';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profil innstillinger';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
@@ -29,6 +29,14 @@ class AppLocalizationsNe extends AppLocalizations {
   String get selectLanguageTitle => 'आफ्नो भाषा चयन गर्नुहोस्';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'प्रोफाइल सेटअप';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
@@ -29,6 +29,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
@@ -29,6 +29,14 @@ class AppLocalizationsNn extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
@@ -29,6 +29,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
@@ -29,6 +29,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get selectLanguageTitle => 'Wybierz swój język';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Konfiguracja profilu';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
@@ -29,6 +29,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get selectLanguageTitle => 'Selecione seu idioma';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Configurar perfil';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
@@ -29,6 +29,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
@@ -29,6 +29,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get selectLanguageTitle => 'Выбрать язык';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Настройка профиля';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSe extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
@@ -29,6 +29,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get selectLanguageTitle => 'Välj ditt språk';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Ställ in profil';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTg extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
@@ -29,6 +29,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get selectLanguageTitle => 'Dil seçiniz';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profil kurulumu';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
@@ -29,6 +29,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get selectLanguageTitle => 'Select your language';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Profile setup';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
@@ -29,6 +29,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get selectLanguageTitle => 'Оберіть мову';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Налаштування профілю';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
@@ -29,6 +29,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get selectLanguageTitle => 'chọn ngôn ngữ của bạn';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => 'Thiết lập hồ sơ';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
@@ -29,6 +29,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get selectLanguageTitle => '选择您的语言';
 
   @override
+  String installLangPacksTitle(String lang) {
+    return 'Install packages for better $lang language support';
+  }
+
+  @override
+  String get installLangPacksSubtitle => 'Not recommended for slow connections.';
+
+  @override
   String get profileSetupTitle => '配置文件设置';
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
@@ -15,6 +15,16 @@ class SelectLanguageModel extends SafeChangeNotifier {
 
   final SubiquityClient _client;
   final LanguageFallbackService _languageFallback;
+  bool _installLangPacks = true;
+  bool get installLanguagePacks => _installLangPacks;
+
+  void setInstallLanguagePacks(bool value) {
+    if (value == _installLangPacks) {
+      return;
+    }
+    _installLangPacks = value;
+    notifyListeners();
+  }
 
   /// The index of the currently selected language.
   int get selectedLanguageIndex => _selectedLanguageIndex;
@@ -23,6 +33,21 @@ class SelectLanguageModel extends SafeChangeNotifier {
     if (_selectedLanguageIndex == index) return;
     _selectedLanguageIndex = index;
     notifyListeners();
+  }
+
+  /// Fetches the install language support packages from the server.
+  Future<void> getInstallLanguagePacks() {
+    return _client.wslSetupOptions().then((options) {
+      _installLangPacks = options.installLanguageSupportPackages;
+      notifyListeners();
+    });
+  }
+
+  /// Commits the currrent setup options to the server.
+  Future<void> applyInstallLanguagePacks() {
+    return _client.setWslSetupOptions(
+      WSLSetupOptions(installLanguageSupportPackages: _installLangPacks),
+    );
   }
 
   var _languages = <LocalizedLanguage>[];

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
@@ -85,8 +85,12 @@ class SelectLanguageModel extends SafeChangeNotifier {
   /// Returns the name of the language at the given [index].
   /// To avoid issues with the UI in WSL, the international name of
   /// the language is returned in case it's blacklisted.
-  String language(int index) =>
-      _languageFallback.displayNameFor(_languages[index]);
+  String language(int index) {
+    if (_languages.isEmpty) {
+      return '';
+    }
+    return _languageFallback.displayNameFor(_languages[index]);
+  }
 
   /// Selects the given [locale].
   void selectLocale(Locale locale) {

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -4,6 +4,7 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
@@ -48,6 +49,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
             duration: const Duration(milliseconds: 1));
       });
     });
+    model.getInstallLanguagePacks();
   }
 
   @override
@@ -62,33 +64,49 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     final model = Provider.of<SelectLanguageModel>(context);
     return WizardPage(
       title: Text(lang.selectLanguageTitle),
-      content: FractionallySizedBox(
-        widthFactor: 0.5,
-        child: RoundedListView.builder(
-          controller: _languageListScrollController,
-          itemCount: model.languageCount,
-          itemBuilder: (context, index) {
-            return AutoScrollTag(
-              index: index,
-              key: ValueKey(index),
-              controller: _languageListScrollController,
-              child: ListTile(
-                title: Text(model.language(index)),
-                selected: index == model.selectedLanguageIndex,
-                onTap: () {
-                  model.selectedLanguageIndex = index;
-                  InheritedLocale.apply(context, model.uiLocale(index));
+      content: Column(
+        children: [
+          Flexible(
+            child: FractionallySizedBox(
+              widthFactor: 0.5,
+              child: RoundedListView.builder(
+                controller: _languageListScrollController,
+                itemCount: model.languageCount,
+                itemBuilder: (context, index) {
+                  return AutoScrollTag(
+                    index: index,
+                    key: ValueKey(index),
+                    controller: _languageListScrollController,
+                    child: ListTile(
+                      title: Text(model.language(index)),
+                      selected: index == model.selectedLanguageIndex,
+                      onTap: () {
+                        model.selectedLanguageIndex = index;
+                        InheritedLocale.apply(context, model.uiLocale(index));
+                      },
+                    ),
+                  );
                 },
               ),
-            );
-          },
-        ),
+            ),
+          ),
+          const SizedBox(height: kContentSpacing),
+          CheckButton(
+            contentPadding: kContentPadding,
+            title: Text(lang.installLangPacksTitle(
+                model.language(model.selectedLanguageIndex))),
+            subtitle: Text(lang.installLangPacksSubtitle),
+            value: model.installLanguagePacks,
+            onChanged: (value) => model.setInstallLanguagePacks(value!),
+          ),
+        ],
       ),
       actions: [
         WizardAction.back(context),
         WizardAction.next(
           context,
           onNext: () {
+            model.applyInstallLanguagePacks();
             model.applyLocale(model.locale(model.selectedLanguageIndex));
           },
         ),

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -11,6 +11,9 @@ void main() {
   testWidgets('create an app instance', (tester) async {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en');
+    when(client.wslSetupOptions()).thenAnswer(
+      (_) async => const WSLSetupOptions(installLanguageSupportPackages: false),
+    );
     registerMockService<SubiquityClient>(client);
     registerService(LanguageFallbackService.linux);
 

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:diacritic/diacritic.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wsl_setup/pages/select_language/select_language_model.dart';
 import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
@@ -112,5 +113,27 @@ void main() {
     final languages = List.generate(model.languageCount, model.language);
     expect(languages.any((e) => e.contains('\u{0626}')), isFalse);
     expect(languages.any((e) => e.contains('\u{0DC3}')), isFalse);
+  });
+
+  test('get install lang packs option', () async {
+    final client = MockSubiquityClient();
+    when(client.wslSetupOptions()).thenAnswer(
+      (_) async => WSLSetupOptions(installLanguageSupportPackages: false),
+    );
+
+    final model = SelectLanguageModel(client, LanguageFallbackService({}));
+    await model.getInstallLanguagePacks();
+    verify(client.wslSetupOptions()).called(1);
+    expect(model.installLanguagePacks, isFalse);
+  });
+
+  test('set install lang packs option', () {
+    final client = MockSubiquityClient();
+    final model = SelectLanguageModel(client, LanguageFallbackService({}));
+    model.setInstallLanguagePacks(false);
+    model.applyInstallLanguagePacks();
+    verify(client.setWslSetupOptions(
+      WSLSetupOptions(installLanguageSupportPackages: false),
+    )).called(1);
   });
 }

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -36,6 +36,7 @@ void main() {
     when(model.uiLocale(2)).thenReturn(Locale('de_DE'));
     when(model.selectedLanguageIndex).thenReturn(1);
     when(model.getServerLocale()).thenAnswer((_) async => Locale('fr', 'FR'));
+    when(model.installLanguagePacks).thenReturn(true);
     return model;
   }
 
@@ -98,6 +99,9 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.locale()).thenAnswer((_) async => 'en_US.UTF-8');
+    when(client.wslSetupOptions()).thenAnswer(
+      (_) async => WSLSetupOptions(installLanguageSupportPackages: true),
+    );
     registerMockService<SubiquityClient>(client);
     registerService(LanguageFallbackService.linux);
 

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
@@ -36,6 +36,10 @@ class MockSelectLanguageModel extends _i1.Mock
   }
 
   @override
+  bool get installLanguagePacks =>
+      (super.noSuchMethod(Invocation.getter(#installLanguagePacks),
+          returnValue: false) as bool);
+  @override
   int get selectedLanguageIndex =>
       (super.noSuchMethod(Invocation.getter(#selectedLanguageIndex),
           returnValue: 0) as int);
@@ -55,6 +59,20 @@ class MockSelectLanguageModel extends _i1.Mock
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+  @override
+  void setInstallLanguagePacks(bool? value) =>
+      super.noSuchMethod(Invocation.method(#setInstallLanguagePacks, [value]),
+          returnValueForMissingStub: null);
+  @override
+  _i4.Future<void> getInstallLanguagePacks() => (super.noSuchMethod(
+      Invocation.method(#getInstallLanguagePacks, []),
+      returnValue: _i4.Future<void>.value(),
+      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  @override
+  _i4.Future<void> applyInstallLanguagePacks() => (super.noSuchMethod(
+      Invocation.method(#applyInstallLanguagePacks, []),
+      returnValue: _i4.Future<void>.value(),
+      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
   @override
   _i4.Future<void> loadLanguages() => (super.noSuchMethod(
       Invocation.method(#loadLanguages, []),


### PR DESCRIPTION
The motivation is outlined in #1073.

This closes #1073 by:

- Updating Subiquity to 68b92f10229560cc34f780500da5a6f8955909f5 to explore the new endpoint;
- Adding a new type for the new entry point;
- Adding a check box below the list of languages in the "Select your language" page and
- Updating the relevant tests.

Since the new endpoint is optional even for the setup workflow, it's still possible to start the wizard at a different page, as demonstrated in the second integration test case.
Also this was made somewhat flexible, so in the future it will be easy to move this flag to a new page if the need for more options with related semantics raise.