### PR TITLE
Post-pone guided storage choice

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -286,7 +286,7 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
           onNext: (settings) {
             if (settings.arguments == InstallationType.manual) {
               return Routes.allocateDiskSpace;
-            } else if (!service.hasGuidedChoice) {
+            } else if (service.guidedTarget == null) {
               if (settings.arguments == InstallationType.erase) {
                 return Routes.selectGuidedStorage;
               } else if (settings.arguments == InstallationType.alongside) {

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
@@ -124,9 +124,9 @@ class InstallAlongsideModel extends SafeChangeNotifier {
   }
 
   /// Saves the guided storage selection.
-  Future<void> save() {
+  Future<void> save() async {
     final storage = selectedStorage!.copyWith(newSize: currentSize);
-    return _service.setGuidedStorage(storage).then(_updateStorage);
+    _service.guidedTarget = storage;
   }
 
   /// Resets the guided storage selection.

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -124,10 +124,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
     _diskService.useLvm = advancedFeature == AdvancedFeature.lvm;
 
     // automatically pre-select a guided storage target if possible
-    final target = preselectTarget(installationType);
-    if (target != null) {
-      await _diskService.setGuidedStorage(target);
-    }
+    _diskService.guidedTarget = preselectTarget(installationType);
 
     // All possible values for the partition method
     // were extracted from Ubiquity's ubi-partman.py

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -59,9 +59,7 @@ class SelectGuidedStorageModel extends SafeChangeNotifier {
 
   /// Saves the guided storage selection.
   Future<void> saveGuidedStorage() async {
-    return _service
-        .setGuidedStorage(selectedStorage!)
-        .then(_updateGuidedStorage);
+    _service.guidedTarget = selectedStorage;
   }
 
   /// Resets the guided storage selection.

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -31,6 +31,9 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
 
   /// Initializes the model.
   Future<void> init() async {
+    if (_service.guidedTarget != null) {
+      await _service.setGuidedStorage();
+    }
     _originals = await _service.getOriginalStorage().then((disks) =>
         Map.fromEntries(disks.map((d) => MapEntry(
             d.sysname, d.partitions.whereType<Partition>().toList()))));

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -41,10 +41,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -77,6 +73,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -100,12 +100,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.dart
@@ -59,8 +59,6 @@ void main() {
     when(service.getStorage()).thenAnswer((_) async => [disk]);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: [resize1, resize2]));
-    when(service.setGuidedStorage(any)).thenAnswer(
-        (_) async => testGuidedStorageResponse(possible: [resize1, resize2]));
 
     final model = InstallAlongsideModel(service);
     await model.init();
@@ -70,7 +68,8 @@ void main() {
     expect(model.selectedIndex, 1);
 
     await model.save();
-    verify(service.setGuidedStorage(resize2.copyWith(newSize: 200))).called(1);
+    verify(service.guidedTarget = resize2.copyWith(newSize: 200)).called(1);
+    verifyNever(service.setGuidedStorage());
   });
 
   test('reset storage', () async {

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -41,10 +41,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -77,6 +73,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -100,12 +100,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -133,21 +133,19 @@ void main() {
 
   test('single reformat target', () async {
     final reformat = GuidedStorageTargetReformat(diskId: '');
-    final choice = GuidedChoiceV2(target: reformat);
 
     final service = MockDiskStorageService();
     when(service.hasEncryption).thenReturn(false);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: [reformat]));
-    when(service.setGuidedStorage(reformat))
-        .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final model = InstallationTypeModel(service, MockTelemetryService());
 
     await model.init();
 
     await model.save();
-    verify(service.setGuidedStorage(reformat)).called(1);
+    verify(service.guidedTarget = reformat).called(1);
+    verifyNever(service.setGuidedStorage());
   });
 
   test('can install alongside', () async {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -45,10 +45,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -81,6 +77,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -104,12 +104,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -41,10 +41,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -77,6 +73,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -100,12 +100,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.dart
@@ -33,19 +33,19 @@ void main() {
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: testTargets));
-    when(service.setGuidedStorage(any)).thenAnswer(
-        (_) async => testGuidedStorageResponse(possible: testTargets));
 
     final model = SelectGuidedStorageModel(service);
     await model.loadGuidedStorage();
 
     model.selectStorage(0);
     await model.saveGuidedStorage();
-    verify(service.setGuidedStorage(testTargets[0])).called(1);
+    verify(service.guidedTarget = testTargets[0]).called(1);
+    verifyNever(service.setGuidedStorage());
 
     model.selectStorage(1);
     await model.saveGuidedStorage();
-    verify(service.setGuidedStorage(testTargets[1])).called(1);
+    verify(service.guidedTarget = testTargets[1]).called(1);
+    verifyNever(service.setGuidedStorage());
   });
 
   test('get storage', () async {

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -41,10 +41,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -77,6 +73,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -100,12 +100,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -41,7 +41,8 @@ void main() {
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final service = DiskStorageService(client);
-    await service.setGuidedStorage(target);
+    service.guidedTarget = target;
+    await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
   });
 
@@ -54,7 +55,8 @@ void main() {
     final service = DiskStorageService(client);
     service.useLvm = true;
 
-    await service.setGuidedStorage(target);
+    service.guidedTarget = target;
+    await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
   });
 
@@ -247,7 +249,7 @@ void main() {
     expect(service.existingOS, equals([win10, ubuntu2110, ubuntu2204]));
   });
 
-  test('guided choice', () async {
+  test('guided target', () async {
     final target = GuidedStorageTargetReformat(diskId: testDisks.last.id);
     final choice = GuidedChoiceV2(target: target, useLvm: false);
     when(client.setGuidedStorageV2(choice))
@@ -256,13 +258,14 @@ void main() {
         .thenAnswer((_) async => testStorageResponse());
 
     final service = DiskStorageService(client);
-    expect(service.hasGuidedChoice, isFalse);
+    expect(service.guidedTarget, isNull);
 
-    await service.setGuidedStorage(target);
-    expect(service.hasGuidedChoice, isTrue);
+    service.guidedTarget = target;
+    expect(service.guidedTarget, target);
+    await service.setGuidedStorage();
 
     await service.resetStorage();
-    expect(service.hasGuidedChoice, isFalse);
+    expect(service.guidedTarget, isNull);
   });
 
   test('has enough disk space', () async {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -41,10 +41,6 @@ class MockDiskStorageService extends _i1.Mock
       (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
           returnValue: false) as bool);
   @override
-  bool get hasGuidedChoice => (super
-          .noSuchMethod(Invocation.getter(#hasGuidedChoice), returnValue: false)
-      as bool);
-  @override
   bool get needRoot =>
       (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
           as bool);
@@ -77,6 +73,10 @@ class MockDiskStorageService extends _i1.Mock
       super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
           returnValueForMissingStub: null);
   @override
+  set guidedTarget(_i2.GuidedStorageTarget? target) =>
+      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
+          returnValueForMissingStub: null);
+  @override
   int get installMinimumSize => (super
           .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
       as int);
@@ -100,12 +100,11 @@ class MockDiskStorageService extends _i1.Mock
                       this, Invocation.method(#getGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage(
-          _i2.GuidedStorageTarget? target) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, [target]),
+  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
+      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
               returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
                   _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, [target]))))
+                      this, Invocation.method(#setGuidedStorage, []))))
           as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() =>

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -174,6 +174,7 @@ void main() {
     registerMockService<SubiquityClient>(client);
 
     final service = MockDiskStorageService();
+    when(service.guidedTarget).thenReturn(null);
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
     registerMockService<DiskStorageService>(service);


### PR DESCRIPTION
A guided storage choice consists of multiple attributes:

- which target to use
- whether to use LVM
- whether to use encryption
- security key

These inputs are collected from multiple pages:

- _Installation type_
- _Select guided storage_
- _Install X alongside Y_
- _Choose security key_

The problem is that Subiquity only allows setting guided storage once.
That is, we cannot "update" the existing guided storage selection as we
go but we need to wait until all attributes have been gathered and then
apply it all in one go. The best place for this is when arriving at the
_Write changes to disk_ page where the storage changes are summarized.

These changes were extracted from #951.