### PR TITLE
Snap: pin Flutter version to 3.0.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,7 +124,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-branch: stable
+    source-tag: 3.0.5
     source-depth: 1
     plugin: nil
     override-build: |
@@ -157,8 +157,6 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/etc/subiquity
       cp -r snap/local/postinst.d $SNAPCRAFT_PART_INSTALL/etc/subiquity
       cd packages/ubuntu_desktop_installer
-      flutter channel stable
-      flutter upgrade
       flutter doctor
       flutter pub get
       flutter build linux --release -v
@@ -175,8 +173,6 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/libexec
       cd packages/ubuntu_wsl_setup
-      flutter channel stable
-      flutter upgrade
       flutter doctor
       flutter pub get
       flutter build linux --release -v


### PR DESCRIPTION
Flutter 3.3 has severe raster cache rendering issues due to fractional
translation i.e. removal of pixel snapping:
https://github.com/jpnurmi/flutter_raster_cache_bug