### PR TITLE
CI: unpin Flutter version.

### DIFF
--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -31,7 +31,6 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.0.x'
 
     - name: Build Windows Target
       working-directory: packages\ubuntu_wsl_setup\

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -21,7 +21,6 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.0.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -68,7 +67,6 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.0.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -93,7 +91,6 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.0.x'
 
     - name: Install Melos
       run: flutter pub global activate melos

--- a/packages/subiquity_client/test/status_monitor_test.mocks.dart
+++ b/packages/subiquity_client/test/status_monitor_test.mocks.dart
@@ -21,46 +21,86 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeDuration_0 extends _i1.SmartFake implements Duration {
-  _FakeDuration_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeDuration_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeHttpClientRequest_1 extends _i1.SmartFake
     implements _i2.HttpClientRequest {
-  _FakeHttpClientRequest_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeHttpClientRequest_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeUri_2 extends _i1.SmartFake implements Uri {
-  _FakeUri_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUri_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeHttpHeaders_3 extends _i1.SmartFake implements _i2.HttpHeaders {
-  _FakeHttpHeaders_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeHttpHeaders_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeHttpClientResponse_4 extends _i1.SmartFake
     implements _i2.HttpClientResponse {
-  _FakeHttpClientResponse_4(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeHttpClientResponse_4(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeEncoding_5 extends _i1.SmartFake implements _i3.Encoding {
-  _FakeEncoding_5(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEncoding_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeSocket_6 extends _i1.SmartFake implements _i2.Socket {
-  _FakeSocket_6(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSocket_6(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeStreamSubscription_7<T> extends _i1.SmartFake
     implements _i4.StreamSubscription<T> {
-  _FakeStreamSubscription_7(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeStreamSubscription_7(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [HttpClient].
@@ -73,184 +113,493 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
 
   @override
   Duration get idleTimeout => (super.noSuchMethod(
+        Invocation.getter(#idleTimeout),
+        returnValue: _FakeDuration_0(
+          this,
           Invocation.getter(#idleTimeout),
-          returnValue: _FakeDuration_0(this, Invocation.getter(#idleTimeout)))
-      as Duration);
+        ),
+      ) as Duration);
   @override
-  set idleTimeout(Duration? _idleTimeout) =>
-      super.noSuchMethod(Invocation.setter(#idleTimeout, _idleTimeout),
-          returnValueForMissingStub: null);
+  set idleTimeout(Duration? _idleTimeout) => super.noSuchMethod(
+        Invocation.setter(
+          #idleTimeout,
+          _idleTimeout,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   set connectionTimeout(Duration? _connectionTimeout) => super.noSuchMethod(
-      Invocation.setter(#connectionTimeout, _connectionTimeout),
-      returnValueForMissingStub: null);
+        Invocation.setter(
+          #connectionTimeout,
+          _connectionTimeout,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   set maxConnectionsPerHost(int? _maxConnectionsPerHost) => super.noSuchMethod(
-      Invocation.setter(#maxConnectionsPerHost, _maxConnectionsPerHost),
-      returnValueForMissingStub: null);
+        Invocation.setter(
+          #maxConnectionsPerHost,
+          _maxConnectionsPerHost,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get autoUncompress => (super
-          .noSuchMethod(Invocation.getter(#autoUncompress), returnValue: false)
-      as bool);
+  bool get autoUncompress => (super.noSuchMethod(
+        Invocation.getter(#autoUncompress),
+        returnValue: false,
+      ) as bool);
   @override
-  set autoUncompress(bool? _autoUncompress) =>
-      super.noSuchMethod(Invocation.setter(#autoUncompress, _autoUncompress),
-          returnValueForMissingStub: null);
+  set autoUncompress(bool? _autoUncompress) => super.noSuchMethod(
+        Invocation.setter(
+          #autoUncompress,
+          _autoUncompress,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set userAgent(String? _userAgent) =>
-      super.noSuchMethod(Invocation.setter(#userAgent, _userAgent),
-          returnValueForMissingStub: null);
+  set userAgent(String? _userAgent) => super.noSuchMethod(
+        Invocation.setter(
+          #userAgent,
+          _userAgent,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set authenticate(_i4.Future<bool> Function(Uri, String, String?)? f) =>
-      super.noSuchMethod(Invocation.setter(#authenticate, f),
-          returnValueForMissingStub: null);
+  set authenticate(
+          _i4.Future<bool> Function(
+    Uri,
+    String,
+    String?,
+  )?
+              f) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #authenticate,
+          f,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   set connectionFactory(
           _i4.Future<_i2.ConnectionTask<_i2.Socket>> Function(
-                  Uri, String?, int?)?
+    Uri,
+    String?,
+    int?,
+  )?
               f) =>
-      super.noSuchMethod(Invocation.setter(#connectionFactory, f),
-          returnValueForMissingStub: null);
+      super.noSuchMethod(
+        Invocation.setter(
+          #connectionFactory,
+          f,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set findProxy(String Function(Uri)? f) =>
-      super.noSuchMethod(Invocation.setter(#findProxy, f),
-          returnValueForMissingStub: null);
+  set findProxy(String Function(Uri)? f) => super.noSuchMethod(
+        Invocation.setter(
+          #findProxy,
+          f,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   set authenticateProxy(
-          _i4.Future<bool> Function(String, int, String, String?)? f) =>
-      super.noSuchMethod(Invocation.setter(#authenticateProxy, f),
-          returnValueForMissingStub: null);
+          _i4.Future<bool> Function(
+    String,
+    int,
+    String,
+    String?,
+  )?
+              f) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #authenticateProxy,
+          f,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   set badCertificateCallback(
-          bool Function(_i2.X509Certificate, String, int)? callback) =>
-      super.noSuchMethod(Invocation.setter(#badCertificateCallback, callback),
-          returnValueForMissingStub: null);
+          bool Function(
+    _i2.X509Certificate,
+    String,
+    int,
+  )?
+              callback) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #badCertificateCallback,
+          callback,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set keyLog(dynamic Function(String)? callback) =>
-      super.noSuchMethod(Invocation.setter(#keyLog, callback),
-          returnValueForMissingStub: null);
+  set keyLog(dynamic Function(String)? callback) => super.noSuchMethod(
+        Invocation.setter(
+          #keyLog,
+          callback,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<_i2.HttpClientRequest> open(
-          String? method, String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#open, [method, host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(this,
-                      Invocation.method(#open, [method, host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? method,
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #open,
+          [
+            method,
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #open,
+            [
+              method,
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> openUrl(String? method, Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#openUrl, [method, url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#openUrl, [method, url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> openUrl(
+    String? method,
+    Uri? url,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #openUrl,
+          [
+            method,
+            url,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #openUrl,
+            [
+              method,
+              url,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> get(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#get, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#get, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #get,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #get,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> getUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#getUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#getUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #getUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #getUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> post(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#post, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#post, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #post,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #post,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> postUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#postUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#postUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #postUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #postUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> put(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#put, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#put, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #put,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #put,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> putUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#putUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#putUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #putUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #putUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> delete(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#delete, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#delete, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #delete,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> deleteUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#deleteUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#deleteUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #deleteUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #deleteUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> patch(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#patch, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#patch, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #patch,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #patch,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> patchUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#patchUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#patchUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #patchUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #patchUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   _i4.Future<_i2.HttpClientRequest> head(
-          String? host, int? port, String? path) =>
-      (super.noSuchMethod(Invocation.method(#head, [host, port, path]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#head, [host, port, path]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+    String? host,
+    int? port,
+    String? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #head,
+          [
+            host,
+            port,
+            path,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #head,
+            [
+              host,
+              port,
+              path,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
-  _i4.Future<_i2.HttpClientRequest> headUrl(Uri? url) =>
-      (super.noSuchMethod(Invocation.method(#headUrl, [url]),
-              returnValue: _i4.Future<_i2.HttpClientRequest>.value(
-                  _FakeHttpClientRequest_1(
-                      this, Invocation.method(#headUrl, [url]))))
-          as _i4.Future<_i2.HttpClientRequest>);
+  _i4.Future<_i2.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
+        Invocation.method(
+          #headUrl,
+          [url],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientRequest>.value(_FakeHttpClientRequest_1(
+          this,
+          Invocation.method(
+            #headUrl,
+            [url],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientRequest>);
   @override
   void addCredentials(
-          Uri? url, String? realm, _i2.HttpClientCredentials? credentials) =>
+    Uri? url,
+    String? realm,
+    _i2.HttpClientCredentials? credentials,
+  ) =>
       super.noSuchMethod(
-          Invocation.method(#addCredentials, [url, realm, credentials]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #addCredentials,
+          [
+            url,
+            realm,
+            credentials,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addProxyCredentials(String? host, int? port, String? realm,
-          _i2.HttpClientCredentials? credentials) =>
+  void addProxyCredentials(
+    String? host,
+    int? port,
+    String? realm,
+    _i2.HttpClientCredentials? credentials,
+  ) =>
       super.noSuchMethod(
-          Invocation.method(
-              #addProxyCredentials, [host, port, realm, credentials]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #addProxyCredentials,
+          [
+            host,
+            port,
+            realm,
+            credentials,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void close({bool? force = false}) =>
-      super.noSuchMethod(Invocation.method(#close, [], {#force: force}),
-          returnValueForMissingStub: null);
+  void close({bool? force = false}) => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+          {#force: force},
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [HttpClientRequest].
@@ -262,117 +611,230 @@ class MockHttpClientRequest extends _i1.Mock implements _i2.HttpClientRequest {
   }
 
   @override
-  bool get persistentConnection =>
-      (super.noSuchMethod(Invocation.getter(#persistentConnection),
-          returnValue: false) as bool);
+  bool get persistentConnection => (super.noSuchMethod(
+        Invocation.getter(#persistentConnection),
+        returnValue: false,
+      ) as bool);
   @override
   set persistentConnection(bool? _persistentConnection) => super.noSuchMethod(
-      Invocation.setter(#persistentConnection, _persistentConnection),
-      returnValueForMissingStub: null);
+        Invocation.setter(
+          #persistentConnection,
+          _persistentConnection,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get followRedirects => (super
-          .noSuchMethod(Invocation.getter(#followRedirects), returnValue: false)
-      as bool);
+  bool get followRedirects => (super.noSuchMethod(
+        Invocation.getter(#followRedirects),
+        returnValue: false,
+      ) as bool);
   @override
-  set followRedirects(bool? _followRedirects) =>
-      super.noSuchMethod(Invocation.setter(#followRedirects, _followRedirects),
-          returnValueForMissingStub: null);
+  set followRedirects(bool? _followRedirects) => super.noSuchMethod(
+        Invocation.setter(
+          #followRedirects,
+          _followRedirects,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get maxRedirects =>
-      (super.noSuchMethod(Invocation.getter(#maxRedirects), returnValue: 0)
-          as int);
+  int get maxRedirects => (super.noSuchMethod(
+        Invocation.getter(#maxRedirects),
+        returnValue: 0,
+      ) as int);
   @override
-  set maxRedirects(int? _maxRedirects) =>
-      super.noSuchMethod(Invocation.setter(#maxRedirects, _maxRedirects),
-          returnValueForMissingStub: null);
+  set maxRedirects(int? _maxRedirects) => super.noSuchMethod(
+        Invocation.setter(
+          #maxRedirects,
+          _maxRedirects,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get contentLength =>
-      (super.noSuchMethod(Invocation.getter(#contentLength), returnValue: 0)
-          as int);
+  int get contentLength => (super.noSuchMethod(
+        Invocation.getter(#contentLength),
+        returnValue: 0,
+      ) as int);
   @override
-  set contentLength(int? _contentLength) =>
-      super.noSuchMethod(Invocation.setter(#contentLength, _contentLength),
-          returnValueForMissingStub: null);
+  set contentLength(int? _contentLength) => super.noSuchMethod(
+        Invocation.setter(
+          #contentLength,
+          _contentLength,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get bufferOutput =>
-      (super.noSuchMethod(Invocation.getter(#bufferOutput), returnValue: false)
-          as bool);
+  bool get bufferOutput => (super.noSuchMethod(
+        Invocation.getter(#bufferOutput),
+        returnValue: false,
+      ) as bool);
   @override
-  set bufferOutput(bool? _bufferOutput) =>
-      super.noSuchMethod(Invocation.setter(#bufferOutput, _bufferOutput),
-          returnValueForMissingStub: null);
+  set bufferOutput(bool? _bufferOutput) => super.noSuchMethod(
+        Invocation.setter(
+          #bufferOutput,
+          _bufferOutput,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get method =>
-      (super.noSuchMethod(Invocation.getter(#method), returnValue: '')
-          as String);
+  String get method => (super.noSuchMethod(
+        Invocation.getter(#method),
+        returnValue: '',
+      ) as String);
   @override
-  Uri get uri => (super.noSuchMethod(Invocation.getter(#uri),
-      returnValue: _FakeUri_2(this, Invocation.getter(#uri))) as Uri);
+  Uri get uri => (super.noSuchMethod(
+        Invocation.getter(#uri),
+        returnValue: _FakeUri_2(
+          this,
+          Invocation.getter(#uri),
+        ),
+      ) as Uri);
   @override
   _i2.HttpHeaders get headers => (super.noSuchMethod(
+        Invocation.getter(#headers),
+        returnValue: _FakeHttpHeaders_3(
+          this,
           Invocation.getter(#headers),
-          returnValue: _FakeHttpHeaders_3(this, Invocation.getter(#headers)))
-      as _i2.HttpHeaders);
+        ),
+      ) as _i2.HttpHeaders);
   @override
-  List<_i2.Cookie> get cookies =>
-      (super.noSuchMethod(Invocation.getter(#cookies),
-          returnValue: <_i2.Cookie>[]) as List<_i2.Cookie>);
+  List<_i2.Cookie> get cookies => (super.noSuchMethod(
+        Invocation.getter(#cookies),
+        returnValue: <_i2.Cookie>[],
+      ) as List<_i2.Cookie>);
   @override
-  _i4.Future<_i2.HttpClientResponse> get done =>
-      (super.noSuchMethod(Invocation.getter(#done),
-              returnValue: _i4.Future<_i2.HttpClientResponse>.value(
-                  _FakeHttpClientResponse_4(this, Invocation.getter(#done))))
-          as _i4.Future<_i2.HttpClientResponse>);
+  _i4.Future<_i2.HttpClientResponse> get done => (super.noSuchMethod(
+        Invocation.getter(#done),
+        returnValue:
+            _i4.Future<_i2.HttpClientResponse>.value(_FakeHttpClientResponse_4(
+          this,
+          Invocation.getter(#done),
+        )),
+      ) as _i4.Future<_i2.HttpClientResponse>);
   @override
-  _i3.Encoding get encoding => (super.noSuchMethod(Invocation.getter(#encoding),
-          returnValue: _FakeEncoding_5(this, Invocation.getter(#encoding)))
-      as _i3.Encoding);
+  _i3.Encoding get encoding => (super.noSuchMethod(
+        Invocation.getter(#encoding),
+        returnValue: _FakeEncoding_5(
+          this,
+          Invocation.getter(#encoding),
+        ),
+      ) as _i3.Encoding);
   @override
-  set encoding(_i3.Encoding? _encoding) =>
-      super.noSuchMethod(Invocation.setter(#encoding, _encoding),
-          returnValueForMissingStub: null);
+  set encoding(_i3.Encoding? _encoding) => super.noSuchMethod(
+        Invocation.setter(
+          #encoding,
+          _encoding,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<_i2.HttpClientResponse> close() => (super.noSuchMethod(
-          Invocation.method(#close, []),
-          returnValue: _i4.Future<_i2.HttpClientResponse>.value(
-              _FakeHttpClientResponse_4(this, Invocation.method(#close, []))))
-      as _i4.Future<_i2.HttpClientResponse>);
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientResponse>.value(_FakeHttpClientResponse_4(
+          this,
+          Invocation.method(
+            #close,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientResponse>);
   @override
-  void abort([Object? exception, StackTrace? stackTrace]) =>
-      super.noSuchMethod(Invocation.method(#abort, [exception, stackTrace]),
-          returnValueForMissingStub: null);
+  void abort([
+    Object? exception,
+    StackTrace? stackTrace,
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #abort,
+          [
+            exception,
+            stackTrace,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void add(List<int>? data) =>
-      super.noSuchMethod(Invocation.method(#add, [data]),
-          returnValueForMissingStub: null);
+  void add(List<int>? data) => super.noSuchMethod(
+        Invocation.method(
+          #add,
+          [data],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void write(Object? object) =>
-      super.noSuchMethod(Invocation.method(#write, [object]),
-          returnValueForMissingStub: null);
+  void write(Object? object) => super.noSuchMethod(
+        Invocation.method(
+          #write,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeAll(Iterable<dynamic>? objects, [String? separator = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeAll, [objects, separator]),
-          returnValueForMissingStub: null);
+  void writeAll(
+    Iterable<dynamic>? objects, [
+    String? separator = r'',
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeAll,
+          [
+            objects,
+            separator,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeln([Object? object = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeln, [object]),
-          returnValueForMissingStub: null);
+  void writeln([Object? object = r'']) => super.noSuchMethod(
+        Invocation.method(
+          #writeln,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeCharCode(int? charCode) =>
-      super.noSuchMethod(Invocation.method(#writeCharCode, [charCode]),
-          returnValueForMissingStub: null);
+  void writeCharCode(int? charCode) => super.noSuchMethod(
+        Invocation.method(
+          #writeCharCode,
+          [charCode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addError(Object? error, [StackTrace? stackTrace]) =>
-      super.noSuchMethod(Invocation.method(#addError, [error, stackTrace]),
-          returnValueForMissingStub: null);
+  void addError(
+    Object? error, [
+    StackTrace? stackTrace,
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addError,
+          [
+            error,
+            stackTrace,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<dynamic> addStream(_i4.Stream<List<int>>? stream) =>
-      (super.noSuchMethod(Invocation.method(#addStream, [stream]),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addStream,
+          [stream],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<dynamic> flush() =>
-      (super.noSuchMethod(Invocation.method(#flush, []),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> flush() => (super.noSuchMethod(
+        Invocation.method(
+          #flush,
+          [],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [HttpClientResponse].
@@ -385,241 +847,460 @@ class MockHttpClientResponse extends _i1.Mock
   }
 
   @override
-  int get statusCode =>
-      (super.noSuchMethod(Invocation.getter(#statusCode), returnValue: 0)
-          as int);
+  int get statusCode => (super.noSuchMethod(
+        Invocation.getter(#statusCode),
+        returnValue: 0,
+      ) as int);
   @override
-  String get reasonPhrase =>
-      (super.noSuchMethod(Invocation.getter(#reasonPhrase), returnValue: '')
-          as String);
+  String get reasonPhrase => (super.noSuchMethod(
+        Invocation.getter(#reasonPhrase),
+        returnValue: '',
+      ) as String);
   @override
-  int get contentLength =>
-      (super.noSuchMethod(Invocation.getter(#contentLength), returnValue: 0)
-          as int);
+  int get contentLength => (super.noSuchMethod(
+        Invocation.getter(#contentLength),
+        returnValue: 0,
+      ) as int);
   @override
   _i2.HttpClientResponseCompressionState get compressionState =>
-      (super.noSuchMethod(Invocation.getter(#compressionState),
-              returnValue: _i2.HttpClientResponseCompressionState.notCompressed)
-          as _i2.HttpClientResponseCompressionState);
+      (super.noSuchMethod(
+        Invocation.getter(#compressionState),
+        returnValue: _i2.HttpClientResponseCompressionState.notCompressed,
+      ) as _i2.HttpClientResponseCompressionState);
   @override
-  bool get persistentConnection =>
-      (super.noSuchMethod(Invocation.getter(#persistentConnection),
-          returnValue: false) as bool);
+  bool get persistentConnection => (super.noSuchMethod(
+        Invocation.getter(#persistentConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isRedirect =>
-      (super.noSuchMethod(Invocation.getter(#isRedirect), returnValue: false)
-          as bool);
+  bool get isRedirect => (super.noSuchMethod(
+        Invocation.getter(#isRedirect),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.RedirectInfo> get redirects =>
-      (super.noSuchMethod(Invocation.getter(#redirects),
-          returnValue: <_i2.RedirectInfo>[]) as List<_i2.RedirectInfo>);
+  List<_i2.RedirectInfo> get redirects => (super.noSuchMethod(
+        Invocation.getter(#redirects),
+        returnValue: <_i2.RedirectInfo>[],
+      ) as List<_i2.RedirectInfo>);
   @override
   _i2.HttpHeaders get headers => (super.noSuchMethod(
+        Invocation.getter(#headers),
+        returnValue: _FakeHttpHeaders_3(
+          this,
           Invocation.getter(#headers),
-          returnValue: _FakeHttpHeaders_3(this, Invocation.getter(#headers)))
-      as _i2.HttpHeaders);
+        ),
+      ) as _i2.HttpHeaders);
   @override
-  List<_i2.Cookie> get cookies =>
-      (super.noSuchMethod(Invocation.getter(#cookies),
-          returnValue: <_i2.Cookie>[]) as List<_i2.Cookie>);
+  List<_i2.Cookie> get cookies => (super.noSuchMethod(
+        Invocation.getter(#cookies),
+        returnValue: <_i2.Cookie>[],
+      ) as List<_i2.Cookie>);
   @override
-  bool get isBroadcast =>
-      (super.noSuchMethod(Invocation.getter(#isBroadcast), returnValue: false)
-          as bool);
+  bool get isBroadcast => (super.noSuchMethod(
+        Invocation.getter(#isBroadcast),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<int> get length => (super.noSuchMethod(Invocation.getter(#length),
-      returnValue: _i4.Future<int>.value(0)) as _i4.Future<int>);
+  _i4.Future<int> get length => (super.noSuchMethod(
+        Invocation.getter(#length),
+        returnValue: _i4.Future<int>.value(0),
+      ) as _i4.Future<int>);
   @override
-  _i4.Future<bool> get isEmpty =>
-      (super.noSuchMethod(Invocation.getter(#isEmpty),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> get isEmpty => (super.noSuchMethod(
+        Invocation.getter(#isEmpty),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
-  _i4.Future<List<int>> get first =>
-      (super.noSuchMethod(Invocation.getter(#first),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+  _i4.Future<List<int>> get first => (super.noSuchMethod(
+        Invocation.getter(#first),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<List<int>> get last =>
-      (super.noSuchMethod(Invocation.getter(#last),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+  _i4.Future<List<int>> get last => (super.noSuchMethod(
+        Invocation.getter(#last),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<List<int>> get single =>
-      (super.noSuchMethod(Invocation.getter(#single),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+  _i4.Future<List<int>> get single => (super.noSuchMethod(
+        Invocation.getter(#single),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<_i2.HttpClientResponse> redirect(
-          [String? method, Uri? url, bool? followLoops]) =>
+  _i4.Future<_i2.HttpClientResponse> redirect([
+    String? method,
+    Uri? url,
+    bool? followLoops,
+  ]) =>
       (super.noSuchMethod(
-              Invocation.method(#redirect, [method, url, followLoops]),
-              returnValue: _i4.Future<_i2.HttpClientResponse>.value(
-                  _FakeHttpClientResponse_4(
-                      this,
-                      Invocation.method(
-                          #redirect, [method, url, followLoops]))))
-          as _i4.Future<_i2.HttpClientResponse>);
+        Invocation.method(
+          #redirect,
+          [
+            method,
+            url,
+            followLoops,
+          ],
+        ),
+        returnValue:
+            _i4.Future<_i2.HttpClientResponse>.value(_FakeHttpClientResponse_4(
+          this,
+          Invocation.method(
+            #redirect,
+            [
+              method,
+              url,
+              followLoops,
+            ],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpClientResponse>);
   @override
-  _i4.Future<_i2.Socket> detachSocket() =>
-      (super.noSuchMethod(Invocation.method(#detachSocket, []),
-              returnValue: _i4.Future<_i2.Socket>.value(
-                  _FakeSocket_6(this, Invocation.method(#detachSocket, []))))
-          as _i4.Future<_i2.Socket>);
+  _i4.Future<_i2.Socket> detachSocket() => (super.noSuchMethod(
+        Invocation.method(
+          #detachSocket,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.Socket>.value(_FakeSocket_6(
+          this,
+          Invocation.method(
+            #detachSocket,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.Socket>);
   @override
-  _i4.Stream<List<int>> asBroadcastStream(
-          {void Function(_i4.StreamSubscription<List<int>>)? onListen,
-          void Function(_i4.StreamSubscription<List<int>>)? onCancel}) =>
+  _i4.Stream<List<int>> asBroadcastStream({
+    void Function(_i4.StreamSubscription<List<int>>)? onListen,
+    void Function(_i4.StreamSubscription<List<int>>)? onCancel,
+  }) =>
       (super.noSuchMethod(
-          Invocation.method(#asBroadcastStream, [],
-              {#onListen: onListen, #onCancel: onCancel}),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+        Invocation.method(
+          #asBroadcastStream,
+          [],
+          {
+            #onListen: onListen,
+            #onCancel: onCancel,
+          },
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
-  _i4.StreamSubscription<List<int>> listen(void Function(List<int>)? onData,
-          {Function? onError, void Function()? onDone, bool? cancelOnError}) =>
+  _i4.StreamSubscription<List<int>> listen(
+    void Function(List<int>)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(#listen, [
-                onData
-              ], {
-                #onError: onError,
-                #onDone: onDone,
-                #cancelOnError: cancelOnError
-              }),
-              returnValue: _FakeStreamSubscription_7<List<int>>(this,
-                  Invocation.method(#listen, [onData], {#onError: onError, #onDone: onDone, #cancelOnError: cancelOnError})))
-          as _i4.StreamSubscription<List<int>>);
+        Invocation.method(
+          #listen,
+          [onData],
+          {
+            #onError: onError,
+            #onDone: onDone,
+            #cancelOnError: cancelOnError,
+          },
+        ),
+        returnValue: _FakeStreamSubscription_7<List<int>>(
+          this,
+          Invocation.method(
+            #listen,
+            [onData],
+            {
+              #onError: onError,
+              #onDone: onDone,
+              #cancelOnError: cancelOnError,
+            },
+          ),
+        ),
+      ) as _i4.StreamSubscription<List<int>>);
   @override
   _i4.Stream<List<int>> where(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(Invocation.method(#where, [test]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #where,
+          [test],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
-  _i4.Stream<S> map<S>(S Function(List<int>)? convert) =>
-      (super.noSuchMethod(Invocation.method(#map, [convert]),
-          returnValue: _i4.Stream<S>.empty()) as _i4.Stream<S>);
+  _i4.Stream<S> map<S>(S Function(List<int>)? convert) => (super.noSuchMethod(
+        Invocation.method(
+          #map,
+          [convert],
+        ),
+        returnValue: _i4.Stream<S>.empty(),
+      ) as _i4.Stream<S>);
   @override
   _i4.Stream<E> asyncMap<E>(_i4.FutureOr<E> Function(List<int>)? convert) =>
-      (super.noSuchMethod(Invocation.method(#asyncMap, [convert]),
-          returnValue: _i4.Stream<E>.empty()) as _i4.Stream<E>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #asyncMap,
+          [convert],
+        ),
+        returnValue: _i4.Stream<E>.empty(),
+      ) as _i4.Stream<E>);
   @override
   _i4.Stream<E> asyncExpand<E>(_i4.Stream<E>? Function(List<int>)? convert) =>
-      (super.noSuchMethod(Invocation.method(#asyncExpand, [convert]),
-          returnValue: _i4.Stream<E>.empty()) as _i4.Stream<E>);
-  @override
-  _i4.Stream<List<int>> handleError(Function? onError,
-          {bool Function(dynamic)? test}) =>
       (super.noSuchMethod(
-          Invocation.method(#handleError, [onError], {#test: test}),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+        Invocation.method(
+          #asyncExpand,
+          [convert],
+        ),
+        returnValue: _i4.Stream<E>.empty(),
+      ) as _i4.Stream<E>);
+  @override
+  _i4.Stream<List<int>> handleError(
+    Function? onError, {
+    bool Function(dynamic)? test,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleError,
+          [onError],
+          {#test: test},
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
   _i4.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) =>
-      (super.noSuchMethod(Invocation.method(#expand, [convert]),
-          returnValue: _i4.Stream<S>.empty()) as _i4.Stream<S>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #expand,
+          [convert],
+        ),
+        returnValue: _i4.Stream<S>.empty(),
+      ) as _i4.Stream<S>);
   @override
   _i4.Future<dynamic> pipe(_i4.StreamConsumer<List<int>>? streamConsumer) =>
-      (super.noSuchMethod(Invocation.method(#pipe, [streamConsumer]),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #pipe,
+          [streamConsumer],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
   _i4.Stream<S> transform<S>(
           _i4.StreamTransformer<List<int>, S>? streamTransformer) =>
-      (super.noSuchMethod(Invocation.method(#transform, [streamTransformer]),
-          returnValue: _i4.Stream<S>.empty()) as _i4.Stream<S>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #transform,
+          [streamTransformer],
+        ),
+        returnValue: _i4.Stream<S>.empty(),
+      ) as _i4.Stream<S>);
   @override
   _i4.Future<List<int>> reduce(
-          List<int> Function(List<int>, List<int>)? combine) =>
-      (super.noSuchMethod(Invocation.method(#reduce, [combine]),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+          List<int> Function(
+    List<int>,
+    List<int>,
+  )?
+              combine) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #reduce,
+          [combine],
+        ),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<S> fold<S>(S? initialValue, S Function(S, List<int>)? combine) =>
-      (super.noSuchMethod(Invocation.method(#fold, [initialValue, combine]),
-          returnValue: _i4.Future<S>.value(null)) as _i4.Future<S>);
+  _i4.Future<S> fold<S>(
+    S? initialValue,
+    S Function(
+      S,
+      List<int>,
+    )?
+        combine,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fold,
+          [
+            initialValue,
+            combine,
+          ],
+        ),
+        returnValue: _i4.Future<S>.value(null),
+      ) as _i4.Future<S>);
   @override
-  _i4.Future<String> join([String? separator = r'']) =>
-      (super.noSuchMethod(Invocation.method(#join, [separator]),
-          returnValue: _i4.Future<String>.value('')) as _i4.Future<String>);
+  _i4.Future<String> join([String? separator = r'']) => (super.noSuchMethod(
+        Invocation.method(
+          #join,
+          [separator],
+        ),
+        returnValue: _i4.Future<String>.value(''),
+      ) as _i4.Future<String>);
   @override
-  _i4.Future<bool> contains(Object? needle) =>
-      (super.noSuchMethod(Invocation.method(#contains, [needle]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> contains(Object? needle) => (super.noSuchMethod(
+        Invocation.method(
+          #contains,
+          [needle],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<dynamic> forEach(void Function(List<int>)? action) =>
-      (super.noSuchMethod(Invocation.method(#forEach, [action]),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #forEach,
+          [action],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<bool> every(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(Invocation.method(#every, [test]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
+        Invocation.method(
+          #every,
+          [test],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
-  _i4.Future<bool> any(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(Invocation.method(#any, [test]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> any(bool Function(List<int>)? test) => (super.noSuchMethod(
+        Invocation.method(
+          #any,
+          [test],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
-  _i4.Stream<R> cast<R>() => (super.noSuchMethod(Invocation.method(#cast, []),
-      returnValue: _i4.Stream<R>.empty()) as _i4.Stream<R>);
+  _i4.Stream<R> cast<R>() => (super.noSuchMethod(
+        Invocation.method(
+          #cast,
+          [],
+        ),
+        returnValue: _i4.Stream<R>.empty(),
+      ) as _i4.Stream<R>);
   @override
-  _i4.Future<List<List<int>>> toList() =>
-      (super.noSuchMethod(Invocation.method(#toList, []),
-              returnValue: _i4.Future<List<List<int>>>.value(<List<int>>[]))
-          as _i4.Future<List<List<int>>>);
+  _i4.Future<List<List<int>>> toList() => (super.noSuchMethod(
+        Invocation.method(
+          #toList,
+          [],
+        ),
+        returnValue: _i4.Future<List<List<int>>>.value(<List<int>>[]),
+      ) as _i4.Future<List<List<int>>>);
   @override
-  _i4.Future<Set<List<int>>> toSet() =>
-      (super.noSuchMethod(Invocation.method(#toSet, []),
-              returnValue: _i4.Future<Set<List<int>>>.value(<List<int>>{}))
-          as _i4.Future<Set<List<int>>>);
+  _i4.Future<Set<List<int>>> toSet() => (super.noSuchMethod(
+        Invocation.method(
+          #toSet,
+          [],
+        ),
+        returnValue: _i4.Future<Set<List<int>>>.value(<List<int>>{}),
+      ) as _i4.Future<Set<List<int>>>);
   @override
-  _i4.Future<E> drain<E>([E? futureValue]) =>
-      (super.noSuchMethod(Invocation.method(#drain, [futureValue]),
-          returnValue: _i4.Future<E>.value(null)) as _i4.Future<E>);
+  _i4.Future<E> drain<E>([E? futureValue]) => (super.noSuchMethod(
+        Invocation.method(
+          #drain,
+          [futureValue],
+        ),
+        returnValue: _i4.Future<E>.value(null),
+      ) as _i4.Future<E>);
   @override
-  _i4.Stream<List<int>> take(int? count) =>
-      (super.noSuchMethod(Invocation.method(#take, [count]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+  _i4.Stream<List<int>> take(int? count) => (super.noSuchMethod(
+        Invocation.method(
+          #take,
+          [count],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
   _i4.Stream<List<int>> takeWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(Invocation.method(#takeWhile, [test]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #takeWhile,
+          [test],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
-  _i4.Stream<List<int>> skip(int? count) =>
-      (super.noSuchMethod(Invocation.method(#skip, [count]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+  _i4.Stream<List<int>> skip(int? count) => (super.noSuchMethod(
+        Invocation.method(
+          #skip,
+          [count],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
   _i4.Stream<List<int>> skipWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(Invocation.method(#skipWhile, [test]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #skipWhile,
+          [test],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
   _i4.Stream<List<int>> distinct(
-          [bool Function(List<int>, List<int>)? equals]) =>
-      (super.noSuchMethod(Invocation.method(#distinct, [equals]),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
-  @override
-  _i4.Future<List<int>> firstWhere(bool Function(List<int>)? test,
-          {List<int> Function()? orElse}) =>
+          [bool Function(
+            List<int>,
+            List<int>,
+          )?
+              equals]) =>
       (super.noSuchMethod(
-              Invocation.method(#firstWhere, [test], {#orElse: orElse}),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+        Invocation.method(
+          #distinct,
+          [equals],
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
   @override
-  _i4.Future<List<int>> lastWhere(bool Function(List<int>)? test,
-          {List<int> Function()? orElse}) =>
+  _i4.Future<List<int>> firstWhere(
+    bool Function(List<int>)? test, {
+    List<int> Function()? orElse,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(#lastWhere, [test], {#orElse: orElse}),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+        Invocation.method(
+          #firstWhere,
+          [test],
+          {#orElse: orElse},
+        ),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<List<int>> singleWhere(bool Function(List<int>)? test,
-          {List<int> Function()? orElse}) =>
+  _i4.Future<List<int>> lastWhere(
+    bool Function(List<int>)? test, {
+    List<int> Function()? orElse,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(#singleWhere, [test], {#orElse: orElse}),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
+        Invocation.method(
+          #lastWhere,
+          [test],
+          {#orElse: orElse},
+        ),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
   @override
-  _i4.Future<List<int>> elementAt(int? index) =>
-      (super.noSuchMethod(Invocation.method(#elementAt, [index]),
-              returnValue: _i4.Future<List<int>>.value(<int>[]))
-          as _i4.Future<List<int>>);
-  @override
-  _i4.Stream<List<int>> timeout(Duration? timeLimit,
-          {void Function(_i4.EventSink<List<int>>)? onTimeout}) =>
+  _i4.Future<List<int>> singleWhere(
+    bool Function(List<int>)? test, {
+    List<int> Function()? orElse,
+  }) =>
       (super.noSuchMethod(
-          Invocation.method(#timeout, [timeLimit], {#onTimeout: onTimeout}),
-          returnValue: _i4.Stream<List<int>>.empty()) as _i4.Stream<List<int>>);
+        Invocation.method(
+          #singleWhere,
+          [test],
+          {#orElse: orElse},
+        ),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
+  @override
+  _i4.Future<List<int>> elementAt(int? index) => (super.noSuchMethod(
+        Invocation.method(
+          #elementAt,
+          [index],
+        ),
+        returnValue: _i4.Future<List<int>>.value(<int>[]),
+      ) as _i4.Future<List<int>>);
+  @override
+  _i4.Stream<List<int>> timeout(
+    Duration? timeLimit, {
+    void Function(_i4.EventSink<List<int>>)? onTimeout,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #timeout,
+          [timeLimit],
+          {#onTimeout: onTimeout},
+        ),
+        returnValue: _i4.Stream<List<int>>.empty(),
+      ) as _i4.Stream<List<int>>);
 }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -80,14 +79,14 @@ import 'app_localizations_uk.dart';
 import 'app_localizations_vi.dart';
 import 'app_localizations_zh.dart';
 
-/// Callers can lookup localized strings with an instance of AppLocalizations returned
-/// by `AppLocalizations.of(context)`.
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
 ///
 /// Applications need to include `AppLocalizations.delegate()` in their app's
-/// localizationDelegates list, and the locales they support in the app's
-/// supportedLocales list. For example:
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
 ///
-/// ```
+/// ```dart
 /// import 'l10n/app_localizations.dart';
 ///
 /// return MaterialApp(
@@ -102,14 +101,14 @@ import 'app_localizations_zh.dart';
 /// Please make sure to update your pubspec.yaml to include the following
 /// packages:
 ///
-/// ```
+/// ```yaml
 /// dependencies:
 ///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
 ///   intl: any # Use the pinned version from flutter_localizations
 ///
-///   # rest of dependencies
+///   # Rest of dependencies
 /// ```
 ///
 /// ## iOS Applications

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Amharic (`am`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Arabic (`ar`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Belarusian (`be`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bulgarian (`bg`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bengali Bangla (`bn`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tibetan (`bo`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bosnian (`bs`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Catalan Valencian (`ca`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Czech (`cs`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Welsh (`cy`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Danish (`da`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for German (`de`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Dzongkha (`dz`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Modern Greek (`el`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for English (`en`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Esperanto (`eo`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Spanish Castilian (`es`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Estonian (`et`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Basque (`eu`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Persian (`fa`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Finnish (`fi`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for French (`fr`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Irish (`ga`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Galician (`gl`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Gujarati (`gu`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hebrew (`he`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hindi (`hi`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Croatian (`hr`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hungarian (`hu`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Indonesian (`id`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Icelandic (`is`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Italian (`it`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Japanese (`ja`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Georgian (`ka`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kazakh (`kk`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Khmer Central Khmer (`km`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kannada (`kn`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Korean (`ko`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kurdish (`ku`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Lao (`lo`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Lithuanian (`lt`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Latvian (`lv`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Macedonian (`mk`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Malayalam (`ml`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Marathi (`mr`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Burmese (`my`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Norwegian Bokmål (`nb`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Nepali (`ne`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Dutch Flemish (`nl`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Norwegian Nynorsk (`nn`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Occitan (`oc`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Panjabi Punjabi (`pa`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Polish (`pl`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Portuguese (`pt`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Romanian Moldavian Moldovan (`ro`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Russian (`ru`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Northern Sami (`se`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Sinhala Sinhalese (`si`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Slovak (`sk`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Slovenian (`sl`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Albanian (`sq`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Serbian (`sr`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Swedish (`sv`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tamil (`ta`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Telugu (`te`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tajik (`tg`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Thai (`th`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tagalog (`tl`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Turkish (`tr`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Uighur Uyghur (`ug`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Ukrainian (`uk`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Vietnamese (`vi`).

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Chinese (`zh`).

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -37,123 +42,213 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
@@ -26,8 +26,13 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeUdevDeviceInfo_0 extends _i1.SmartFake
     implements _i2.UdevDeviceInfo {
-  _FakeUdevDeviceInfo_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUdevDeviceInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AllocateDiskSpaceModel].
@@ -40,127 +45,245 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
   }
 
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i4.Disk> get disks =>
-      (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i4.Disk>[])
-          as List<_i4.Disk>);
+  List<_i4.Disk> get disks => (super.noSuchMethod(
+        Invocation.getter(#disks),
+        returnValue: <_i4.Disk>[],
+      ) as List<_i4.Disk>);
   @override
-  int get selectedDiskIndex =>
-      (super.noSuchMethod(Invocation.getter(#selectedDiskIndex), returnValue: 0)
-          as int);
+  int get selectedDiskIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedDiskIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  int get selectedObjectIndex => (super
-          .noSuchMethod(Invocation.getter(#selectedObjectIndex), returnValue: 0)
-      as int);
+  int get selectedObjectIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedObjectIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  _i5.Stream<dynamic> get onSelectionChanged =>
-      (super.noSuchMethod(Invocation.getter(#onSelectionChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onSelectionChanged => (super.noSuchMethod(
+        Invocation.getter(#onSelectionChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  bool get canAddPartition => (super
-          .noSuchMethod(Invocation.getter(#canAddPartition), returnValue: false)
-      as bool);
+  bool get canAddPartition => (super.noSuchMethod(
+        Invocation.getter(#canAddPartition),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get canRemovePartition =>
-      (super.noSuchMethod(Invocation.getter(#canRemovePartition),
-          returnValue: false) as bool);
+  bool get canRemovePartition => (super.noSuchMethod(
+        Invocation.getter(#canRemovePartition),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get canEditPartition =>
-      (super.noSuchMethod(Invocation.getter(#canEditPartition),
-          returnValue: false) as bool);
+  bool get canEditPartition => (super.noSuchMethod(
+        Invocation.getter(#canEditPartition),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get canReformatDisk => (super
-          .noSuchMethod(Invocation.getter(#canReformatDisk), returnValue: false)
-      as bool);
+  bool get canReformatDisk => (super.noSuchMethod(
+        Invocation.getter(#canReformatDisk),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  bool isStorageSelected(int? diskIndex, [int? objectIndex = -1]) =>
+  bool isStorageSelected(
+    int? diskIndex, [
+    int? objectIndex = -1,
+  ]) =>
       (super.noSuchMethod(
-          Invocation.method(#isStorageSelected, [diskIndex, objectIndex]),
-          returnValue: false) as bool);
+        Invocation.method(
+          #isStorageSelected,
+          [
+            diskIndex,
+            objectIndex,
+          ],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  _i5.Future<void> addPartition(_i4.Disk? disk, _i4.Gap? gap,
-          {int? size, _i4.PartitionFormat? format, String? mount}) =>
+  _i5.Future<void> addPartition(
+    _i4.Disk? disk,
+    _i4.Gap? gap, {
+    int? size,
+    _i4.PartitionFormat? format,
+    String? mount,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap],
-                  {#size: size, #format: format, #mount: mount}),
-              returnValue: _i5.Future<void>.value(),
-              returnValueForMissingStub: _i5.Future<void>.value())
-          as _i5.Future<void>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+          ],
+          {
+            #size: size,
+            #format: format,
+            #mount: mount,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<void> editPartition(_i4.Disk? disk, _i4.Partition? partition,
-          {_i4.PartitionFormat? format, bool? wipe, String? mount}) =>
+  _i5.Future<void> editPartition(
+    _i4.Disk? disk,
+    _i4.Partition? partition, {
+    _i4.PartitionFormat? format,
+    bool? wipe,
+    String? mount,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(#editPartition, [disk, partition],
-                  {#format: format, #wipe: wipe, #mount: mount}),
-              returnValue: _i5.Future<void>.value(),
-              returnValueForMissingStub: _i5.Future<void>.value())
-          as _i5.Future<void>);
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+          {
+            #format: format,
+            #wipe: wipe,
+            #mount: mount,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<void> deletePartition(_i4.Disk? disk, _i4.Partition? partition) =>
+  _i5.Future<void> deletePartition(
+    _i4.Disk? disk,
+    _i4.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i5.Future<void>.value(),
-              returnValueForMissingStub: _i5.Future<void>.value())
-          as _i5.Future<void>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  bool canSelectStorage(int? diskIndex, [int? objectIndex = -1]) =>
+  bool canSelectStorage(
+    int? diskIndex, [
+    int? objectIndex = -1,
+  ]) =>
       (super.noSuchMethod(
-          Invocation.method(#canSelectStorage, [diskIndex, objectIndex]),
-          returnValue: false) as bool);
+        Invocation.method(
+          #canSelectStorage,
+          [
+            diskIndex,
+            objectIndex,
+          ],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectStorage(int? diskIndex, [int? objectIndex = -1]) => super
-      .noSuchMethod(Invocation.method(#selectStorage, [diskIndex, objectIndex]),
-          returnValueForMissingStub: null);
+  void selectStorage(
+    int? diskIndex, [
+    int? objectIndex = -1,
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #selectStorage,
+          [
+            diskIndex,
+            objectIndex,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void selectBootDisk(int? diskIndex) =>
-      super.noSuchMethod(Invocation.method(#selectBootDisk, [diskIndex]),
-          returnValueForMissingStub: null);
+  void selectBootDisk(int? diskIndex) => super.noSuchMethod(
+        Invocation.method(
+          #selectBootDisk,
+          [diskIndex],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> getStorage() => (super.noSuchMethod(
-      Invocation.method(#getStorage, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> setStorage() => (super.noSuchMethod(
-      Invocation.method(#setStorage, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #setStorage,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> resetStorage() => (super.noSuchMethod(
-      Invocation.method(#resetStorage, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> reformatDisk(_i4.Disk? disk) => (super.noSuchMethod(
-      Invocation.method(#reformatDisk, [disk]),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UdevDeviceInfo].
@@ -172,9 +295,10 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
   }
 
   @override
-  String get fullName =>
-      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
-          as String);
+  String get fullName => (super.noSuchMethod(
+        Invocation.getter(#fullName),
+        returnValue: '',
+      ) as String);
 }
 
 /// A class which mocks [UdevService].
@@ -186,15 +310,31 @@ class MockUdevService extends _i1.Mock implements _i2.UdevService {
   }
 
   @override
-  _i2.UdevDeviceInfo bySysname(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
-              returnValue: _FakeUdevDeviceInfo_0(
-                  this, Invocation.method(#bySysname, [sysname])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
+        Invocation.method(
+          #bySysname,
+          [sysname],
+        ),
+        returnValue: _FakeUdevDeviceInfo_0(
+          this,
+          Invocation.method(
+            #bySysname,
+            [sysname],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
   @override
-  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
-      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
-              returnValue: _FakeUdevDeviceInfo_0(
-                  this, Invocation.method(#bySyspath, [syspath])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
+        Invocation.method(
+          #bySyspath,
+          [syspath],
+        ),
+        returnValue: _FakeUdevDeviceInfo_0(
+          this,
+          Invocation.method(
+            #bySyspath,
+            [syspath],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
 }

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.mocks.dart
@@ -31,56 +31,94 @@ class MockChooseSecurityKeyModel extends _i1.Mock
   }
 
   @override
-  String get securityKey =>
-      (super.noSuchMethod(Invocation.getter(#securityKey), returnValue: '')
-          as String);
+  String get securityKey => (super.noSuchMethod(
+        Invocation.getter(#securityKey),
+        returnValue: '',
+      ) as String);
   @override
-  set securityKey(String? value) =>
-      super.noSuchMethod(Invocation.setter(#securityKey, value),
-          returnValueForMissingStub: null);
+  set securityKey(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #securityKey,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get confirmedSecurityKey =>
-      (super.noSuchMethod(Invocation.getter(#confirmedSecurityKey),
-          returnValue: '') as String);
+  String get confirmedSecurityKey => (super.noSuchMethod(
+        Invocation.getter(#confirmedSecurityKey),
+        returnValue: '',
+      ) as String);
   @override
-  set confirmedSecurityKey(String? value) =>
-      super.noSuchMethod(Invocation.setter(#confirmedSecurityKey, value),
-          returnValueForMissingStub: null);
+  set confirmedSecurityKey(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #confirmedSecurityKey,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i3.Future<void> loadSecurityKey() => (super.noSuchMethod(
-      Invocation.method(#loadSecurityKey, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #loadSecurityKey,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> saveSecurityKey() => (super.noSuchMethod(
-      Invocation.method(#saveSecurityKey, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #saveSecurityKey,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -20,8 +20,13 @@ import 'package:ubuntu_desktop_installer/settings.dart' as _i3;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeLocale_0 extends _i1.SmartFake implements _i2.Locale {
-  _FakeLocale_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeLocale_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [Settings].
@@ -33,38 +38,69 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   }
 
   @override
-  _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
-          returnValue: _FakeLocale_0(this, Invocation.getter(#locale)))
-      as _i2.Locale);
+  _i2.Locale get locale => (super.noSuchMethod(
+        Invocation.getter(#locale),
+        returnValue: _FakeLocale_0(
+          this,
+          Invocation.getter(#locale),
+        ),
+      ) as _i2.Locale);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void applyTheme(_i2.Brightness? brightness) =>
-      super.noSuchMethod(Invocation.method(#applyTheme, [brightness]),
-          returnValueForMissingStub: null);
+  void applyTheme(_i2.Brightness? brightness) => super.noSuchMethod(
+        Invocation.method(
+          #applyTheme,
+          [brightness],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void applyLocale(_i2.Locale? locale) =>
-      super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
-          returnValueForMissingStub: null);
+  void applyLocale(_i2.Locale? locale) => super.noSuchMethod(
+        Invocation.method(
+          #applyLocale,
+          [locale],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.mocks.dart
@@ -30,62 +30,99 @@ class MockConfigureSecureBootModel extends _i1.Mock
   }
 
   @override
-  _i2.SecureBootMode get secureBootMode =>
-      (super.noSuchMethod(Invocation.getter(#secureBootMode),
-          returnValue: _i2.SecureBootMode.turnOff) as _i2.SecureBootMode);
+  _i2.SecureBootMode get secureBootMode => (super.noSuchMethod(
+        Invocation.getter(#secureBootMode),
+        returnValue: _i2.SecureBootMode.turnOff,
+      ) as _i2.SecureBootMode);
   @override
-  String get securityKey =>
-      (super.noSuchMethod(Invocation.getter(#securityKey), returnValue: '')
-          as String);
+  String get securityKey => (super.noSuchMethod(
+        Invocation.getter(#securityKey),
+        returnValue: '',
+      ) as String);
   @override
-  String get confirmKey =>
-      (super.noSuchMethod(Invocation.getter(#confirmKey), returnValue: '')
-          as String);
+  String get confirmKey => (super.noSuchMethod(
+        Invocation.getter(#confirmKey),
+        returnValue: '',
+      ) as String);
   @override
-  bool get areTextFieldsEnabled =>
-      (super.noSuchMethod(Invocation.getter(#areTextFieldsEnabled),
-          returnValue: false) as bool);
+  bool get areTextFieldsEnabled => (super.noSuchMethod(
+        Invocation.getter(#areTextFieldsEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isFormValid =>
-      (super.noSuchMethod(Invocation.getter(#isFormValid), returnValue: false)
-          as bool);
+  bool get isFormValid => (super.noSuchMethod(
+        Invocation.getter(#isFormValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConfirmationKeyValid =>
-      (super.noSuchMethod(Invocation.getter(#isConfirmationKeyValid),
-          returnValue: false) as bool);
+  bool get isConfirmationKeyValid => (super.noSuchMethod(
+        Invocation.getter(#isConfirmationKeyValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void setSecureBootMode(_i2.SecureBootMode? mode) =>
-      super.noSuchMethod(Invocation.method(#setSecureBootMode, [mode]),
-          returnValueForMissingStub: null);
+  void setSecureBootMode(_i2.SecureBootMode? mode) => super.noSuchMethod(
+        Invocation.method(
+          #setSecureBootMode,
+          [mode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setSecurityKey(String? key) =>
-      super.noSuchMethod(Invocation.method(#setSecurityKey, [key]),
-          returnValueForMissingStub: null);
+  void setSecurityKey(String? key) => super.noSuchMethod(
+        Invocation.method(
+          #setSecurityKey,
+          [key],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setConfirmKey(String? key) =>
-      super.noSuchMethod(Invocation.method(#setConfirmKey, [key]),
-          returnValueForMissingStub: null);
+  void setConfirmKey(String? key) => super.noSuchMethod(
+        Invocation.method(
+          #setConfirmKey,
+          [key],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i3.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i3.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i3.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i3.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_model_test.mocks.dart
@@ -30,80 +30,132 @@ class MockConnectModel extends _i1.Mock implements _i2.ConnectModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i3.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i3.Stream<dynamic>.empty()) as _i3.Stream<dynamic>);
+  _i3.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i3.Stream<dynamic>.empty(),
+      ) as _i3.Stream<dynamic>);
   @override
-  _i2.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i2.ConnectMode.none) as _i2.ConnectMode);
+  _i2.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i2.ConnectMode.none,
+      ) as _i2.ConnectMode);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
@@ -33,56 +33,100 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeNetworkManagerAccessPoint_0 extends _i1.SmartFake
     implements _i2.NetworkManagerAccessPoint {
-  _FakeNetworkManagerAccessPoint_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerAccessPoint_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkService_1 extends _i1.SmartFake
     implements _i2.NetworkService {
-  _FakeNetworkService_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkService_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeEthernetDevice_2 extends _i1.SmartFake
     implements _i3.EthernetDevice {
-  _FakeEthernetDevice_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEthernetDevice_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDevice_3 extends _i1.SmartFake
     implements _i2.NetworkManagerDevice {
-  _FakeNetworkManagerDevice_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDevice_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWifiDevice_4 extends _i1.SmartFake implements _i4.WifiDevice {
-  _FakeWifiDevice_4(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWifiDevice_4(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerSettings_5 extends _i1.SmartFake
     implements _i2.NetworkManagerSettings {
-  _FakeNetworkManagerSettings_5(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerSettings_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDnsManager_6 extends _i1.SmartFake
     implements _i2.NetworkManagerDnsManager {
-  _FakeNetworkManagerDnsManager_6(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDnsManager_6(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerActiveConnection_7 extends _i1.SmartFake
     implements _i2.NetworkManagerActiveConnection {
   _FakeNetworkManagerActiveConnection_7(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeUdevDeviceInfo_8 extends _i1.SmartFake
     implements _i2.UdevDeviceInfo {
-  _FakeUdevDeviceInfo_8(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUdevDeviceInfo_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AccessPoint].
@@ -94,75 +138,136 @@ class MockAccessPoint extends _i1.Mock implements _i4.AccessPoint {
   }
 
   @override
-  _i2.NetworkManagerAccessPoint get accessPoint =>
-      (super.noSuchMethod(Invocation.getter(#accessPoint),
-              returnValue: _FakeNetworkManagerAccessPoint_0(
-                  this, Invocation.getter(#accessPoint)))
-          as _i2.NetworkManagerAccessPoint);
+  _i2.NetworkManagerAccessPoint get accessPoint => (super.noSuchMethod(
+        Invocation.getter(#accessPoint),
+        returnValue: _FakeNetworkManagerAccessPoint_0(
+          this,
+          Invocation.getter(#accessPoint),
+        ),
+      ) as _i2.NetworkManagerAccessPoint);
   @override
-  List<int> get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: <int>[])
-          as List<int>);
+  List<int> get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: <int>[],
+      ) as List<int>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  String get name =>
-      (super.noSuchMethod(Invocation.getter(#name), returnValue: '') as String);
+  String get name => (super.noSuchMethod(
+        Invocation.getter(#name),
+        returnValue: '',
+      ) as String);
   @override
-  int get strength =>
-      (super.noSuchMethod(Invocation.getter(#strength), returnValue: 0) as int);
+  int get strength => (super.noSuchMethod(
+        Invocation.getter(#strength),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isOpen =>
-      (super.noSuchMethod(Invocation.getter(#isOpen), returnValue: false)
-          as bool);
+  bool get isOpen => (super.noSuchMethod(
+        Invocation.getter(#isOpen),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [ConnectToInternetModel].
@@ -175,95 +280,159 @@ class MockConnectToInternetModel extends _i1.Mock
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i5.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  _i8.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i8.ConnectMode.none) as _i8.ConnectMode);
+  _i8.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i8.ConnectMode.none,
+      ) as _i8.ConnectMode);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void addConnectMode(_i8.ConnectModel? model) =>
-      super.noSuchMethod(Invocation.method(#addConnectMode, [model]),
-          returnValueForMissingStub: null);
+  void addConnectMode(_i8.ConnectModel? model) => super.noSuchMethod(
+        Invocation.method(
+          #addConnectMode,
+          [model],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void selectConnectMode([_i8.ConnectMode? mode]) =>
-      super.noSuchMethod(Invocation.method(#selectConnectMode, [mode]),
-          returnValueForMissingStub: null);
+  void selectConnectMode([_i8.ConnectMode? mode]) => super.noSuchMethod(
+        Invocation.method(
+          #selectConnectMode,
+          [mode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> markConfigured() => (super.noSuchMethod(
-      Invocation.method(#markConfigured, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [EthernetModel].
@@ -275,131 +444,234 @@ class MockEthernetModel extends _i1.Mock implements _i3.EthernetModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i8.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i8.ConnectMode.none) as _i8.ConnectMode);
+  _i8.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i8.ConnectMode.none,
+      ) as _i8.ConnectMode);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_1(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_1(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i3.EthernetDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i3.EthernetDevice>[]) as List<_i3.EthernetDevice>);
+  List<_i3.EthernetDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i3.EthernetDevice>[],
+      ) as List<_i3.EthernetDevice>);
   @override
-  _i5.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i3.EthernetDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeEthernetDevice_2(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i3.EthernetDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeEthernetDevice_2(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i3.EthernetDevice);
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i3.EthernetDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i3.EthernetDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i3.EthernetDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i3.EthernetDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [EthernetDevice].
@@ -411,104 +683,174 @@ class MockEthernetDevice extends _i1.Mock implements _i3.EthernetDevice {
   }
 
   @override
-  _i2.NetworkManagerDevice get device =>
-      (super.noSuchMethod(Invocation.getter(#device),
-              returnValue:
-                  _FakeNetworkManagerDevice_3(this, Invocation.getter(#device)))
-          as _i2.NetworkManagerDevice);
+  _i2.NetworkManagerDevice get device => (super.noSuchMethod(
+        Invocation.getter(#device),
+        returnValue: _FakeNetworkManagerDevice_3(
+          this,
+          Invocation.getter(#device),
+        ),
+      ) as _i2.NetworkManagerDevice);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  bool get isActive =>
-      (super.noSuchMethod(Invocation.getter(#isActive), returnValue: false)
-          as bool);
+  bool get isActive => (super.noSuchMethod(
+        Invocation.getter(#isActive),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisconnected => (super
-          .noSuchMethod(Invocation.getter(#isDisconnected), returnValue: false)
-      as bool);
+  bool get isDisconnected => (super.noSuchMethod(
+        Invocation.getter(#isDisconnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isUnmanaged =>
-      (super.noSuchMethod(Invocation.getter(#isUnmanaged), returnValue: false)
-          as bool);
+  bool get isUnmanaged => (super.noSuchMethod(
+        Invocation.getter(#isUnmanaged),
+        returnValue: false,
+      ) as bool);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevice(_i2.NetworkManagerDevice? device) =>
-      super.noSuchMethod(Invocation.method(#updateDevice, [device]),
-          returnValueForMissingStub: null);
+  void updateDevice(_i2.NetworkManagerDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [HiddenWifiModel].
@@ -520,137 +862,246 @@ class MockHiddenWifiModel extends _i1.Mock implements _i9.HiddenWifiModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i8.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i8.ConnectMode.none) as _i8.ConnectMode);
+  _i8.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i8.ConnectMode.none,
+      ) as _i8.ConnectMode);
   @override
-  String get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: '') as String);
+  String get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_1(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_1(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i4.WifiDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i4.WifiDevice>[]) as List<_i4.WifiDevice>);
+  List<_i4.WifiDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i4.WifiDevice>[],
+      ) as List<_i4.WifiDevice>);
   @override
-  _i5.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i5.Future<dynamic> connect() =>
-      (super.noSuchMethod(Invocation.method(#connect, []),
-          returnValue: _i5.Future<dynamic>.value()) as _i5.Future<dynamic>);
+  _i5.Future<dynamic> connect() => (super.noSuchMethod(
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<dynamic>.value(),
+      ) as _i5.Future<dynamic>);
   @override
-  void setSsid(String? ssid) =>
-      super.noSuchMethod(Invocation.method(#setSsid, [ssid]),
-          returnValueForMissingStub: null);
+  void setSsid(String? ssid) => super.noSuchMethod(
+        Invocation.method(
+          #setSsid,
+          [ssid],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i4.WifiDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeWifiDevice_4(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i4.WifiDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeWifiDevice_4(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i4.WifiDevice);
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i4.WifiDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i4.WifiDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i4.WifiDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i4.WifiDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [NetworkService].
@@ -662,204 +1113,285 @@ class MockNetworkService extends _i1.Mock implements _i2.NetworkService {
   }
 
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get wiredDevices =>
-      (super.noSuchMethod(Invocation.getter(#wiredDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
+        Invocation.getter(#wiredDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get wirelessDevices =>
-      (super.noSuchMethod(Invocation.getter(#wirelessDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wirelessDevices => (super.noSuchMethod(
+        Invocation.getter(#wirelessDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  _i5.Stream<_i2.NetworkManagerDevice> get deviceAdded =>
-      (super.noSuchMethod(Invocation.getter(#deviceAdded),
-              returnValue: _i5.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i5.Stream<_i2.NetworkManagerDevice>);
+  _i5.Stream<_i2.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i5.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i5.Stream<_i2.NetworkManagerDevice>);
   @override
-  _i5.Stream<_i2.NetworkManagerDevice> get deviceRemoved =>
-      (super.noSuchMethod(Invocation.getter(#deviceRemoved),
-              returnValue: _i5.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i5.Stream<_i2.NetworkManagerDevice>);
+  _i5.Stream<_i2.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i5.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i5.Stream<_i2.NetworkManagerDevice>);
   @override
   _i5.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionAdded =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionAdded),
-              returnValue:
-                  _i5.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i5.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionAdded),
+        returnValue: _i5.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i5.Stream<_i2.NetworkManagerActiveConnection>);
   @override
   _i5.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionRemoved =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionRemoved),
-              returnValue:
-                  _i5.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i5.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionRemoved),
+        returnValue: _i5.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i5.Stream<_i2.NetworkManagerActiveConnection>);
   @override
-  _i5.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i5.Stream<List<String>>.empty())
-          as _i5.Stream<List<String>>);
+  _i5.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i5.Stream<List<String>>.empty(),
+      ) as _i5.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get allDevices =>
-      (super.noSuchMethod(Invocation.getter(#allDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get allDevices => (super.noSuchMethod(
+        Invocation.getter(#allDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  bool get networkingEnabled =>
-      (super.noSuchMethod(Invocation.getter(#networkingEnabled),
-          returnValue: false) as bool);
+  bool get networkingEnabled => (super.noSuchMethod(
+        Invocation.getter(#networkingEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessEnabled => (super
-          .noSuchMethod(Invocation.getter(#wirelessEnabled), returnValue: false)
-      as bool);
+  bool get wirelessEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wirelessHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wirelessHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanEnabled), returnValue: false)
-          as bool);
+  bool get wwanEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wwanHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
   List<_i2.NetworkManagerActiveConnection> get activeConnections =>
-      (super.noSuchMethod(Invocation.getter(#activeConnections),
-              returnValue: <_i2.NetworkManagerActiveConnection>[])
-          as List<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnections),
+        returnValue: <_i2.NetworkManagerActiveConnection>[],
+      ) as List<_i2.NetworkManagerActiveConnection>);
   @override
-  String get primaryConnectionType =>
-      (super.noSuchMethod(Invocation.getter(#primaryConnectionType),
-          returnValue: '') as String);
+  String get primaryConnectionType => (super.noSuchMethod(
+        Invocation.getter(#primaryConnectionType),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get startup =>
-      (super.noSuchMethod(Invocation.getter(#startup), returnValue: false)
-          as bool);
+  bool get startup => (super.noSuchMethod(
+        Invocation.getter(#startup),
+        returnValue: false,
+      ) as bool);
   @override
-  String get version =>
-      (super.noSuchMethod(Invocation.getter(#version), returnValue: '')
-          as String);
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerConnectivityState get connectivity =>
-      (super.noSuchMethod(Invocation.getter(#connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+  _i2.NetworkManagerConnectivityState get connectivity => (super.noSuchMethod(
+        Invocation.getter(#connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
-  bool get connectivityCheckAvailable =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckAvailable),
-          returnValue: false) as bool);
+  bool get connectivityCheckAvailable => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get connectivityCheckEnabled =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckEnabled),
-          returnValue: false) as bool);
+  bool get connectivityCheckEnabled => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  String get connectivityCheckUri =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckUri),
-          returnValue: '') as String);
+  String get connectivityCheckUri => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckUri),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkManagerState get state => (super.noSuchMethod(
-      Invocation.getter(#state),
-      returnValue: _i2.NetworkManagerState.unknown) as _i2.NetworkManagerState);
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerState.unknown,
+      ) as _i2.NetworkManagerState);
   @override
   _i2.NetworkManagerSettings get settings => (super.noSuchMethod(
+        Invocation.getter(#settings),
+        returnValue: _FakeNetworkManagerSettings_5(
+          this,
           Invocation.getter(#settings),
-          returnValue:
-              _FakeNetworkManagerSettings_5(this, Invocation.getter(#settings)))
-      as _i2.NetworkManagerSettings);
+        ),
+      ) as _i2.NetworkManagerSettings);
   @override
-  _i2.NetworkManagerDnsManager get dnsManager =>
-      (super.noSuchMethod(Invocation.getter(#dnsManager),
-              returnValue: _FakeNetworkManagerDnsManager_6(
-                  this, Invocation.getter(#dnsManager)))
-          as _i2.NetworkManagerDnsManager);
+  _i2.NetworkManagerDnsManager get dnsManager => (super.noSuchMethod(
+        Invocation.getter(#dnsManager),
+        returnValue: _FakeNetworkManagerDnsManager_6(
+          this,
+          Invocation.getter(#dnsManager),
+        ),
+      ) as _i2.NetworkManagerDnsManager);
   @override
   Map<String, Map<String, _i10.DBusValue>> getWifiSettings({String? ssid}) =>
       (super.noSuchMethod(
-              Invocation.method(#getWifiSettings, [], {#ssid: ssid}),
-              returnValue: <String, Map<String, _i10.DBusValue>>{})
-          as Map<String, Map<String, _i10.DBusValue>>);
+        Invocation.method(
+          #getWifiSettings,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: <String, Map<String, _i10.DBusValue>>{},
+      ) as Map<String, Map<String, _i10.DBusValue>>);
   @override
   _i5.Future<void> markConfigured() => (super.noSuchMethod(
-      Invocation.method(#markConfigured, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWirelessEnabled, [value]),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #setWirelessEnabled,
+          [value],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWwanEnabled, [value]),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #setWwanEnabled,
+          [value],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> setConnectivityCheckEnabled(bool? value) =>
       (super.noSuchMethod(
-              Invocation.method(#setConnectivityCheckEnabled, [value]),
-              returnValue: _i5.Future<void>.value(),
-              returnValueForMissingStub: _i5.Future<void>.value())
-          as _i5.Future<void>);
+        Invocation.method(
+          #setConnectivityCheckEnabled,
+          [value],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection(
-          {Map<String, Map<String, _i10.DBusValue>>? connection = const {},
-          _i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#addAndActivateConnection, [], {#connection: connection, #device: device, #accessPoint: accessPoint}),
-          returnValue: _i5.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_7(
-                  this,
-                  Invocation.method(#addAndActivateConnection, [], {
-                    #connection: connection,
-                    #device: device,
-                    #accessPoint: accessPoint
-                  })))) as _i5.Future<_i2.NetworkManagerActiveConnection>);
+  _i5.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i10.DBusValue>>? connection = const {},
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAndActivateConnection,
+          [],
+          {
+            #connection: connection,
+            #device: device,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i5.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_7(
+          this,
+          Invocation.method(
+            #addAndActivateConnection,
+            [],
+            {
+              #connection: connection,
+              #device: device,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.NetworkManagerActiveConnection>);
   @override
-  _i5.Future<_i2.NetworkManagerActiveConnection> activateConnection(
-          {_i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerSettingsConnection? connection,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#activateConnection, [], {#device: device, #connection: connection, #accessPoint: accessPoint}),
-          returnValue: _i5.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_7(
-                  this,
-                  Invocation.method(#activateConnection, [], {
-                    #device: device,
-                    #connection: connection,
-                    #accessPoint: accessPoint
-                  })))) as _i5.Future<_i2.NetworkManagerActiveConnection>);
+  _i5.Future<_i2.NetworkManagerActiveConnection> activateConnection({
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerSettingsConnection? connection,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #activateConnection,
+          [],
+          {
+            #device: device,
+            #connection: connection,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i5.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_7(
+          this,
+          Invocation.method(
+            #activateConnection,
+            [],
+            {
+              #device: device,
+              #connection: connection,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.NetworkManagerActiveConnection>);
   @override
   _i5.Future<void> deactivateConnection(
           _i2.NetworkManagerActiveConnection? connection) =>
       (super.noSuchMethod(
-              Invocation.method(#deactivateConnection, [connection]),
-              returnValue: _i5.Future<void>.value(),
-              returnValueForMissingStub: _i5.Future<void>.value())
-          as _i5.Future<void>);
+        Invocation.method(
+          #deactivateConnection,
+          [connection],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [UdevDeviceInfo].
@@ -871,9 +1403,10 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
   }
 
   @override
-  String get fullName =>
-      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
-          as String);
+  String get fullName => (super.noSuchMethod(
+        Invocation.getter(#fullName),
+        returnValue: '',
+      ) as String);
 }
 
 /// A class which mocks [UdevService].
@@ -885,17 +1418,33 @@ class MockUdevService extends _i1.Mock implements _i2.UdevService {
   }
 
   @override
-  _i2.UdevDeviceInfo bySysname(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
-              returnValue: _FakeUdevDeviceInfo_8(
-                  this, Invocation.method(#bySysname, [sysname])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
+        Invocation.method(
+          #bySysname,
+          [sysname],
+        ),
+        returnValue: _FakeUdevDeviceInfo_8(
+          this,
+          Invocation.method(
+            #bySysname,
+            [sysname],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
   @override
-  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
-      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
-              returnValue: _FakeUdevDeviceInfo_8(
-                  this, Invocation.method(#bySyspath, [syspath])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
+        Invocation.method(
+          #bySyspath,
+          [syspath],
+        ),
+        returnValue: _FakeUdevDeviceInfo_8(
+          this,
+          Invocation.method(
+            #bySyspath,
+            [syspath],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
 }
 
 /// A class which mocks [WifiModel].
@@ -907,143 +1456,259 @@ class MockWifiModel extends _i1.Mock implements _i4.WifiModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i8.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i8.ConnectMode.none) as _i8.ConnectMode);
+  _i8.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i8.ConnectMode.none,
+      ) as _i8.ConnectMode);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_1(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_1(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i4.WifiDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i4.WifiDevice>[]) as List<_i4.WifiDevice>);
+  List<_i4.WifiDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i4.WifiDevice>[],
+      ) as List<_i4.WifiDevice>);
   @override
-  _i5.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i4.WifiDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeWifiDevice_4(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i4.WifiDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeWifiDevice_4(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i4.WifiDevice);
   @override
-  void startPeriodicScanning() =>
-      super.noSuchMethod(Invocation.method(#startPeriodicScanning, []),
-          returnValueForMissingStub: null);
+  void startPeriodicScanning() => super.noSuchMethod(
+        Invocation.method(
+          #startPeriodicScanning,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void stopPeriodicScanning() =>
-      super.noSuchMethod(Invocation.method(#stopPeriodicScanning, []),
-          returnValueForMissingStub: null);
+  void stopPeriodicScanning() => super.noSuchMethod(
+        Invocation.method(
+          #stopPeriodicScanning,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i5.Future<dynamic> requestScan({String? ssid}) =>
-      (super.noSuchMethod(Invocation.method(#requestScan, [], {#ssid: ssid}),
-          returnValue: _i5.Future<dynamic>.value()) as _i5.Future<dynamic>);
+  _i5.Future<dynamic> requestScan({String? ssid}) => (super.noSuchMethod(
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: _i5.Future<dynamic>.value(),
+      ) as _i5.Future<dynamic>);
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i4.WifiDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i4.WifiDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i4.WifiDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i4.WifiDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [WifiDevice].
@@ -1055,134 +1720,228 @@ class MockWifiDevice extends _i1.Mock implements _i4.WifiDevice {
   }
 
   @override
-  bool get isActive =>
-      (super.noSuchMethod(Invocation.getter(#isActive), returnValue: false)
-          as bool);
+  bool get isActive => (super.noSuchMethod(
+        Invocation.getter(#isActive),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i4.AccessPoint> get accessPoints =>
-      (super.noSuchMethod(Invocation.getter(#accessPoints),
-          returnValue: <_i4.AccessPoint>[]) as List<_i4.AccessPoint>);
+  List<_i4.AccessPoint> get accessPoints => (super.noSuchMethod(
+        Invocation.getter(#accessPoints),
+        returnValue: <_i4.AccessPoint>[],
+      ) as List<_i4.AccessPoint>);
   @override
-  bool get scanning =>
-      (super.noSuchMethod(Invocation.getter(#scanning), returnValue: false)
-          as bool);
+  bool get scanning => (super.noSuchMethod(
+        Invocation.getter(#scanning),
+        returnValue: false,
+      ) as bool);
   @override
-  int get lastScan =>
-      (super.noSuchMethod(Invocation.getter(#lastScan), returnValue: 0) as int);
+  int get lastScan => (super.noSuchMethod(
+        Invocation.getter(#lastScan),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerDevice get device =>
-      (super.noSuchMethod(Invocation.getter(#device),
-              returnValue:
-                  _FakeNetworkManagerDevice_3(this, Invocation.getter(#device)))
-          as _i2.NetworkManagerDevice);
+  _i2.NetworkManagerDevice get device => (super.noSuchMethod(
+        Invocation.getter(#device),
+        returnValue: _FakeNetworkManagerDevice_3(
+          this,
+          Invocation.getter(#device),
+        ),
+      ) as _i2.NetworkManagerDevice);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisconnected => (super
-          .noSuchMethod(Invocation.getter(#isDisconnected), returnValue: false)
-      as bool);
+  bool get isDisconnected => (super.noSuchMethod(
+        Invocation.getter(#isDisconnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isUnmanaged =>
-      (super.noSuchMethod(Invocation.getter(#isUnmanaged), returnValue: false)
-          as bool);
+  bool get isUnmanaged => (super.noSuchMethod(
+        Invocation.getter(#isUnmanaged),
+        returnValue: false,
+      ) as bool);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevice(_i2.NetworkManagerDevice? device) =>
-      super.noSuchMethod(Invocation.method(#updateDevice, [device]),
-          returnValueForMissingStub: null);
+  void updateDevice(_i2.NetworkManagerDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool isActiveAccessPoint(_i4.AccessPoint? accessPoint) => (super.noSuchMethod(
-      Invocation.method(#isActiveAccessPoint, [accessPoint]),
-      returnValue: false) as bool);
+        Invocation.method(
+          #isActiveAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  bool isSelectedAccessPoint(_i4.AccessPoint? accessPoint) => (super
-      .noSuchMethod(Invocation.method(#isSelectedAccessPoint, [accessPoint]),
-          returnValue: false) as bool);
+  bool isSelectedAccessPoint(_i4.AccessPoint? accessPoint) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectAccessPoint(_i4.AccessPoint? accessPoint) =>
-      super.noSuchMethod(Invocation.method(#selectAccessPoint, [accessPoint]),
-          returnValueForMissingStub: null);
+  void selectAccessPoint(_i4.AccessPoint? accessPoint) => super.noSuchMethod(
+        Invocation.method(
+          #selectAccessPoint,
+          [accessPoint],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> requestScan({String? ssid}) => (super.noSuchMethod(
-      Invocation.method(#requestScan, [], {#ssid: ssid}),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i4.AccessPoint? findAccessPoint(String? ssid) =>
-      (super.noSuchMethod(Invocation.method(#findAccessPoint, [ssid]))
-          as _i4.AccessPoint?);
+      (super.noSuchMethod(Invocation.method(
+        #findAccessPoint,
+        [ssid],
+      )) as _i4.AccessPoint?);
   @override
   _i5.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
@@ -24,27 +24,45 @@ import 'package:ubuntu_desktop_installer/services/network_service.dart' as _i5;
 class _FakeNetworkManagerDeviceStateAndReason_0 extends _i1.SmartFake
     implements _i2.NetworkManagerDeviceStateAndReason {
   _FakeNetworkManagerDeviceStateAndReason_0(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerSettings_1 extends _i1.SmartFake
     implements _i2.NetworkManagerSettings {
-  _FakeNetworkManagerSettings_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerSettings_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDnsManager_2 extends _i1.SmartFake
     implements _i2.NetworkManagerDnsManager {
-  _FakeNetworkManagerDnsManager_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDnsManager_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerActiveConnection_3 extends _i1.SmartFake
     implements _i2.NetworkManagerActiveConnection {
   _FakeNetworkManagerActiveConnection_3(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [NetworkManagerActiveConnection].
@@ -57,45 +75,56 @@ class MockNetworkManagerActiveConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get id =>
-      (super.noSuchMethod(Invocation.getter(#id), returnValue: '') as String);
+  String get id => (super.noSuchMethod(
+        Invocation.getter(#id),
+        returnValue: '',
+      ) as String);
   @override
-  String get uuid =>
-      (super.noSuchMethod(Invocation.getter(#uuid), returnValue: '') as String);
+  String get uuid => (super.noSuchMethod(
+        Invocation.getter(#uuid),
+        returnValue: '',
+      ) as String);
   @override
-  String get type =>
-      (super.noSuchMethod(Invocation.getter(#type), returnValue: '') as String);
+  String get type => (super.noSuchMethod(
+        Invocation.getter(#type),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerActiveConnectionState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerActiveConnectionState.unknown)
-          as _i2.NetworkManagerActiveConnectionState);
+  _i2.NetworkManagerActiveConnectionState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerActiveConnectionState.unknown,
+      ) as _i2.NetworkManagerActiveConnectionState);
   @override
   List<_i2.NetworkManagerActivationStateFlag> get stateFlags =>
-      (super.noSuchMethod(Invocation.getter(#stateFlags),
-              returnValue: <_i2.NetworkManagerActivationStateFlag>[])
-          as List<_i2.NetworkManagerActivationStateFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#stateFlags),
+        returnValue: <_i2.NetworkManagerActivationStateFlag>[],
+      ) as List<_i2.NetworkManagerActivationStateFlag>);
   @override
-  bool get default4 =>
-      (super.noSuchMethod(Invocation.getter(#default4), returnValue: false)
-          as bool);
+  bool get default4 => (super.noSuchMethod(
+        Invocation.getter(#default4),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get default6 =>
-      (super.noSuchMethod(Invocation.getter(#default6), returnValue: false)
-          as bool);
+  bool get default6 => (super.noSuchMethod(
+        Invocation.getter(#default6),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get vpn =>
-      (super.noSuchMethod(Invocation.getter(#vpn), returnValue: false) as bool);
+  bool get vpn => (super.noSuchMethod(
+        Invocation.getter(#vpn),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
 }
 
 /// A class which mocks [NetworkManagerDevice].
@@ -108,133 +137,174 @@ class MockNetworkManagerDevice extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get udi =>
-      (super.noSuchMethod(Invocation.getter(#udi), returnValue: '') as String);
+  String get udi => (super.noSuchMethod(
+        Invocation.getter(#udi),
+        returnValue: '',
+      ) as String);
   @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  String get path => (super.noSuchMethod(
+        Invocation.getter(#path),
+        returnValue: '',
+      ) as String);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  String get ipInterface =>
-      (super.noSuchMethod(Invocation.getter(#ipInterface), returnValue: '')
-          as String);
+  String get ipInterface => (super.noSuchMethod(
+        Invocation.getter(#ipInterface),
+        returnValue: '',
+      ) as String);
   @override
-  String get driver =>
-      (super.noSuchMethod(Invocation.getter(#driver), returnValue: '')
-          as String);
+  String get driver => (super.noSuchMethod(
+        Invocation.getter(#driver),
+        returnValue: '',
+      ) as String);
   @override
-  String get driverVersion =>
-      (super.noSuchMethod(Invocation.getter(#driverVersion), returnValue: '')
-          as String);
+  String get driverVersion => (super.noSuchMethod(
+        Invocation.getter(#driverVersion),
+        returnValue: '',
+      ) as String);
   @override
-  String get firmwareVersion =>
-      (super.noSuchMethod(Invocation.getter(#firmwareVersion), returnValue: '')
-          as String);
+  String get firmwareVersion => (super.noSuchMethod(
+        Invocation.getter(#firmwareVersion),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerDeviceCapability> get capabilities =>
-      (super.noSuchMethod(Invocation.getter(#capabilities),
-              returnValue: <_i2.NetworkManagerDeviceCapability>[])
-          as List<_i2.NetworkManagerDeviceCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#capabilities),
+        returnValue: <_i2.NetworkManagerDeviceCapability>[],
+      ) as List<_i2.NetworkManagerDeviceCapability>);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  _i2.NetworkManagerDeviceStateAndReason get stateReason =>
-      (super.noSuchMethod(Invocation.getter(#stateReason),
-              returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
-                  this, Invocation.getter(#stateReason)))
-          as _i2.NetworkManagerDeviceStateAndReason);
+  _i2.NetworkManagerDeviceStateAndReason get stateReason => (super.noSuchMethod(
+        Invocation.getter(#stateReason),
+        returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
+          this,
+          Invocation.getter(#stateReason),
+        ),
+      ) as _i2.NetworkManagerDeviceStateAndReason);
   @override
-  bool get managed =>
-      (super.noSuchMethod(Invocation.getter(#managed), returnValue: false)
-          as bool);
+  bool get managed => (super.noSuchMethod(
+        Invocation.getter(#managed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get autoconnect =>
-      (super.noSuchMethod(Invocation.getter(#autoconnect), returnValue: false)
-          as bool);
+  bool get autoconnect => (super.noSuchMethod(
+        Invocation.getter(#autoconnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get firmwareMissing => (super
-          .noSuchMethod(Invocation.getter(#firmwareMissing), returnValue: false)
-      as bool);
+  bool get firmwareMissing => (super.noSuchMethod(
+        Invocation.getter(#firmwareMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get nmPluginMissing => (super
-          .noSuchMethod(Invocation.getter(#nmPluginMissing), returnValue: false)
-      as bool);
+  bool get nmPluginMissing => (super.noSuchMethod(
+        Invocation.getter(#nmPluginMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  _i2.NetworkManagerDeviceType get deviceType =>
-      (super.noSuchMethod(Invocation.getter(#deviceType),
-              returnValue: _i2.NetworkManagerDeviceType.unknown)
-          as _i2.NetworkManagerDeviceType);
+  _i2.NetworkManagerDeviceType get deviceType => (super.noSuchMethod(
+        Invocation.getter(#deviceType),
+        returnValue: _i2.NetworkManagerDeviceType.unknown,
+      ) as _i2.NetworkManagerDeviceType);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  String get physicalPortId =>
-      (super.noSuchMethod(Invocation.getter(#physicalPortId), returnValue: '')
-          as String);
+  String get physicalPortId => (super.noSuchMethod(
+        Invocation.getter(#physicalPortId),
+        returnValue: '',
+      ) as String);
   @override
-  int get mtu =>
-      (super.noSuchMethod(Invocation.getter(#mtu), returnValue: 0) as int);
+  int get mtu => (super.noSuchMethod(
+        Invocation.getter(#mtu),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get real =>
-      (super.noSuchMethod(Invocation.getter(#real), returnValue: false)
-          as bool);
+  bool get real => (super.noSuchMethod(
+        Invocation.getter(#real),
+        returnValue: false,
+      ) as bool);
   @override
   _i2.NetworkManagerConnectivityState get ip4Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip4Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip4Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   _i2.NetworkManagerConnectivityState get ip6Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip6Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip6Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   List<_i2.NetworkManagerDeviceInterfaceFlag> get interfaceFlags =>
-      (super.noSuchMethod(Invocation.getter(#interfaceFlags),
-              returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[])
-          as List<_i2.NetworkManagerDeviceInterfaceFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#interfaceFlags),
+        returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[],
+      ) as List<_i2.NetworkManagerDeviceInterfaceFlag>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setManaged(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setManaged, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setManaged,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setAutoconnect(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setAutoconnect, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setAutoconnect,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkManagerSettingsConnection].
@@ -247,66 +317,95 @@ class MockNetworkManagerSettingsConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  bool get unsaved =>
-      (super.noSuchMethod(Invocation.getter(#unsaved), returnValue: false)
-          as bool);
+  bool get unsaved => (super.noSuchMethod(
+        Invocation.getter(#unsaved),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerConnectionFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerConnectionFlag>[])
-          as List<_i2.NetworkManagerConnectionFlag>);
+  List<_i2.NetworkManagerConnectionFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerConnectionFlag>[],
+      ) as List<_i2.NetworkManagerConnectionFlag>);
   @override
-  String get filename =>
-      (super.noSuchMethod(Invocation.getter(#filename), returnValue: '')
-          as String);
+  String get filename => (super.noSuchMethod(
+        Invocation.getter(#filename),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> update(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#update, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> updateUnsaved(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#updateUnsaved, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUnsaved,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSettings() =>
-      (super.noSuchMethod(Invocation.method(#getSettings, []),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSettings,
+          [],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSecrets(
           [String? settingName = r'']) =>
-      (super.noSuchMethod(Invocation.method(#getSecrets, [settingName]),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSecrets,
+          [settingName],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<void> clearSecrets() => (super.noSuchMethod(
-      Invocation.method(#clearSecrets, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #clearSecrets,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkService].
@@ -318,202 +417,283 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
   }
 
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get wiredDevices =>
-      (super.noSuchMethod(Invocation.getter(#wiredDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
+        Invocation.getter(#wiredDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get wirelessDevices =>
-      (super.noSuchMethod(Invocation.getter(#wirelessDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wirelessDevices => (super.noSuchMethod(
+        Invocation.getter(#wirelessDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded =>
-      (super.noSuchMethod(Invocation.getter(#deviceAdded),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved =>
-      (super.noSuchMethod(Invocation.getter(#deviceRemoved),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionAdded =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionAdded),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionRemoved =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionRemoved),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get allDevices =>
-      (super.noSuchMethod(Invocation.getter(#allDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get allDevices => (super.noSuchMethod(
+        Invocation.getter(#allDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  bool get networkingEnabled =>
-      (super.noSuchMethod(Invocation.getter(#networkingEnabled),
-          returnValue: false) as bool);
+  bool get networkingEnabled => (super.noSuchMethod(
+        Invocation.getter(#networkingEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessEnabled => (super
-          .noSuchMethod(Invocation.getter(#wirelessEnabled), returnValue: false)
-      as bool);
+  bool get wirelessEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wirelessHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wirelessHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanEnabled), returnValue: false)
-          as bool);
+  bool get wwanEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wwanHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
   List<_i2.NetworkManagerActiveConnection> get activeConnections =>
-      (super.noSuchMethod(Invocation.getter(#activeConnections),
-              returnValue: <_i2.NetworkManagerActiveConnection>[])
-          as List<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnections),
+        returnValue: <_i2.NetworkManagerActiveConnection>[],
+      ) as List<_i2.NetworkManagerActiveConnection>);
   @override
-  String get primaryConnectionType =>
-      (super.noSuchMethod(Invocation.getter(#primaryConnectionType),
-          returnValue: '') as String);
+  String get primaryConnectionType => (super.noSuchMethod(
+        Invocation.getter(#primaryConnectionType),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get startup =>
-      (super.noSuchMethod(Invocation.getter(#startup), returnValue: false)
-          as bool);
+  bool get startup => (super.noSuchMethod(
+        Invocation.getter(#startup),
+        returnValue: false,
+      ) as bool);
   @override
-  String get version =>
-      (super.noSuchMethod(Invocation.getter(#version), returnValue: '')
-          as String);
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerConnectivityState get connectivity =>
-      (super.noSuchMethod(Invocation.getter(#connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+  _i2.NetworkManagerConnectivityState get connectivity => (super.noSuchMethod(
+        Invocation.getter(#connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
-  bool get connectivityCheckAvailable =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckAvailable),
-          returnValue: false) as bool);
+  bool get connectivityCheckAvailable => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get connectivityCheckEnabled =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckEnabled),
-          returnValue: false) as bool);
+  bool get connectivityCheckEnabled => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  String get connectivityCheckUri =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckUri),
-          returnValue: '') as String);
+  String get connectivityCheckUri => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckUri),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkManagerState get state => (super.noSuchMethod(
-      Invocation.getter(#state),
-      returnValue: _i2.NetworkManagerState.unknown) as _i2.NetworkManagerState);
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerState.unknown,
+      ) as _i2.NetworkManagerState);
   @override
   _i2.NetworkManagerSettings get settings => (super.noSuchMethod(
+        Invocation.getter(#settings),
+        returnValue: _FakeNetworkManagerSettings_1(
+          this,
           Invocation.getter(#settings),
-          returnValue:
-              _FakeNetworkManagerSettings_1(this, Invocation.getter(#settings)))
-      as _i2.NetworkManagerSettings);
+        ),
+      ) as _i2.NetworkManagerSettings);
   @override
-  _i2.NetworkManagerDnsManager get dnsManager =>
-      (super.noSuchMethod(Invocation.getter(#dnsManager),
-              returnValue: _FakeNetworkManagerDnsManager_2(
-                  this, Invocation.getter(#dnsManager)))
-          as _i2.NetworkManagerDnsManager);
+  _i2.NetworkManagerDnsManager get dnsManager => (super.noSuchMethod(
+        Invocation.getter(#dnsManager),
+        returnValue: _FakeNetworkManagerDnsManager_2(
+          this,
+          Invocation.getter(#dnsManager),
+        ),
+      ) as _i2.NetworkManagerDnsManager);
   @override
   Map<String, Map<String, _i4.DBusValue>> getWifiSettings({String? ssid}) =>
       (super.noSuchMethod(
-              Invocation.method(#getWifiSettings, [], {#ssid: ssid}),
-              returnValue: <String, Map<String, _i4.DBusValue>>{})
-          as Map<String, Map<String, _i4.DBusValue>>);
+        Invocation.method(
+          #getWifiSettings,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: <String, Map<String, _i4.DBusValue>>{},
+      ) as Map<String, Map<String, _i4.DBusValue>>);
   @override
   _i3.Future<void> markConfigured() => (super.noSuchMethod(
-      Invocation.method(#markConfigured, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWirelessEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWirelessEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWwanEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWwanEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setConnectivityCheckEnabled(bool? value) =>
       (super.noSuchMethod(
-              Invocation.method(#setConnectivityCheckEnabled, [value]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #setConnectivityCheckEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection(
-          {Map<String, Map<String, _i4.DBusValue>>? connection = const {},
-          _i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#addAndActivateConnection, [], {#connection: connection, #device: device, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#addAndActivateConnection, [], {
-                    #connection: connection,
-                    #device: device,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i4.DBusValue>>? connection = const {},
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAndActivateConnection,
+          [],
+          {
+            #connection: connection,
+            #device: device,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #addAndActivateConnection,
+            [],
+            {
+              #connection: connection,
+              #device: device,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection(
-          {_i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerSettingsConnection? connection,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#activateConnection, [], {#device: device, #connection: connection, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#activateConnection, [], {
-                    #device: device,
-                    #connection: connection,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection({
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerSettingsConnection? connection,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #activateConnection,
+          [],
+          {
+            #device: device,
+            #connection: connection,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #activateConnection,
+            [],
+            {
+              #device: device,
+              #connection: connection,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Future<void> deactivateConnection(
           _i2.NetworkManagerActiveConnection? connection) =>
       (super.noSuchMethod(
-              Invocation.method(#deactivateConnection, [connection]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #deactivateConnection,
+          [connection],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_view_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_view_test.mocks.dart
@@ -26,20 +26,35 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeNetworkService_0 extends _i1.SmartFake
     implements _i2.NetworkService {
-  _FakeNetworkService_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkService_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeEthernetDevice_1 extends _i1.SmartFake
     implements _i3.EthernetDevice {
-  _FakeEthernetDevice_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEthernetDevice_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDevice_2 extends _i1.SmartFake
     implements _i2.NetworkManagerDevice {
-  _FakeNetworkManagerDevice_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDevice_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [EthernetModel].
@@ -51,131 +66,234 @@ class MockEthernetModel extends _i1.Mock implements _i3.EthernetModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i4.ConnectMode.none) as _i4.ConnectMode);
+  _i4.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i4.ConnectMode.none,
+      ) as _i4.ConnectMode);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_0(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_0(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i3.EthernetDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i3.EthernetDevice>[]) as List<_i3.EthernetDevice>);
+  List<_i3.EthernetDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i3.EthernetDevice>[],
+      ) as List<_i3.EthernetDevice>);
   @override
-  _i5.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i5.Stream<dynamic>.empty()) as _i5.Stream<dynamic>);
+  _i5.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i5.Stream<dynamic>.empty(),
+      ) as _i5.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i3.EthernetDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeEthernetDevice_1(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i3.EthernetDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeEthernetDevice_1(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i3.EthernetDevice);
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i3.EthernetDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i3.EthernetDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i3.EthernetDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i3.EthernetDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [EthernetDevice].
@@ -187,102 +305,172 @@ class MockEthernetDevice extends _i1.Mock implements _i3.EthernetDevice {
   }
 
   @override
-  _i2.NetworkManagerDevice get device =>
-      (super.noSuchMethod(Invocation.getter(#device),
-              returnValue:
-                  _FakeNetworkManagerDevice_2(this, Invocation.getter(#device)))
-          as _i2.NetworkManagerDevice);
+  _i2.NetworkManagerDevice get device => (super.noSuchMethod(
+        Invocation.getter(#device),
+        returnValue: _FakeNetworkManagerDevice_2(
+          this,
+          Invocation.getter(#device),
+        ),
+      ) as _i2.NetworkManagerDevice);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  bool get isActive =>
-      (super.noSuchMethod(Invocation.getter(#isActive), returnValue: false)
-          as bool);
+  bool get isActive => (super.noSuchMethod(
+        Invocation.getter(#isActive),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisconnected => (super
-          .noSuchMethod(Invocation.getter(#isDisconnected), returnValue: false)
-      as bool);
+  bool get isDisconnected => (super.noSuchMethod(
+        Invocation.getter(#isDisconnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isUnmanaged =>
-      (super.noSuchMethod(Invocation.getter(#isUnmanaged), returnValue: false)
-          as bool);
+  bool get isUnmanaged => (super.noSuchMethod(
+        Invocation.getter(#isUnmanaged),
+        returnValue: false,
+      ) as bool);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevice(_i2.NetworkManagerDevice? device) =>
-      super.noSuchMethod(Invocation.method(#updateDevice, [device]),
-          returnValueForMissingStub: null);
+  void updateDevice(_i2.NetworkManagerDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i6.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
@@ -24,27 +24,45 @@ import 'package:ubuntu_desktop_installer/services/network_service.dart' as _i5;
 class _FakeNetworkManagerDeviceStateAndReason_0 extends _i1.SmartFake
     implements _i2.NetworkManagerDeviceStateAndReason {
   _FakeNetworkManagerDeviceStateAndReason_0(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerSettings_1 extends _i1.SmartFake
     implements _i2.NetworkManagerSettings {
-  _FakeNetworkManagerSettings_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerSettings_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDnsManager_2 extends _i1.SmartFake
     implements _i2.NetworkManagerDnsManager {
-  _FakeNetworkManagerDnsManager_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDnsManager_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerActiveConnection_3 extends _i1.SmartFake
     implements _i2.NetworkManagerActiveConnection {
   _FakeNetworkManagerActiveConnection_3(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [NetworkManagerAccessPoint].
@@ -57,52 +75,62 @@ class MockNetworkManagerAccessPoint extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerWifiAccessPointFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointFlag>);
+  List<_i2.NetworkManagerWifiAccessPointFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointFlag>);
   @override
   List<_i2.NetworkManagerWifiAccessPointSecurityFlag> get wpaFlags =>
-      (super.noSuchMethod(Invocation.getter(#wpaFlags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#wpaFlags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
   @override
   List<_i2.NetworkManagerWifiAccessPointSecurityFlag> get rsnFlags =>
-      (super.noSuchMethod(Invocation.getter(#rsnFlags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#rsnFlags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
   @override
-  List<int> get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: <int>[])
-          as List<int>);
+  List<int> get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: <int>[],
+      ) as List<int>);
   @override
-  int get frequency =>
-      (super.noSuchMethod(Invocation.getter(#frequency), returnValue: 0)
-          as int);
+  int get frequency => (super.noSuchMethod(
+        Invocation.getter(#frequency),
+        returnValue: 0,
+      ) as int);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerWifiMode get mode =>
-      (super.noSuchMethod(Invocation.getter(#mode),
-              returnValue: _i2.NetworkManagerWifiMode.unknown)
-          as _i2.NetworkManagerWifiMode);
+  _i2.NetworkManagerWifiMode get mode => (super.noSuchMethod(
+        Invocation.getter(#mode),
+        returnValue: _i2.NetworkManagerWifiMode.unknown,
+      ) as _i2.NetworkManagerWifiMode);
   @override
-  int get maxBitrate =>
-      (super.noSuchMethod(Invocation.getter(#maxBitrate), returnValue: 0)
-          as int);
+  int get maxBitrate => (super.noSuchMethod(
+        Invocation.getter(#maxBitrate),
+        returnValue: 0,
+      ) as int);
   @override
-  int get strength =>
-      (super.noSuchMethod(Invocation.getter(#strength), returnValue: 0) as int);
+  int get strength => (super.noSuchMethod(
+        Invocation.getter(#strength),
+        returnValue: 0,
+      ) as int);
   @override
-  int get lastSeen =>
-      (super.noSuchMethod(Invocation.getter(#lastSeen), returnValue: 0) as int);
+  int get lastSeen => (super.noSuchMethod(
+        Invocation.getter(#lastSeen),
+        returnValue: 0,
+      ) as int);
 }
 
 /// A class which mocks [NetworkManagerActiveConnection].
@@ -115,45 +143,56 @@ class MockNetworkManagerActiveConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get id =>
-      (super.noSuchMethod(Invocation.getter(#id), returnValue: '') as String);
+  String get id => (super.noSuchMethod(
+        Invocation.getter(#id),
+        returnValue: '',
+      ) as String);
   @override
-  String get uuid =>
-      (super.noSuchMethod(Invocation.getter(#uuid), returnValue: '') as String);
+  String get uuid => (super.noSuchMethod(
+        Invocation.getter(#uuid),
+        returnValue: '',
+      ) as String);
   @override
-  String get type =>
-      (super.noSuchMethod(Invocation.getter(#type), returnValue: '') as String);
+  String get type => (super.noSuchMethod(
+        Invocation.getter(#type),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerActiveConnectionState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerActiveConnectionState.unknown)
-          as _i2.NetworkManagerActiveConnectionState);
+  _i2.NetworkManagerActiveConnectionState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerActiveConnectionState.unknown,
+      ) as _i2.NetworkManagerActiveConnectionState);
   @override
   List<_i2.NetworkManagerActivationStateFlag> get stateFlags =>
-      (super.noSuchMethod(Invocation.getter(#stateFlags),
-              returnValue: <_i2.NetworkManagerActivationStateFlag>[])
-          as List<_i2.NetworkManagerActivationStateFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#stateFlags),
+        returnValue: <_i2.NetworkManagerActivationStateFlag>[],
+      ) as List<_i2.NetworkManagerActivationStateFlag>);
   @override
-  bool get default4 =>
-      (super.noSuchMethod(Invocation.getter(#default4), returnValue: false)
-          as bool);
+  bool get default4 => (super.noSuchMethod(
+        Invocation.getter(#default4),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get default6 =>
-      (super.noSuchMethod(Invocation.getter(#default6), returnValue: false)
-          as bool);
+  bool get default6 => (super.noSuchMethod(
+        Invocation.getter(#default6),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get vpn =>
-      (super.noSuchMethod(Invocation.getter(#vpn), returnValue: false) as bool);
+  bool get vpn => (super.noSuchMethod(
+        Invocation.getter(#vpn),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
 }
 
 /// A class which mocks [NetworkManagerDevice].
@@ -166,133 +205,174 @@ class MockNetworkManagerDevice extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get udi =>
-      (super.noSuchMethod(Invocation.getter(#udi), returnValue: '') as String);
+  String get udi => (super.noSuchMethod(
+        Invocation.getter(#udi),
+        returnValue: '',
+      ) as String);
   @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  String get path => (super.noSuchMethod(
+        Invocation.getter(#path),
+        returnValue: '',
+      ) as String);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  String get ipInterface =>
-      (super.noSuchMethod(Invocation.getter(#ipInterface), returnValue: '')
-          as String);
+  String get ipInterface => (super.noSuchMethod(
+        Invocation.getter(#ipInterface),
+        returnValue: '',
+      ) as String);
   @override
-  String get driver =>
-      (super.noSuchMethod(Invocation.getter(#driver), returnValue: '')
-          as String);
+  String get driver => (super.noSuchMethod(
+        Invocation.getter(#driver),
+        returnValue: '',
+      ) as String);
   @override
-  String get driverVersion =>
-      (super.noSuchMethod(Invocation.getter(#driverVersion), returnValue: '')
-          as String);
+  String get driverVersion => (super.noSuchMethod(
+        Invocation.getter(#driverVersion),
+        returnValue: '',
+      ) as String);
   @override
-  String get firmwareVersion =>
-      (super.noSuchMethod(Invocation.getter(#firmwareVersion), returnValue: '')
-          as String);
+  String get firmwareVersion => (super.noSuchMethod(
+        Invocation.getter(#firmwareVersion),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerDeviceCapability> get capabilities =>
-      (super.noSuchMethod(Invocation.getter(#capabilities),
-              returnValue: <_i2.NetworkManagerDeviceCapability>[])
-          as List<_i2.NetworkManagerDeviceCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#capabilities),
+        returnValue: <_i2.NetworkManagerDeviceCapability>[],
+      ) as List<_i2.NetworkManagerDeviceCapability>);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  _i2.NetworkManagerDeviceStateAndReason get stateReason =>
-      (super.noSuchMethod(Invocation.getter(#stateReason),
-              returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
-                  this, Invocation.getter(#stateReason)))
-          as _i2.NetworkManagerDeviceStateAndReason);
+  _i2.NetworkManagerDeviceStateAndReason get stateReason => (super.noSuchMethod(
+        Invocation.getter(#stateReason),
+        returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
+          this,
+          Invocation.getter(#stateReason),
+        ),
+      ) as _i2.NetworkManagerDeviceStateAndReason);
   @override
-  bool get managed =>
-      (super.noSuchMethod(Invocation.getter(#managed), returnValue: false)
-          as bool);
+  bool get managed => (super.noSuchMethod(
+        Invocation.getter(#managed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get autoconnect =>
-      (super.noSuchMethod(Invocation.getter(#autoconnect), returnValue: false)
-          as bool);
+  bool get autoconnect => (super.noSuchMethod(
+        Invocation.getter(#autoconnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get firmwareMissing => (super
-          .noSuchMethod(Invocation.getter(#firmwareMissing), returnValue: false)
-      as bool);
+  bool get firmwareMissing => (super.noSuchMethod(
+        Invocation.getter(#firmwareMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get nmPluginMissing => (super
-          .noSuchMethod(Invocation.getter(#nmPluginMissing), returnValue: false)
-      as bool);
+  bool get nmPluginMissing => (super.noSuchMethod(
+        Invocation.getter(#nmPluginMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  _i2.NetworkManagerDeviceType get deviceType =>
-      (super.noSuchMethod(Invocation.getter(#deviceType),
-              returnValue: _i2.NetworkManagerDeviceType.unknown)
-          as _i2.NetworkManagerDeviceType);
+  _i2.NetworkManagerDeviceType get deviceType => (super.noSuchMethod(
+        Invocation.getter(#deviceType),
+        returnValue: _i2.NetworkManagerDeviceType.unknown,
+      ) as _i2.NetworkManagerDeviceType);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  String get physicalPortId =>
-      (super.noSuchMethod(Invocation.getter(#physicalPortId), returnValue: '')
-          as String);
+  String get physicalPortId => (super.noSuchMethod(
+        Invocation.getter(#physicalPortId),
+        returnValue: '',
+      ) as String);
   @override
-  int get mtu =>
-      (super.noSuchMethod(Invocation.getter(#mtu), returnValue: 0) as int);
+  int get mtu => (super.noSuchMethod(
+        Invocation.getter(#mtu),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get real =>
-      (super.noSuchMethod(Invocation.getter(#real), returnValue: false)
-          as bool);
+  bool get real => (super.noSuchMethod(
+        Invocation.getter(#real),
+        returnValue: false,
+      ) as bool);
   @override
   _i2.NetworkManagerConnectivityState get ip4Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip4Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip4Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   _i2.NetworkManagerConnectivityState get ip6Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip6Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip6Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   List<_i2.NetworkManagerDeviceInterfaceFlag> get interfaceFlags =>
-      (super.noSuchMethod(Invocation.getter(#interfaceFlags),
-              returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[])
-          as List<_i2.NetworkManagerDeviceInterfaceFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#interfaceFlags),
+        returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[],
+      ) as List<_i2.NetworkManagerDeviceInterfaceFlag>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setManaged(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setManaged, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setManaged,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setAutoconnect(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setAutoconnect, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setAutoconnect,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkManagerDeviceWireless].
@@ -305,39 +385,51 @@ class MockNetworkManagerDeviceWireless extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get permHwAddress =>
-      (super.noSuchMethod(Invocation.getter(#permHwAddress), returnValue: '')
-          as String);
+  String get permHwAddress => (super.noSuchMethod(
+        Invocation.getter(#permHwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerWifiMode get mode =>
-      (super.noSuchMethod(Invocation.getter(#mode),
-              returnValue: _i2.NetworkManagerWifiMode.unknown)
-          as _i2.NetworkManagerWifiMode);
+  _i2.NetworkManagerWifiMode get mode => (super.noSuchMethod(
+        Invocation.getter(#mode),
+        returnValue: _i2.NetworkManagerWifiMode.unknown,
+      ) as _i2.NetworkManagerWifiMode);
   @override
-  int get bitrate =>
-      (super.noSuchMethod(Invocation.getter(#bitrate), returnValue: 0) as int);
+  int get bitrate => (super.noSuchMethod(
+        Invocation.getter(#bitrate),
+        returnValue: 0,
+      ) as int);
   @override
-  List<_i2.NetworkManagerAccessPoint> get accessPoints =>
-      (super.noSuchMethod(Invocation.getter(#accessPoints),
-              returnValue: <_i2.NetworkManagerAccessPoint>[])
-          as List<_i2.NetworkManagerAccessPoint>);
+  List<_i2.NetworkManagerAccessPoint> get accessPoints => (super.noSuchMethod(
+        Invocation.getter(#accessPoints),
+        returnValue: <_i2.NetworkManagerAccessPoint>[],
+      ) as List<_i2.NetworkManagerAccessPoint>);
   @override
   List<_i2.NetworkManagerDeviceWifiCapability> get wirelessCapabilities =>
-      (super.noSuchMethod(Invocation.getter(#wirelessCapabilities),
-              returnValue: <_i2.NetworkManagerDeviceWifiCapability>[])
-          as List<_i2.NetworkManagerDeviceWifiCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#wirelessCapabilities),
+        returnValue: <_i2.NetworkManagerDeviceWifiCapability>[],
+      ) as List<_i2.NetworkManagerDeviceWifiCapability>);
   @override
-  int get lastScan =>
-      (super.noSuchMethod(Invocation.getter(#lastScan), returnValue: 0) as int);
+  int get lastScan => (super.noSuchMethod(
+        Invocation.getter(#lastScan),
+        returnValue: 0,
+      ) as int);
   @override
   _i3.Future<dynamic> requestScan({List<List<int>>? ssids}) =>
-      (super.noSuchMethod(Invocation.method(#requestScan, [], {#ssids: ssids}),
-          returnValue: _i3.Future<dynamic>.value()) as _i3.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssids: ssids},
+        ),
+        returnValue: _i3.Future<dynamic>.value(),
+      ) as _i3.Future<dynamic>);
 }
 
 /// A class which mocks [NetworkManagerSettingsConnection].
@@ -350,66 +442,95 @@ class MockNetworkManagerSettingsConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  bool get unsaved =>
-      (super.noSuchMethod(Invocation.getter(#unsaved), returnValue: false)
-          as bool);
+  bool get unsaved => (super.noSuchMethod(
+        Invocation.getter(#unsaved),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerConnectionFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerConnectionFlag>[])
-          as List<_i2.NetworkManagerConnectionFlag>);
+  List<_i2.NetworkManagerConnectionFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerConnectionFlag>[],
+      ) as List<_i2.NetworkManagerConnectionFlag>);
   @override
-  String get filename =>
-      (super.noSuchMethod(Invocation.getter(#filename), returnValue: '')
-          as String);
+  String get filename => (super.noSuchMethod(
+        Invocation.getter(#filename),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> update(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#update, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> updateUnsaved(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#updateUnsaved, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUnsaved,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSettings() =>
-      (super.noSuchMethod(Invocation.method(#getSettings, []),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSettings,
+          [],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSecrets(
           [String? settingName = r'']) =>
-      (super.noSuchMethod(Invocation.method(#getSecrets, [settingName]),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSecrets,
+          [settingName],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<void> clearSecrets() => (super.noSuchMethod(
-      Invocation.method(#clearSecrets, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #clearSecrets,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkService].
@@ -421,202 +542,283 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
   }
 
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get wiredDevices =>
-      (super.noSuchMethod(Invocation.getter(#wiredDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
+        Invocation.getter(#wiredDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get wirelessDevices =>
-      (super.noSuchMethod(Invocation.getter(#wirelessDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wirelessDevices => (super.noSuchMethod(
+        Invocation.getter(#wirelessDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded =>
-      (super.noSuchMethod(Invocation.getter(#deviceAdded),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved =>
-      (super.noSuchMethod(Invocation.getter(#deviceRemoved),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionAdded =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionAdded),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionRemoved =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionRemoved),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get allDevices =>
-      (super.noSuchMethod(Invocation.getter(#allDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get allDevices => (super.noSuchMethod(
+        Invocation.getter(#allDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  bool get networkingEnabled =>
-      (super.noSuchMethod(Invocation.getter(#networkingEnabled),
-          returnValue: false) as bool);
+  bool get networkingEnabled => (super.noSuchMethod(
+        Invocation.getter(#networkingEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessEnabled => (super
-          .noSuchMethod(Invocation.getter(#wirelessEnabled), returnValue: false)
-      as bool);
+  bool get wirelessEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wirelessHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wirelessHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanEnabled), returnValue: false)
-          as bool);
+  bool get wwanEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wwanHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
   List<_i2.NetworkManagerActiveConnection> get activeConnections =>
-      (super.noSuchMethod(Invocation.getter(#activeConnections),
-              returnValue: <_i2.NetworkManagerActiveConnection>[])
-          as List<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnections),
+        returnValue: <_i2.NetworkManagerActiveConnection>[],
+      ) as List<_i2.NetworkManagerActiveConnection>);
   @override
-  String get primaryConnectionType =>
-      (super.noSuchMethod(Invocation.getter(#primaryConnectionType),
-          returnValue: '') as String);
+  String get primaryConnectionType => (super.noSuchMethod(
+        Invocation.getter(#primaryConnectionType),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get startup =>
-      (super.noSuchMethod(Invocation.getter(#startup), returnValue: false)
-          as bool);
+  bool get startup => (super.noSuchMethod(
+        Invocation.getter(#startup),
+        returnValue: false,
+      ) as bool);
   @override
-  String get version =>
-      (super.noSuchMethod(Invocation.getter(#version), returnValue: '')
-          as String);
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerConnectivityState get connectivity =>
-      (super.noSuchMethod(Invocation.getter(#connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+  _i2.NetworkManagerConnectivityState get connectivity => (super.noSuchMethod(
+        Invocation.getter(#connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
-  bool get connectivityCheckAvailable =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckAvailable),
-          returnValue: false) as bool);
+  bool get connectivityCheckAvailable => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get connectivityCheckEnabled =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckEnabled),
-          returnValue: false) as bool);
+  bool get connectivityCheckEnabled => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  String get connectivityCheckUri =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckUri),
-          returnValue: '') as String);
+  String get connectivityCheckUri => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckUri),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkManagerState get state => (super.noSuchMethod(
-      Invocation.getter(#state),
-      returnValue: _i2.NetworkManagerState.unknown) as _i2.NetworkManagerState);
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerState.unknown,
+      ) as _i2.NetworkManagerState);
   @override
   _i2.NetworkManagerSettings get settings => (super.noSuchMethod(
+        Invocation.getter(#settings),
+        returnValue: _FakeNetworkManagerSettings_1(
+          this,
           Invocation.getter(#settings),
-          returnValue:
-              _FakeNetworkManagerSettings_1(this, Invocation.getter(#settings)))
-      as _i2.NetworkManagerSettings);
+        ),
+      ) as _i2.NetworkManagerSettings);
   @override
-  _i2.NetworkManagerDnsManager get dnsManager =>
-      (super.noSuchMethod(Invocation.getter(#dnsManager),
-              returnValue: _FakeNetworkManagerDnsManager_2(
-                  this, Invocation.getter(#dnsManager)))
-          as _i2.NetworkManagerDnsManager);
+  _i2.NetworkManagerDnsManager get dnsManager => (super.noSuchMethod(
+        Invocation.getter(#dnsManager),
+        returnValue: _FakeNetworkManagerDnsManager_2(
+          this,
+          Invocation.getter(#dnsManager),
+        ),
+      ) as _i2.NetworkManagerDnsManager);
   @override
   Map<String, Map<String, _i4.DBusValue>> getWifiSettings({String? ssid}) =>
       (super.noSuchMethod(
-              Invocation.method(#getWifiSettings, [], {#ssid: ssid}),
-              returnValue: <String, Map<String, _i4.DBusValue>>{})
-          as Map<String, Map<String, _i4.DBusValue>>);
+        Invocation.method(
+          #getWifiSettings,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: <String, Map<String, _i4.DBusValue>>{},
+      ) as Map<String, Map<String, _i4.DBusValue>>);
   @override
   _i3.Future<void> markConfigured() => (super.noSuchMethod(
-      Invocation.method(#markConfigured, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWirelessEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWirelessEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWwanEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWwanEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setConnectivityCheckEnabled(bool? value) =>
       (super.noSuchMethod(
-              Invocation.method(#setConnectivityCheckEnabled, [value]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #setConnectivityCheckEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection(
-          {Map<String, Map<String, _i4.DBusValue>>? connection = const {},
-          _i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#addAndActivateConnection, [], {#connection: connection, #device: device, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#addAndActivateConnection, [], {
-                    #connection: connection,
-                    #device: device,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i4.DBusValue>>? connection = const {},
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAndActivateConnection,
+          [],
+          {
+            #connection: connection,
+            #device: device,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #addAndActivateConnection,
+            [],
+            {
+              #connection: connection,
+              #device: device,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection(
-          {_i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerSettingsConnection? connection,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#activateConnection, [], {#device: device, #connection: connection, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#activateConnection, [], {
-                    #device: device,
-                    #connection: connection,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection({
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerSettingsConnection? connection,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #activateConnection,
+          [],
+          {
+            #device: device,
+            #connection: connection,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #activateConnection,
+            [],
+            {
+              #device: device,
+              #connection: connection,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Future<void> deactivateConnection(
           _i2.NetworkManagerActiveConnection? connection) =>
       (super.noSuchMethod(
-              Invocation.method(#deactivateConnection, [connection]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #deactivateConnection,
+          [connection],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_view_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_view_test.mocks.dart
@@ -28,19 +28,34 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeNetworkService_0 extends _i1.SmartFake
     implements _i2.NetworkService {
-  _FakeNetworkService_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkService_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWifiDevice_1 extends _i1.SmartFake implements _i3.WifiDevice {
-  _FakeWifiDevice_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWifiDevice_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDevice_2 extends _i1.SmartFake
     implements _i2.NetworkManagerDevice {
-  _FakeNetworkManagerDevice_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDevice_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [HiddenWifiModel].
@@ -52,137 +67,246 @@ class MockHiddenWifiModel extends _i1.Mock implements _i4.HiddenWifiModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i5.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i5.ConnectMode.none) as _i5.ConnectMode);
+  _i5.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i5.ConnectMode.none,
+      ) as _i5.ConnectMode);
   @override
-  String get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: '') as String);
+  String get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_0(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_0(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i3.WifiDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i3.WifiDevice>[]) as List<_i3.WifiDevice>);
+  List<_i3.WifiDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i3.WifiDevice>[],
+      ) as List<_i3.WifiDevice>);
   @override
-  _i6.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i6.Stream<dynamic>.empty()) as _i6.Stream<dynamic>);
+  _i6.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i6.Stream<dynamic>.empty(),
+      ) as _i6.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i6.Future<dynamic> connect() =>
-      (super.noSuchMethod(Invocation.method(#connect, []),
-          returnValue: _i6.Future<dynamic>.value()) as _i6.Future<dynamic>);
+  _i6.Future<dynamic> connect() => (super.noSuchMethod(
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i6.Future<dynamic>.value(),
+      ) as _i6.Future<dynamic>);
   @override
-  void setSsid(String? ssid) =>
-      super.noSuchMethod(Invocation.method(#setSsid, [ssid]),
-          returnValueForMissingStub: null);
+  void setSsid(String? ssid) => super.noSuchMethod(
+        Invocation.method(
+          #setSsid,
+          [ssid],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i6.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i3.WifiDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeWifiDevice_1(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i3.WifiDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeWifiDevice_1(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i3.WifiDevice);
   @override
-  _i6.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+  _i6.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i3.WifiDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i3.WifiDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i3.WifiDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i3.WifiDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i7.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i7.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [WifiDevice].
@@ -194,134 +318,228 @@ class MockWifiDevice extends _i1.Mock implements _i3.WifiDevice {
   }
 
   @override
-  bool get isActive =>
-      (super.noSuchMethod(Invocation.getter(#isActive), returnValue: false)
-          as bool);
+  bool get isActive => (super.noSuchMethod(
+        Invocation.getter(#isActive),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i3.AccessPoint> get accessPoints =>
-      (super.noSuchMethod(Invocation.getter(#accessPoints),
-          returnValue: <_i3.AccessPoint>[]) as List<_i3.AccessPoint>);
+  List<_i3.AccessPoint> get accessPoints => (super.noSuchMethod(
+        Invocation.getter(#accessPoints),
+        returnValue: <_i3.AccessPoint>[],
+      ) as List<_i3.AccessPoint>);
   @override
-  bool get scanning =>
-      (super.noSuchMethod(Invocation.getter(#scanning), returnValue: false)
-          as bool);
+  bool get scanning => (super.noSuchMethod(
+        Invocation.getter(#scanning),
+        returnValue: false,
+      ) as bool);
   @override
-  int get lastScan =>
-      (super.noSuchMethod(Invocation.getter(#lastScan), returnValue: 0) as int);
+  int get lastScan => (super.noSuchMethod(
+        Invocation.getter(#lastScan),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerDevice get device =>
-      (super.noSuchMethod(Invocation.getter(#device),
-              returnValue:
-                  _FakeNetworkManagerDevice_2(this, Invocation.getter(#device)))
-          as _i2.NetworkManagerDevice);
+  _i2.NetworkManagerDevice get device => (super.noSuchMethod(
+        Invocation.getter(#device),
+        returnValue: _FakeNetworkManagerDevice_2(
+          this,
+          Invocation.getter(#device),
+        ),
+      ) as _i2.NetworkManagerDevice);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisconnected => (super
-          .noSuchMethod(Invocation.getter(#isDisconnected), returnValue: false)
-      as bool);
+  bool get isDisconnected => (super.noSuchMethod(
+        Invocation.getter(#isDisconnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isUnmanaged =>
-      (super.noSuchMethod(Invocation.getter(#isUnmanaged), returnValue: false)
-          as bool);
+  bool get isUnmanaged => (super.noSuchMethod(
+        Invocation.getter(#isUnmanaged),
+        returnValue: false,
+      ) as bool);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevice(_i2.NetworkManagerDevice? device) =>
-      super.noSuchMethod(Invocation.method(#updateDevice, [device]),
-          returnValueForMissingStub: null);
+  void updateDevice(_i2.NetworkManagerDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool isActiveAccessPoint(_i3.AccessPoint? accessPoint) => (super.noSuchMethod(
-      Invocation.method(#isActiveAccessPoint, [accessPoint]),
-      returnValue: false) as bool);
+        Invocation.method(
+          #isActiveAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  bool isSelectedAccessPoint(_i3.AccessPoint? accessPoint) => (super
-      .noSuchMethod(Invocation.method(#isSelectedAccessPoint, [accessPoint]),
-          returnValue: false) as bool);
+  bool isSelectedAccessPoint(_i3.AccessPoint? accessPoint) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectAccessPoint(_i3.AccessPoint? accessPoint) =>
-      super.noSuchMethod(Invocation.method(#selectAccessPoint, [accessPoint]),
-          returnValueForMissingStub: null);
+  void selectAccessPoint(_i3.AccessPoint? accessPoint) => super.noSuchMethod(
+        Invocation.method(
+          #selectAccessPoint,
+          [accessPoint],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i6.Future<void> requestScan({String? ssid}) => (super.noSuchMethod(
-      Invocation.method(#requestScan, [], {#ssid: ssid}),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i3.AccessPoint? findAccessPoint(String? ssid) =>
-      (super.noSuchMethod(Invocation.method(#findAccessPoint, [ssid]))
-          as _i3.AccessPoint?);
+      (super.noSuchMethod(Invocation.method(
+        #findAccessPoint,
+        [ssid],
+      )) as _i3.AccessPoint?);
   @override
   _i6.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i7.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i7.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/network_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/network_model_test.mocks.dart
@@ -24,14 +24,23 @@ import 'package:ubuntu_desktop_installer/services/udev_service.dart' as _i3;
 class _FakeNetworkManagerDeviceStateAndReason_0 extends _i1.SmartFake
     implements _i2.NetworkManagerDeviceStateAndReason {
   _FakeNetworkManagerDeviceStateAndReason_0(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeUdevDeviceInfo_1 extends _i1.SmartFake
     implements _i3.UdevDeviceInfo {
-  _FakeUdevDeviceInfo_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUdevDeviceInfo_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [NetworkManagerActiveConnection].
@@ -44,45 +53,56 @@ class MockNetworkManagerActiveConnection extends _i1.Mock
   }
 
   @override
-  _i4.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i4.Stream<List<String>>.empty())
-          as _i4.Stream<List<String>>);
+  _i4.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i4.Stream<List<String>>.empty(),
+      ) as _i4.Stream<List<String>>);
   @override
-  String get id =>
-      (super.noSuchMethod(Invocation.getter(#id), returnValue: '') as String);
+  String get id => (super.noSuchMethod(
+        Invocation.getter(#id),
+        returnValue: '',
+      ) as String);
   @override
-  String get uuid =>
-      (super.noSuchMethod(Invocation.getter(#uuid), returnValue: '') as String);
+  String get uuid => (super.noSuchMethod(
+        Invocation.getter(#uuid),
+        returnValue: '',
+      ) as String);
   @override
-  String get type =>
-      (super.noSuchMethod(Invocation.getter(#type), returnValue: '') as String);
+  String get type => (super.noSuchMethod(
+        Invocation.getter(#type),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerActiveConnectionState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerActiveConnectionState.unknown)
-          as _i2.NetworkManagerActiveConnectionState);
+  _i2.NetworkManagerActiveConnectionState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerActiveConnectionState.unknown,
+      ) as _i2.NetworkManagerActiveConnectionState);
   @override
   List<_i2.NetworkManagerActivationStateFlag> get stateFlags =>
-      (super.noSuchMethod(Invocation.getter(#stateFlags),
-              returnValue: <_i2.NetworkManagerActivationStateFlag>[])
-          as List<_i2.NetworkManagerActivationStateFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#stateFlags),
+        returnValue: <_i2.NetworkManagerActivationStateFlag>[],
+      ) as List<_i2.NetworkManagerActivationStateFlag>);
   @override
-  bool get default4 =>
-      (super.noSuchMethod(Invocation.getter(#default4), returnValue: false)
-          as bool);
+  bool get default4 => (super.noSuchMethod(
+        Invocation.getter(#default4),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get default6 =>
-      (super.noSuchMethod(Invocation.getter(#default6), returnValue: false)
-          as bool);
+  bool get default6 => (super.noSuchMethod(
+        Invocation.getter(#default6),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get vpn =>
-      (super.noSuchMethod(Invocation.getter(#vpn), returnValue: false) as bool);
+  bool get vpn => (super.noSuchMethod(
+        Invocation.getter(#vpn),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
 }
 
 /// A class which mocks [NetworkManagerDevice].
@@ -95,133 +115,174 @@ class MockNetworkManagerDevice extends _i1.Mock
   }
 
   @override
-  _i4.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i4.Stream<List<String>>.empty())
-          as _i4.Stream<List<String>>);
+  _i4.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i4.Stream<List<String>>.empty(),
+      ) as _i4.Stream<List<String>>);
   @override
-  String get udi =>
-      (super.noSuchMethod(Invocation.getter(#udi), returnValue: '') as String);
+  String get udi => (super.noSuchMethod(
+        Invocation.getter(#udi),
+        returnValue: '',
+      ) as String);
   @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  String get path => (super.noSuchMethod(
+        Invocation.getter(#path),
+        returnValue: '',
+      ) as String);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  String get ipInterface =>
-      (super.noSuchMethod(Invocation.getter(#ipInterface), returnValue: '')
-          as String);
+  String get ipInterface => (super.noSuchMethod(
+        Invocation.getter(#ipInterface),
+        returnValue: '',
+      ) as String);
   @override
-  String get driver =>
-      (super.noSuchMethod(Invocation.getter(#driver), returnValue: '')
-          as String);
+  String get driver => (super.noSuchMethod(
+        Invocation.getter(#driver),
+        returnValue: '',
+      ) as String);
   @override
-  String get driverVersion =>
-      (super.noSuchMethod(Invocation.getter(#driverVersion), returnValue: '')
-          as String);
+  String get driverVersion => (super.noSuchMethod(
+        Invocation.getter(#driverVersion),
+        returnValue: '',
+      ) as String);
   @override
-  String get firmwareVersion =>
-      (super.noSuchMethod(Invocation.getter(#firmwareVersion), returnValue: '')
-          as String);
+  String get firmwareVersion => (super.noSuchMethod(
+        Invocation.getter(#firmwareVersion),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerDeviceCapability> get capabilities =>
-      (super.noSuchMethod(Invocation.getter(#capabilities),
-              returnValue: <_i2.NetworkManagerDeviceCapability>[])
-          as List<_i2.NetworkManagerDeviceCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#capabilities),
+        returnValue: <_i2.NetworkManagerDeviceCapability>[],
+      ) as List<_i2.NetworkManagerDeviceCapability>);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  _i2.NetworkManagerDeviceStateAndReason get stateReason =>
-      (super.noSuchMethod(Invocation.getter(#stateReason),
-              returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
-                  this, Invocation.getter(#stateReason)))
-          as _i2.NetworkManagerDeviceStateAndReason);
+  _i2.NetworkManagerDeviceStateAndReason get stateReason => (super.noSuchMethod(
+        Invocation.getter(#stateReason),
+        returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
+          this,
+          Invocation.getter(#stateReason),
+        ),
+      ) as _i2.NetworkManagerDeviceStateAndReason);
   @override
-  bool get managed =>
-      (super.noSuchMethod(Invocation.getter(#managed), returnValue: false)
-          as bool);
+  bool get managed => (super.noSuchMethod(
+        Invocation.getter(#managed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get autoconnect =>
-      (super.noSuchMethod(Invocation.getter(#autoconnect), returnValue: false)
-          as bool);
+  bool get autoconnect => (super.noSuchMethod(
+        Invocation.getter(#autoconnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get firmwareMissing => (super
-          .noSuchMethod(Invocation.getter(#firmwareMissing), returnValue: false)
-      as bool);
+  bool get firmwareMissing => (super.noSuchMethod(
+        Invocation.getter(#firmwareMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get nmPluginMissing => (super
-          .noSuchMethod(Invocation.getter(#nmPluginMissing), returnValue: false)
-      as bool);
+  bool get nmPluginMissing => (super.noSuchMethod(
+        Invocation.getter(#nmPluginMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  _i2.NetworkManagerDeviceType get deviceType =>
-      (super.noSuchMethod(Invocation.getter(#deviceType),
-              returnValue: _i2.NetworkManagerDeviceType.unknown)
-          as _i2.NetworkManagerDeviceType);
+  _i2.NetworkManagerDeviceType get deviceType => (super.noSuchMethod(
+        Invocation.getter(#deviceType),
+        returnValue: _i2.NetworkManagerDeviceType.unknown,
+      ) as _i2.NetworkManagerDeviceType);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  String get physicalPortId =>
-      (super.noSuchMethod(Invocation.getter(#physicalPortId), returnValue: '')
-          as String);
+  String get physicalPortId => (super.noSuchMethod(
+        Invocation.getter(#physicalPortId),
+        returnValue: '',
+      ) as String);
   @override
-  int get mtu =>
-      (super.noSuchMethod(Invocation.getter(#mtu), returnValue: 0) as int);
+  int get mtu => (super.noSuchMethod(
+        Invocation.getter(#mtu),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get real =>
-      (super.noSuchMethod(Invocation.getter(#real), returnValue: false)
-          as bool);
+  bool get real => (super.noSuchMethod(
+        Invocation.getter(#real),
+        returnValue: false,
+      ) as bool);
   @override
   _i2.NetworkManagerConnectivityState get ip4Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip4Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip4Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   _i2.NetworkManagerConnectivityState get ip6Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip6Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip6Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   List<_i2.NetworkManagerDeviceInterfaceFlag> get interfaceFlags =>
-      (super.noSuchMethod(Invocation.getter(#interfaceFlags),
-              returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[])
-          as List<_i2.NetworkManagerDeviceInterfaceFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#interfaceFlags),
+        returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[],
+      ) as List<_i2.NetworkManagerDeviceInterfaceFlag>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   _i4.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> setManaged(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setManaged, [value]),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #setManaged,
+          [value],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> setAutoconnect(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setAutoconnect, [value]),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #setAutoconnect,
+          [value],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [NetworkManagerSettingsConnection].
@@ -234,66 +295,95 @@ class MockNetworkManagerSettingsConnection extends _i1.Mock
   }
 
   @override
-  _i4.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i4.Stream<List<String>>.empty())
-          as _i4.Stream<List<String>>);
+  _i4.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i4.Stream<List<String>>.empty(),
+      ) as _i4.Stream<List<String>>);
   @override
-  bool get unsaved =>
-      (super.noSuchMethod(Invocation.getter(#unsaved), returnValue: false)
-          as bool);
+  bool get unsaved => (super.noSuchMethod(
+        Invocation.getter(#unsaved),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerConnectionFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerConnectionFlag>[])
-          as List<_i2.NetworkManagerConnectionFlag>);
+  List<_i2.NetworkManagerConnectionFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerConnectionFlag>[],
+      ) as List<_i2.NetworkManagerConnectionFlag>);
   @override
-  String get filename =>
-      (super.noSuchMethod(Invocation.getter(#filename), returnValue: '')
-          as String);
+  String get filename => (super.noSuchMethod(
+        Invocation.getter(#filename),
+        returnValue: '',
+      ) as String);
   @override
   _i4.Future<void> update(
           Map<String, Map<String, _i5.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#update, [properties]),
-              returnValue: _i4.Future<void>.value(),
-              returnValueForMissingStub: _i4.Future<void>.value())
-          as _i4.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [properties],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> updateUnsaved(
           Map<String, Map<String, _i5.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#updateUnsaved, [properties]),
-              returnValue: _i4.Future<void>.value(),
-              returnValueForMissingStub: _i4.Future<void>.value())
-          as _i4.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUnsaved,
+          [properties],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<Map<String, Map<String, _i5.DBusValue>>> getSettings() =>
-      (super.noSuchMethod(Invocation.method(#getSettings, []),
-              returnValue:
-                  _i4.Future<Map<String, Map<String, _i5.DBusValue>>>.value(
-                      <String, Map<String, _i5.DBusValue>>{}))
-          as _i4.Future<Map<String, Map<String, _i5.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSettings,
+          [],
+        ),
+        returnValue: _i4.Future<Map<String, Map<String, _i5.DBusValue>>>.value(
+            <String, Map<String, _i5.DBusValue>>{}),
+      ) as _i4.Future<Map<String, Map<String, _i5.DBusValue>>>);
   @override
   _i4.Future<Map<String, Map<String, _i5.DBusValue>>> getSecrets(
           [String? settingName = r'']) =>
-      (super.noSuchMethod(Invocation.method(#getSecrets, [settingName]),
-              returnValue:
-                  _i4.Future<Map<String, Map<String, _i5.DBusValue>>>.value(
-                      <String, Map<String, _i5.DBusValue>>{}))
-          as _i4.Future<Map<String, Map<String, _i5.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSecrets,
+          [settingName],
+        ),
+        returnValue: _i4.Future<Map<String, Map<String, _i5.DBusValue>>>.value(
+            <String, Map<String, _i5.DBusValue>>{}),
+      ) as _i4.Future<Map<String, Map<String, _i5.DBusValue>>>);
   @override
   _i4.Future<void> clearSecrets() => (super.noSuchMethod(
-      Invocation.method(#clearSecrets, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #clearSecrets,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i4.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [UdevDeviceInfo].
@@ -305,9 +395,10 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i3.UdevDeviceInfo {
   }
 
   @override
-  String get fullName =>
-      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
-          as String);
+  String get fullName => (super.noSuchMethod(
+        Invocation.getter(#fullName),
+        returnValue: '',
+      ) as String);
 }
 
 /// A class which mocks [UdevService].
@@ -319,15 +410,31 @@ class MockUdevService extends _i1.Mock implements _i3.UdevService {
   }
 
   @override
-  _i3.UdevDeviceInfo bySysname(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
-              returnValue: _FakeUdevDeviceInfo_1(
-                  this, Invocation.method(#bySysname, [sysname])))
-          as _i3.UdevDeviceInfo);
+  _i3.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
+        Invocation.method(
+          #bySysname,
+          [sysname],
+        ),
+        returnValue: _FakeUdevDeviceInfo_1(
+          this,
+          Invocation.method(
+            #bySysname,
+            [sysname],
+          ),
+        ),
+      ) as _i3.UdevDeviceInfo);
   @override
-  _i3.UdevDeviceInfo bySyspath(String? syspath) =>
-      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
-              returnValue: _FakeUdevDeviceInfo_1(
-                  this, Invocation.method(#bySyspath, [syspath])))
-          as _i3.UdevDeviceInfo);
+  _i3.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
+        Invocation.method(
+          #bySyspath,
+          [syspath],
+        ),
+        returnValue: _FakeUdevDeviceInfo_1(
+          this,
+          Invocation.method(
+            #bySyspath,
+            [syspath],
+          ),
+        ),
+      ) as _i3.UdevDeviceInfo);
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
@@ -24,27 +24,45 @@ import 'package:ubuntu_desktop_installer/services/network_service.dart' as _i5;
 class _FakeNetworkManagerDeviceStateAndReason_0 extends _i1.SmartFake
     implements _i2.NetworkManagerDeviceStateAndReason {
   _FakeNetworkManagerDeviceStateAndReason_0(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerSettings_1 extends _i1.SmartFake
     implements _i2.NetworkManagerSettings {
-  _FakeNetworkManagerSettings_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerSettings_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDnsManager_2 extends _i1.SmartFake
     implements _i2.NetworkManagerDnsManager {
-  _FakeNetworkManagerDnsManager_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDnsManager_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerActiveConnection_3 extends _i1.SmartFake
     implements _i2.NetworkManagerActiveConnection {
   _FakeNetworkManagerActiveConnection_3(
-      Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [NetworkManagerAccessPoint].
@@ -57,52 +75,62 @@ class MockNetworkManagerAccessPoint extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerWifiAccessPointFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointFlag>);
+  List<_i2.NetworkManagerWifiAccessPointFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointFlag>);
   @override
   List<_i2.NetworkManagerWifiAccessPointSecurityFlag> get wpaFlags =>
-      (super.noSuchMethod(Invocation.getter(#wpaFlags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#wpaFlags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
   @override
   List<_i2.NetworkManagerWifiAccessPointSecurityFlag> get rsnFlags =>
-      (super.noSuchMethod(Invocation.getter(#rsnFlags),
-              returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[])
-          as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#rsnFlags),
+        returnValue: <_i2.NetworkManagerWifiAccessPointSecurityFlag>[],
+      ) as List<_i2.NetworkManagerWifiAccessPointSecurityFlag>);
   @override
-  List<int> get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: <int>[])
-          as List<int>);
+  List<int> get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: <int>[],
+      ) as List<int>);
   @override
-  int get frequency =>
-      (super.noSuchMethod(Invocation.getter(#frequency), returnValue: 0)
-          as int);
+  int get frequency => (super.noSuchMethod(
+        Invocation.getter(#frequency),
+        returnValue: 0,
+      ) as int);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerWifiMode get mode =>
-      (super.noSuchMethod(Invocation.getter(#mode),
-              returnValue: _i2.NetworkManagerWifiMode.unknown)
-          as _i2.NetworkManagerWifiMode);
+  _i2.NetworkManagerWifiMode get mode => (super.noSuchMethod(
+        Invocation.getter(#mode),
+        returnValue: _i2.NetworkManagerWifiMode.unknown,
+      ) as _i2.NetworkManagerWifiMode);
   @override
-  int get maxBitrate =>
-      (super.noSuchMethod(Invocation.getter(#maxBitrate), returnValue: 0)
-          as int);
+  int get maxBitrate => (super.noSuchMethod(
+        Invocation.getter(#maxBitrate),
+        returnValue: 0,
+      ) as int);
   @override
-  int get strength =>
-      (super.noSuchMethod(Invocation.getter(#strength), returnValue: 0) as int);
+  int get strength => (super.noSuchMethod(
+        Invocation.getter(#strength),
+        returnValue: 0,
+      ) as int);
   @override
-  int get lastSeen =>
-      (super.noSuchMethod(Invocation.getter(#lastSeen), returnValue: 0) as int);
+  int get lastSeen => (super.noSuchMethod(
+        Invocation.getter(#lastSeen),
+        returnValue: 0,
+      ) as int);
 }
 
 /// A class which mocks [NetworkManagerActiveConnection].
@@ -115,45 +143,56 @@ class MockNetworkManagerActiveConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get id =>
-      (super.noSuchMethod(Invocation.getter(#id), returnValue: '') as String);
+  String get id => (super.noSuchMethod(
+        Invocation.getter(#id),
+        returnValue: '',
+      ) as String);
   @override
-  String get uuid =>
-      (super.noSuchMethod(Invocation.getter(#uuid), returnValue: '') as String);
+  String get uuid => (super.noSuchMethod(
+        Invocation.getter(#uuid),
+        returnValue: '',
+      ) as String);
   @override
-  String get type =>
-      (super.noSuchMethod(Invocation.getter(#type), returnValue: '') as String);
+  String get type => (super.noSuchMethod(
+        Invocation.getter(#type),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerActiveConnectionState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerActiveConnectionState.unknown)
-          as _i2.NetworkManagerActiveConnectionState);
+  _i2.NetworkManagerActiveConnectionState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerActiveConnectionState.unknown,
+      ) as _i2.NetworkManagerActiveConnectionState);
   @override
   List<_i2.NetworkManagerActivationStateFlag> get stateFlags =>
-      (super.noSuchMethod(Invocation.getter(#stateFlags),
-              returnValue: <_i2.NetworkManagerActivationStateFlag>[])
-          as List<_i2.NetworkManagerActivationStateFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#stateFlags),
+        returnValue: <_i2.NetworkManagerActivationStateFlag>[],
+      ) as List<_i2.NetworkManagerActivationStateFlag>);
   @override
-  bool get default4 =>
-      (super.noSuchMethod(Invocation.getter(#default4), returnValue: false)
-          as bool);
+  bool get default4 => (super.noSuchMethod(
+        Invocation.getter(#default4),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get default6 =>
-      (super.noSuchMethod(Invocation.getter(#default6), returnValue: false)
-          as bool);
+  bool get default6 => (super.noSuchMethod(
+        Invocation.getter(#default6),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get vpn =>
-      (super.noSuchMethod(Invocation.getter(#vpn), returnValue: false) as bool);
+  bool get vpn => (super.noSuchMethod(
+        Invocation.getter(#vpn),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
 }
 
 /// A class which mocks [NetworkManagerDevice].
@@ -166,133 +205,174 @@ class MockNetworkManagerDevice extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get udi =>
-      (super.noSuchMethod(Invocation.getter(#udi), returnValue: '') as String);
+  String get udi => (super.noSuchMethod(
+        Invocation.getter(#udi),
+        returnValue: '',
+      ) as String);
   @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  String get path => (super.noSuchMethod(
+        Invocation.getter(#path),
+        returnValue: '',
+      ) as String);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  String get ipInterface =>
-      (super.noSuchMethod(Invocation.getter(#ipInterface), returnValue: '')
-          as String);
+  String get ipInterface => (super.noSuchMethod(
+        Invocation.getter(#ipInterface),
+        returnValue: '',
+      ) as String);
   @override
-  String get driver =>
-      (super.noSuchMethod(Invocation.getter(#driver), returnValue: '')
-          as String);
+  String get driver => (super.noSuchMethod(
+        Invocation.getter(#driver),
+        returnValue: '',
+      ) as String);
   @override
-  String get driverVersion =>
-      (super.noSuchMethod(Invocation.getter(#driverVersion), returnValue: '')
-          as String);
+  String get driverVersion => (super.noSuchMethod(
+        Invocation.getter(#driverVersion),
+        returnValue: '',
+      ) as String);
   @override
-  String get firmwareVersion =>
-      (super.noSuchMethod(Invocation.getter(#firmwareVersion), returnValue: '')
-          as String);
+  String get firmwareVersion => (super.noSuchMethod(
+        Invocation.getter(#firmwareVersion),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerDeviceCapability> get capabilities =>
-      (super.noSuchMethod(Invocation.getter(#capabilities),
-              returnValue: <_i2.NetworkManagerDeviceCapability>[])
-          as List<_i2.NetworkManagerDeviceCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#capabilities),
+        returnValue: <_i2.NetworkManagerDeviceCapability>[],
+      ) as List<_i2.NetworkManagerDeviceCapability>);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  _i2.NetworkManagerDeviceStateAndReason get stateReason =>
-      (super.noSuchMethod(Invocation.getter(#stateReason),
-              returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
-                  this, Invocation.getter(#stateReason)))
-          as _i2.NetworkManagerDeviceStateAndReason);
+  _i2.NetworkManagerDeviceStateAndReason get stateReason => (super.noSuchMethod(
+        Invocation.getter(#stateReason),
+        returnValue: _FakeNetworkManagerDeviceStateAndReason_0(
+          this,
+          Invocation.getter(#stateReason),
+        ),
+      ) as _i2.NetworkManagerDeviceStateAndReason);
   @override
-  bool get managed =>
-      (super.noSuchMethod(Invocation.getter(#managed), returnValue: false)
-          as bool);
+  bool get managed => (super.noSuchMethod(
+        Invocation.getter(#managed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get autoconnect =>
-      (super.noSuchMethod(Invocation.getter(#autoconnect), returnValue: false)
-          as bool);
+  bool get autoconnect => (super.noSuchMethod(
+        Invocation.getter(#autoconnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get firmwareMissing => (super
-          .noSuchMethod(Invocation.getter(#firmwareMissing), returnValue: false)
-      as bool);
+  bool get firmwareMissing => (super.noSuchMethod(
+        Invocation.getter(#firmwareMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get nmPluginMissing => (super
-          .noSuchMethod(Invocation.getter(#nmPluginMissing), returnValue: false)
-      as bool);
+  bool get nmPluginMissing => (super.noSuchMethod(
+        Invocation.getter(#nmPluginMissing),
+        returnValue: false,
+      ) as bool);
   @override
-  _i2.NetworkManagerDeviceType get deviceType =>
-      (super.noSuchMethod(Invocation.getter(#deviceType),
-              returnValue: _i2.NetworkManagerDeviceType.unknown)
-          as _i2.NetworkManagerDeviceType);
+  _i2.NetworkManagerDeviceType get deviceType => (super.noSuchMethod(
+        Invocation.getter(#deviceType),
+        returnValue: _i2.NetworkManagerDeviceType.unknown,
+      ) as _i2.NetworkManagerDeviceType);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  String get physicalPortId =>
-      (super.noSuchMethod(Invocation.getter(#physicalPortId), returnValue: '')
-          as String);
+  String get physicalPortId => (super.noSuchMethod(
+        Invocation.getter(#physicalPortId),
+        returnValue: '',
+      ) as String);
   @override
-  int get mtu =>
-      (super.noSuchMethod(Invocation.getter(#mtu), returnValue: 0) as int);
+  int get mtu => (super.noSuchMethod(
+        Invocation.getter(#mtu),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get real =>
-      (super.noSuchMethod(Invocation.getter(#real), returnValue: false)
-          as bool);
+  bool get real => (super.noSuchMethod(
+        Invocation.getter(#real),
+        returnValue: false,
+      ) as bool);
   @override
   _i2.NetworkManagerConnectivityState get ip4Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip4Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip4Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   _i2.NetworkManagerConnectivityState get ip6Connectivity =>
-      (super.noSuchMethod(Invocation.getter(#ip6Connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+      (super.noSuchMethod(
+        Invocation.getter(#ip6Connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
   List<_i2.NetworkManagerDeviceInterfaceFlag> get interfaceFlags =>
-      (super.noSuchMethod(Invocation.getter(#interfaceFlags),
-              returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[])
-          as List<_i2.NetworkManagerDeviceInterfaceFlag>);
+      (super.noSuchMethod(
+        Invocation.getter(#interfaceFlags),
+        returnValue: <_i2.NetworkManagerDeviceInterfaceFlag>[],
+      ) as List<_i2.NetworkManagerDeviceInterfaceFlag>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setManaged(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setManaged, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setManaged,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setAutoconnect(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setAutoconnect, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setAutoconnect,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkManagerDeviceWireless].
@@ -305,39 +385,51 @@ class MockNetworkManagerDeviceWireless extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  String get permHwAddress =>
-      (super.noSuchMethod(Invocation.getter(#permHwAddress), returnValue: '')
-          as String);
+  String get permHwAddress => (super.noSuchMethod(
+        Invocation.getter(#permHwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerWifiMode get mode =>
-      (super.noSuchMethod(Invocation.getter(#mode),
-              returnValue: _i2.NetworkManagerWifiMode.unknown)
-          as _i2.NetworkManagerWifiMode);
+  _i2.NetworkManagerWifiMode get mode => (super.noSuchMethod(
+        Invocation.getter(#mode),
+        returnValue: _i2.NetworkManagerWifiMode.unknown,
+      ) as _i2.NetworkManagerWifiMode);
   @override
-  int get bitrate =>
-      (super.noSuchMethod(Invocation.getter(#bitrate), returnValue: 0) as int);
+  int get bitrate => (super.noSuchMethod(
+        Invocation.getter(#bitrate),
+        returnValue: 0,
+      ) as int);
   @override
-  List<_i2.NetworkManagerAccessPoint> get accessPoints =>
-      (super.noSuchMethod(Invocation.getter(#accessPoints),
-              returnValue: <_i2.NetworkManagerAccessPoint>[])
-          as List<_i2.NetworkManagerAccessPoint>);
+  List<_i2.NetworkManagerAccessPoint> get accessPoints => (super.noSuchMethod(
+        Invocation.getter(#accessPoints),
+        returnValue: <_i2.NetworkManagerAccessPoint>[],
+      ) as List<_i2.NetworkManagerAccessPoint>);
   @override
   List<_i2.NetworkManagerDeviceWifiCapability> get wirelessCapabilities =>
-      (super.noSuchMethod(Invocation.getter(#wirelessCapabilities),
-              returnValue: <_i2.NetworkManagerDeviceWifiCapability>[])
-          as List<_i2.NetworkManagerDeviceWifiCapability>);
+      (super.noSuchMethod(
+        Invocation.getter(#wirelessCapabilities),
+        returnValue: <_i2.NetworkManagerDeviceWifiCapability>[],
+      ) as List<_i2.NetworkManagerDeviceWifiCapability>);
   @override
-  int get lastScan =>
-      (super.noSuchMethod(Invocation.getter(#lastScan), returnValue: 0) as int);
+  int get lastScan => (super.noSuchMethod(
+        Invocation.getter(#lastScan),
+        returnValue: 0,
+      ) as int);
   @override
   _i3.Future<dynamic> requestScan({List<List<int>>? ssids}) =>
-      (super.noSuchMethod(Invocation.method(#requestScan, [], {#ssids: ssids}),
-          returnValue: _i3.Future<dynamic>.value()) as _i3.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssids: ssids},
+        ),
+        returnValue: _i3.Future<dynamic>.value(),
+      ) as _i3.Future<dynamic>);
 }
 
 /// A class which mocks [NetworkManagerSettingsConnection].
@@ -350,66 +442,95 @@ class MockNetworkManagerSettingsConnection extends _i1.Mock
   }
 
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  bool get unsaved =>
-      (super.noSuchMethod(Invocation.getter(#unsaved), returnValue: false)
-          as bool);
+  bool get unsaved => (super.noSuchMethod(
+        Invocation.getter(#unsaved),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerConnectionFlag> get flags =>
-      (super.noSuchMethod(Invocation.getter(#flags),
-              returnValue: <_i2.NetworkManagerConnectionFlag>[])
-          as List<_i2.NetworkManagerConnectionFlag>);
+  List<_i2.NetworkManagerConnectionFlag> get flags => (super.noSuchMethod(
+        Invocation.getter(#flags),
+        returnValue: <_i2.NetworkManagerConnectionFlag>[],
+      ) as List<_i2.NetworkManagerConnectionFlag>);
   @override
-  String get filename =>
-      (super.noSuchMethod(Invocation.getter(#filename), returnValue: '')
-          as String);
+  String get filename => (super.noSuchMethod(
+        Invocation.getter(#filename),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> update(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#update, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> updateUnsaved(
           Map<String, Map<String, _i4.DBusValue>>? properties) =>
-      (super.noSuchMethod(Invocation.method(#updateUnsaved, [properties]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUnsaved,
+          [properties],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> delete() => (super.noSuchMethod(
-      Invocation.method(#delete, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #delete,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSettings() =>
-      (super.noSuchMethod(Invocation.method(#getSettings, []),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSettings,
+          [],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<Map<String, Map<String, _i4.DBusValue>>> getSecrets(
           [String? settingName = r'']) =>
-      (super.noSuchMethod(Invocation.method(#getSecrets, [settingName]),
-              returnValue:
-                  _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
-                      <String, Map<String, _i4.DBusValue>>{}))
-          as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSecrets,
+          [settingName],
+        ),
+        returnValue: _i3.Future<Map<String, Map<String, _i4.DBusValue>>>.value(
+            <String, Map<String, _i4.DBusValue>>{}),
+      ) as _i3.Future<Map<String, Map<String, _i4.DBusValue>>>);
   @override
   _i3.Future<void> clearSecrets() => (super.noSuchMethod(
-      Invocation.method(#clearSecrets, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #clearSecrets,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }
 
 /// A class which mocks [NetworkService].
@@ -421,202 +542,283 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
   }
 
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.NetworkManagerDevice> get wiredDevices =>
-      (super.noSuchMethod(Invocation.getter(#wiredDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
+        Invocation.getter(#wiredDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get wirelessDevices =>
-      (super.noSuchMethod(Invocation.getter(#wirelessDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get wirelessDevices => (super.noSuchMethod(
+        Invocation.getter(#wirelessDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded =>
-      (super.noSuchMethod(Invocation.getter(#deviceAdded),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
-  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved =>
-      (super.noSuchMethod(Invocation.getter(#deviceRemoved),
-              returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty())
-          as _i3.Stream<_i2.NetworkManagerDevice>);
+  _i3.Stream<_i2.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerDevice>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionAdded =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionAdded),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionAdded),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionRemoved =>
-      (super.noSuchMethod(Invocation.getter(#activeConnectionRemoved),
-              returnValue:
-                  _i3.Stream<_i2.NetworkManagerActiveConnection>.empty())
-          as _i3.Stream<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionRemoved),
+        returnValue: _i3.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i3.Stream<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i3.Stream<List<String>>.empty())
-          as _i3.Stream<List<String>>);
+  _i3.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i3.Stream<List<String>>.empty(),
+      ) as _i3.Stream<List<String>>);
   @override
-  List<_i2.NetworkManagerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  List<_i2.NetworkManagerDevice> get allDevices =>
-      (super.noSuchMethod(Invocation.getter(#allDevices),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> get allDevices => (super.noSuchMethod(
+        Invocation.getter(#allDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
-  bool get networkingEnabled =>
-      (super.noSuchMethod(Invocation.getter(#networkingEnabled),
-          returnValue: false) as bool);
+  bool get networkingEnabled => (super.noSuchMethod(
+        Invocation.getter(#networkingEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessEnabled => (super
-          .noSuchMethod(Invocation.getter(#wirelessEnabled), returnValue: false)
-      as bool);
+  bool get wirelessEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wirelessHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wirelessHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wirelessHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanEnabled), returnValue: false)
-          as bool);
+  bool get wwanEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get wwanHardwareEnabled =>
-      (super.noSuchMethod(Invocation.getter(#wwanHardwareEnabled),
-          returnValue: false) as bool);
+  bool get wwanHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanHardwareEnabled),
+        returnValue: false,
+      ) as bool);
   @override
   List<_i2.NetworkManagerActiveConnection> get activeConnections =>
-      (super.noSuchMethod(Invocation.getter(#activeConnections),
-              returnValue: <_i2.NetworkManagerActiveConnection>[])
-          as List<_i2.NetworkManagerActiveConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnections),
+        returnValue: <_i2.NetworkManagerActiveConnection>[],
+      ) as List<_i2.NetworkManagerActiveConnection>);
   @override
-  String get primaryConnectionType =>
-      (super.noSuchMethod(Invocation.getter(#primaryConnectionType),
-          returnValue: '') as String);
+  String get primaryConnectionType => (super.noSuchMethod(
+        Invocation.getter(#primaryConnectionType),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerMetered get metered =>
-      (super.noSuchMethod(Invocation.getter(#metered),
-              returnValue: _i2.NetworkManagerMetered.unknown)
-          as _i2.NetworkManagerMetered);
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
   @override
-  bool get startup =>
-      (super.noSuchMethod(Invocation.getter(#startup), returnValue: false)
-          as bool);
+  bool get startup => (super.noSuchMethod(
+        Invocation.getter(#startup),
+        returnValue: false,
+      ) as bool);
   @override
-  String get version =>
-      (super.noSuchMethod(Invocation.getter(#version), returnValue: '')
-          as String);
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerConnectivityState get connectivity =>
-      (super.noSuchMethod(Invocation.getter(#connectivity),
-              returnValue: _i2.NetworkManagerConnectivityState.unknown)
-          as _i2.NetworkManagerConnectivityState);
+  _i2.NetworkManagerConnectivityState get connectivity => (super.noSuchMethod(
+        Invocation.getter(#connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
   @override
-  bool get connectivityCheckAvailable =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckAvailable),
-          returnValue: false) as bool);
+  bool get connectivityCheckAvailable => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get connectivityCheckEnabled =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckEnabled),
-          returnValue: false) as bool);
+  bool get connectivityCheckEnabled => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  String get connectivityCheckUri =>
-      (super.noSuchMethod(Invocation.getter(#connectivityCheckUri),
-          returnValue: '') as String);
+  String get connectivityCheckUri => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckUri),
+        returnValue: '',
+      ) as String);
   @override
   _i2.NetworkManagerState get state => (super.noSuchMethod(
-      Invocation.getter(#state),
-      returnValue: _i2.NetworkManagerState.unknown) as _i2.NetworkManagerState);
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerState.unknown,
+      ) as _i2.NetworkManagerState);
   @override
   _i2.NetworkManagerSettings get settings => (super.noSuchMethod(
+        Invocation.getter(#settings),
+        returnValue: _FakeNetworkManagerSettings_1(
+          this,
           Invocation.getter(#settings),
-          returnValue:
-              _FakeNetworkManagerSettings_1(this, Invocation.getter(#settings)))
-      as _i2.NetworkManagerSettings);
+        ),
+      ) as _i2.NetworkManagerSettings);
   @override
-  _i2.NetworkManagerDnsManager get dnsManager =>
-      (super.noSuchMethod(Invocation.getter(#dnsManager),
-              returnValue: _FakeNetworkManagerDnsManager_2(
-                  this, Invocation.getter(#dnsManager)))
-          as _i2.NetworkManagerDnsManager);
+  _i2.NetworkManagerDnsManager get dnsManager => (super.noSuchMethod(
+        Invocation.getter(#dnsManager),
+        returnValue: _FakeNetworkManagerDnsManager_2(
+          this,
+          Invocation.getter(#dnsManager),
+        ),
+      ) as _i2.NetworkManagerDnsManager);
   @override
   Map<String, Map<String, _i4.DBusValue>> getWifiSettings({String? ssid}) =>
       (super.noSuchMethod(
-              Invocation.method(#getWifiSettings, [], {#ssid: ssid}),
-              returnValue: <String, Map<String, _i4.DBusValue>>{})
-          as Map<String, Map<String, _i4.DBusValue>>);
+        Invocation.method(
+          #getWifiSettings,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: <String, Map<String, _i4.DBusValue>>{},
+      ) as Map<String, Map<String, _i4.DBusValue>>);
   @override
   _i3.Future<void> markConfigured() => (super.noSuchMethod(
-      Invocation.method(#markConfigured, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWirelessEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWirelessEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
-      Invocation.method(#setWwanEnabled, [value]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #setWwanEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> setConnectivityCheckEnabled(bool? value) =>
       (super.noSuchMethod(
-              Invocation.method(#setConnectivityCheckEnabled, [value]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #setConnectivityCheckEnabled,
+          [value],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection(
-          {Map<String, Map<String, _i4.DBusValue>>? connection = const {},
-          _i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#addAndActivateConnection, [], {#connection: connection, #device: device, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#addAndActivateConnection, [], {
-                    #connection: connection,
-                    #device: device,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i4.DBusValue>>? connection = const {},
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAndActivateConnection,
+          [],
+          {
+            #connection: connection,
+            #device: device,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #addAndActivateConnection,
+            [],
+            {
+              #connection: connection,
+              #device: device,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
-  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection(
-          {_i2.NetworkManagerDevice? device,
-          _i2.NetworkManagerSettingsConnection? connection,
-          _i2.NetworkManagerAccessPoint? accessPoint}) =>
-      (super.noSuchMethod(Invocation.method(#activateConnection, [], {#device: device, #connection: connection, #accessPoint: accessPoint}),
-          returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
-              _FakeNetworkManagerActiveConnection_3(
-                  this,
-                  Invocation.method(#activateConnection, [], {
-                    #device: device,
-                    #connection: connection,
-                    #accessPoint: accessPoint
-                  })))) as _i3.Future<_i2.NetworkManagerActiveConnection>);
+  _i3.Future<_i2.NetworkManagerActiveConnection> activateConnection({
+    _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerSettingsConnection? connection,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #activateConnection,
+          [],
+          {
+            #device: device,
+            #connection: connection,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i3.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_3(
+          this,
+          Invocation.method(
+            #activateConnection,
+            [],
+            {
+              #device: device,
+              #connection: connection,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i3.Future<_i2.NetworkManagerActiveConnection>);
   @override
   _i3.Future<void> deactivateConnection(
           _i2.NetworkManagerActiveConnection? connection) =>
       (super.noSuchMethod(
-              Invocation.method(#deactivateConnection, [connection]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #deactivateConnection,
+          [connection],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.mocks.dart
@@ -26,25 +26,45 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeNetworkManagerAccessPoint_0 extends _i1.SmartFake
     implements _i2.NetworkManagerAccessPoint {
-  _FakeNetworkManagerAccessPoint_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerAccessPoint_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkService_1 extends _i1.SmartFake
     implements _i2.NetworkService {
-  _FakeNetworkService_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkService_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWifiDevice_2 extends _i1.SmartFake implements _i3.WifiDevice {
-  _FakeWifiDevice_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWifiDevice_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeNetworkManagerDevice_3 extends _i1.SmartFake
     implements _i2.NetworkManagerDevice {
-  _FakeNetworkManagerDevice_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeNetworkManagerDevice_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AccessPoint].
@@ -56,75 +76,136 @@ class MockAccessPoint extends _i1.Mock implements _i3.AccessPoint {
   }
 
   @override
-  _i2.NetworkManagerAccessPoint get accessPoint =>
-      (super.noSuchMethod(Invocation.getter(#accessPoint),
-              returnValue: _FakeNetworkManagerAccessPoint_0(
-                  this, Invocation.getter(#accessPoint)))
-          as _i2.NetworkManagerAccessPoint);
+  _i2.NetworkManagerAccessPoint get accessPoint => (super.noSuchMethod(
+        Invocation.getter(#accessPoint),
+        returnValue: _FakeNetworkManagerAccessPoint_0(
+          this,
+          Invocation.getter(#accessPoint),
+        ),
+      ) as _i2.NetworkManagerAccessPoint);
   @override
-  List<int> get ssid =>
-      (super.noSuchMethod(Invocation.getter(#ssid), returnValue: <int>[])
-          as List<int>);
+  List<int> get ssid => (super.noSuchMethod(
+        Invocation.getter(#ssid),
+        returnValue: <int>[],
+      ) as List<int>);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
-  String get name =>
-      (super.noSuchMethod(Invocation.getter(#name), returnValue: '') as String);
+  String get name => (super.noSuchMethod(
+        Invocation.getter(#name),
+        returnValue: '',
+      ) as String);
   @override
-  int get strength =>
-      (super.noSuchMethod(Invocation.getter(#strength), returnValue: 0) as int);
+  int get strength => (super.noSuchMethod(
+        Invocation.getter(#strength),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isOpen =>
-      (super.noSuchMethod(Invocation.getter(#isOpen), returnValue: false)
-          as bool);
+  bool get isOpen => (super.noSuchMethod(
+        Invocation.getter(#isOpen),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i4.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i5.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i5.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [WifiModel].
@@ -136,143 +217,259 @@ class MockWifiModel extends _i1.Mock implements _i3.WifiModel {
   }
 
   @override
-  bool get canConnect =>
-      (super.noSuchMethod(Invocation.getter(#canConnect), returnValue: false)
-          as bool);
+  bool get canConnect => (super.noSuchMethod(
+        Invocation.getter(#canConnect),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnected =>
-      (super.noSuchMethod(Invocation.getter(#isConnected), returnValue: false)
-          as bool);
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasActiveConnection =>
-      (super.noSuchMethod(Invocation.getter(#hasActiveConnection),
-          returnValue: false) as bool);
+  bool get hasActiveConnection => (super.noSuchMethod(
+        Invocation.getter(#hasActiveConnection),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isEnabled =>
-      (super.noSuchMethod(Invocation.getter(#isEnabled), returnValue: false)
-          as bool);
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  _i6.ConnectMode get connectMode =>
-      (super.noSuchMethod(Invocation.getter(#connectMode),
-          returnValue: _i6.ConnectMode.none) as _i6.ConnectMode);
+  _i6.ConnectMode get connectMode => (super.noSuchMethod(
+        Invocation.getter(#connectMode),
+        returnValue: _i6.ConnectMode.none,
+      ) as _i6.ConnectMode);
   @override
   _i2.NetworkService get service => (super.noSuchMethod(
+        Invocation.getter(#service),
+        returnValue: _FakeNetworkService_1(
+          this,
           Invocation.getter(#service),
-          returnValue: _FakeNetworkService_1(this, Invocation.getter(#service)))
-      as _i2.NetworkService);
+        ),
+      ) as _i2.NetworkService);
   @override
-  List<_i3.WifiDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i3.WifiDevice>[]) as List<_i3.WifiDevice>);
+  List<_i3.WifiDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i3.WifiDevice>[],
+      ) as List<_i3.WifiDevice>);
   @override
-  _i4.Stream<dynamic> get onAvailabilityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onAvailabilityChanged),
-          returnValue: _i4.Stream<dynamic>.empty()) as _i4.Stream<dynamic>);
+  _i4.Stream<dynamic> get onAvailabilityChanged => (super.noSuchMethod(
+        Invocation.getter(#onAvailabilityChanged),
+        returnValue: _i4.Stream<dynamic>.empty(),
+      ) as _i4.Stream<dynamic>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void onSelected() => super.noSuchMethod(Invocation.method(#onSelected, []),
-      returnValueForMissingStub: null);
+  void onSelected() => super.noSuchMethod(
+        Invocation.method(
+          #onSelected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void onDeselected() =>
-      super.noSuchMethod(Invocation.method(#onDeselected, []),
-          returnValueForMissingStub: null);
+  void onDeselected() => super.noSuchMethod(
+        Invocation.method(
+          #onDeselected,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> cleanup() => (super.noSuchMethod(
-      Invocation.method(#cleanup, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> enable() => (super.noSuchMethod(
-      Invocation.method(#enable, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #enable,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  List<_i2.NetworkManagerDevice> getDevices() =>
-      (super.noSuchMethod(Invocation.method(#getDevices, []),
-              returnValue: <_i2.NetworkManagerDevice>[])
-          as List<_i2.NetworkManagerDevice>);
+  List<_i2.NetworkManagerDevice> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
   @override
   _i3.WifiDevice createDevice(_i2.NetworkManagerDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#createDevice, [device]),
-              returnValue: _FakeWifiDevice_2(
-                  this, Invocation.method(#createDevice, [device])))
-          as _i3.WifiDevice);
+      (super.noSuchMethod(
+        Invocation.method(
+          #createDevice,
+          [device],
+        ),
+        returnValue: _FakeWifiDevice_2(
+          this,
+          Invocation.method(
+            #createDevice,
+            [device],
+          ),
+        ),
+      ) as _i3.WifiDevice);
   @override
-  void startPeriodicScanning() =>
-      super.noSuchMethod(Invocation.method(#startPeriodicScanning, []),
-          returnValueForMissingStub: null);
+  void startPeriodicScanning() => super.noSuchMethod(
+        Invocation.method(
+          #startPeriodicScanning,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void stopPeriodicScanning() =>
-      super.noSuchMethod(Invocation.method(#stopPeriodicScanning, []),
-          returnValueForMissingStub: null);
+  void stopPeriodicScanning() => super.noSuchMethod(
+        Invocation.method(
+          #stopPeriodicScanning,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<dynamic> requestScan({String? ssid}) =>
-      (super.noSuchMethod(Invocation.method(#requestScan, [], {#ssid: ssid}),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> requestScan({String? ssid}) => (super.noSuchMethod(
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  void updateDevices() =>
-      super.noSuchMethod(Invocation.method(#updateDevices, []),
-          returnValueForMissingStub: null);
+  void updateDevices() => super.noSuchMethod(
+        Invocation.method(
+          #updateDevices,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool isSelectedDevice(_i3.WifiDevice? device) =>
-      (super.noSuchMethod(Invocation.method(#isSelectedDevice, [device]),
-          returnValue: false) as bool);
+  bool isSelectedDevice(_i3.WifiDevice? device) => (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedDevice,
+          [device],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectDevice(_i3.WifiDevice? device) =>
-      super.noSuchMethod(Invocation.method(#selectDevice, [device]),
-          returnValueForMissingStub: null);
+  void selectDevice(_i3.WifiDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #selectDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setProperties(_i4.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i5.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i5.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [WifiDevice].
@@ -284,134 +481,228 @@ class MockWifiDevice extends _i1.Mock implements _i3.WifiDevice {
   }
 
   @override
-  bool get isActive =>
-      (super.noSuchMethod(Invocation.getter(#isActive), returnValue: false)
-          as bool);
+  bool get isActive => (super.noSuchMethod(
+        Invocation.getter(#isActive),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i3.AccessPoint> get accessPoints =>
-      (super.noSuchMethod(Invocation.getter(#accessPoints),
-          returnValue: <_i3.AccessPoint>[]) as List<_i3.AccessPoint>);
+  List<_i3.AccessPoint> get accessPoints => (super.noSuchMethod(
+        Invocation.getter(#accessPoints),
+        returnValue: <_i3.AccessPoint>[],
+      ) as List<_i3.AccessPoint>);
   @override
-  bool get scanning =>
-      (super.noSuchMethod(Invocation.getter(#scanning), returnValue: false)
-          as bool);
+  bool get scanning => (super.noSuchMethod(
+        Invocation.getter(#scanning),
+        returnValue: false,
+      ) as bool);
   @override
-  int get lastScan =>
-      (super.noSuchMethod(Invocation.getter(#lastScan), returnValue: 0) as int);
+  int get lastScan => (super.noSuchMethod(
+        Invocation.getter(#lastScan),
+        returnValue: 0,
+      ) as int);
   @override
-  _i2.NetworkManagerDevice get device =>
-      (super.noSuchMethod(Invocation.getter(#device),
-              returnValue:
-                  _FakeNetworkManagerDevice_3(this, Invocation.getter(#device)))
-          as _i2.NetworkManagerDevice);
+  _i2.NetworkManagerDevice get device => (super.noSuchMethod(
+        Invocation.getter(#device),
+        returnValue: _FakeNetworkManagerDevice_3(
+          this,
+          Invocation.getter(#device),
+        ),
+      ) as _i2.NetworkManagerDevice);
   @override
-  String get interface =>
-      (super.noSuchMethod(Invocation.getter(#interface), returnValue: '')
-          as String);
+  String get interface => (super.noSuchMethod(
+        Invocation.getter(#interface),
+        returnValue: '',
+      ) as String);
   @override
-  _i2.NetworkManagerDeviceState get state =>
-      (super.noSuchMethod(Invocation.getter(#state),
-              returnValue: _i2.NetworkManagerDeviceState.unknown)
-          as _i2.NetworkManagerDeviceState);
+  _i2.NetworkManagerDeviceState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerDeviceState.unknown,
+      ) as _i2.NetworkManagerDeviceState);
   @override
-  bool get isConnecting =>
-      (super.noSuchMethod(Invocation.getter(#isConnecting), returnValue: false)
-          as bool);
+  bool get isConnecting => (super.noSuchMethod(
+        Invocation.getter(#isConnecting),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisconnected => (super
-          .noSuchMethod(Invocation.getter(#isDisconnected), returnValue: false)
-      as bool);
+  bool get isDisconnected => (super.noSuchMethod(
+        Invocation.getter(#isDisconnected),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isUnmanaged =>
-      (super.noSuchMethod(Invocation.getter(#isUnmanaged), returnValue: false)
-          as bool);
+  bool get isUnmanaged => (super.noSuchMethod(
+        Invocation.getter(#isUnmanaged),
+        returnValue: false,
+      ) as bool);
   @override
-  String get hwAddress =>
-      (super.noSuchMethod(Invocation.getter(#hwAddress), returnValue: '')
-          as String);
+  String get hwAddress => (super.noSuchMethod(
+        Invocation.getter(#hwAddress),
+        returnValue: '',
+      ) as String);
   @override
   List<_i2.NetworkManagerSettingsConnection> get availableConnections =>
-      (super.noSuchMethod(Invocation.getter(#availableConnections),
-              returnValue: <_i2.NetworkManagerSettingsConnection>[])
-          as List<_i2.NetworkManagerSettingsConnection>);
+      (super.noSuchMethod(
+        Invocation.getter(#availableConnections),
+        returnValue: <_i2.NetworkManagerSettingsConnection>[],
+      ) as List<_i2.NetworkManagerSettingsConnection>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void init() => super.noSuchMethod(Invocation.method(#init, []),
-      returnValueForMissingStub: null);
+  void init() => super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void cleanup() => super.noSuchMethod(Invocation.method(#cleanup, []),
-      returnValueForMissingStub: null);
+  void cleanup() => super.noSuchMethod(
+        Invocation.method(
+          #cleanup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void updateDevice(_i2.NetworkManagerDevice? device) =>
-      super.noSuchMethod(Invocation.method(#updateDevice, [device]),
-          returnValueForMissingStub: null);
+  void updateDevice(_i2.NetworkManagerDevice? device) => super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [device],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool isActiveAccessPoint(_i3.AccessPoint? accessPoint) => (super.noSuchMethod(
-      Invocation.method(#isActiveAccessPoint, [accessPoint]),
-      returnValue: false) as bool);
+        Invocation.method(
+          #isActiveAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  bool isSelectedAccessPoint(_i3.AccessPoint? accessPoint) => (super
-      .noSuchMethod(Invocation.method(#isSelectedAccessPoint, [accessPoint]),
-          returnValue: false) as bool);
+  bool isSelectedAccessPoint(_i3.AccessPoint? accessPoint) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isSelectedAccessPoint,
+          [accessPoint],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectAccessPoint(_i3.AccessPoint? accessPoint) =>
-      super.noSuchMethod(Invocation.method(#selectAccessPoint, [accessPoint]),
-          returnValueForMissingStub: null);
+  void selectAccessPoint(_i3.AccessPoint? accessPoint) => super.noSuchMethod(
+        Invocation.method(
+          #selectAccessPoint,
+          [accessPoint],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> requestScan({String? ssid}) => (super.noSuchMethod(
-      Invocation.method(#requestScan, [], {#ssid: ssid}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #requestScan,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i3.AccessPoint? findAccessPoint(String? ssid) =>
-      (super.noSuchMethod(Invocation.method(#findAccessPoint, [ssid]))
-          as _i3.AccessPoint?);
+      (super.noSuchMethod(Invocation.method(
+        #findAccessPoint,
+        [ssid],
+      )) as _i3.AccessPoint?);
   @override
   _i4.Future<void> disconnect() => (super.noSuchMethod(
-      Invocation.method(#disconnect, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #disconnect,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   void setProperties(_i4.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i5.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i5.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -37,123 +42,213 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wizard/utils.dart' as _i2;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeProductInfo_0 extends _i1.SmartFake implements _i2.ProductInfo {
-  _FakeProductInfo_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeProductInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [InstallAlongsideModel].
@@ -38,94 +43,154 @@ class MockInstallAlongsideModel extends _i1.Mock
   }
 
   @override
-  _i2.ProductInfo get productInfo =>
-      (super.noSuchMethod(Invocation.getter(#productInfo),
-              returnValue:
-                  _FakeProductInfo_0(this, Invocation.getter(#productInfo)))
-          as _i2.ProductInfo);
+  _i2.ProductInfo get productInfo => (super.noSuchMethod(
+        Invocation.getter(#productInfo),
+        returnValue: _FakeProductInfo_0(
+          this,
+          Invocation.getter(#productInfo),
+        ),
+      ) as _i2.ProductInfo);
   @override
-  List<_i4.OsProber> get existingOS =>
-      (super.noSuchMethod(Invocation.getter(#existingOS),
-          returnValue: <_i4.OsProber>[]) as List<_i4.OsProber>);
+  List<_i4.OsProber> get existingOS => (super.noSuchMethod(
+        Invocation.getter(#existingOS),
+        returnValue: <_i4.OsProber>[],
+      ) as List<_i4.OsProber>);
   @override
-  int get storageCount =>
-      (super.noSuchMethod(Invocation.getter(#storageCount), returnValue: 0)
-          as int);
+  int get storageCount => (super.noSuchMethod(
+        Invocation.getter(#storageCount),
+        returnValue: 0,
+      ) as int);
   @override
-  int get currentSize =>
-      (super.noSuchMethod(Invocation.getter(#currentSize), returnValue: 0)
-          as int);
+  int get currentSize => (super.noSuchMethod(
+        Invocation.getter(#currentSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get minimumSize =>
-      (super.noSuchMethod(Invocation.getter(#minimumSize), returnValue: 0)
-          as int);
+  int get minimumSize => (super.noSuchMethod(
+        Invocation.getter(#minimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get maximumSize =>
-      (super.noSuchMethod(Invocation.getter(#maximumSize), returnValue: 0)
-          as int);
+  int get maximumSize => (super.noSuchMethod(
+        Invocation.getter(#maximumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get totalSize =>
-      (super.noSuchMethod(Invocation.getter(#totalSize), returnValue: 0)
-          as int);
+  int get totalSize => (super.noSuchMethod(
+        Invocation.getter(#totalSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i4.GuidedStorageTargetResize? getStorage(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getStorage, [index]))
-          as _i4.GuidedStorageTargetResize?);
+      (super.noSuchMethod(Invocation.method(
+        #getStorage,
+        [index],
+      )) as _i4.GuidedStorageTargetResize?);
   @override
-  _i4.Disk? getDisk(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getDisk, [index])) as _i4.Disk?);
+  _i4.Disk? getDisk(int? index) => (super.noSuchMethod(Invocation.method(
+        #getDisk,
+        [index],
+      )) as _i4.Disk?);
   @override
-  _i4.OsProber? getOS(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getOS, [index])) as _i4.OsProber?);
+  _i4.OsProber? getOS(int? index) => (super.noSuchMethod(Invocation.method(
+        #getOS,
+        [index],
+      )) as _i4.OsProber?);
   @override
   _i4.Partition? getPartition(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getPartition, [index]))
-          as _i4.Partition?);
+      (super.noSuchMethod(Invocation.method(
+        #getPartition,
+        [index],
+      )) as _i4.Partition?);
   @override
   List<_i4.Partition>? getAllPartitions(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getAllPartitions, [index]))
-          as List<_i4.Partition>?);
+      (super.noSuchMethod(Invocation.method(
+        #getAllPartitions,
+        [index],
+      )) as List<_i4.Partition>?);
   @override
-  void selectStorage(int? index) =>
-      super.noSuchMethod(Invocation.method(#selectStorage, [index]),
-          returnValueForMissingStub: null);
+  void selectStorage(int? index) => super.noSuchMethod(
+        Invocation.method(
+          #selectStorage,
+          [index],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void resizeStorage(int? size) =>
-      super.noSuchMethod(Invocation.method(#resizeStorage, [size]),
-          returnValueForMissingStub: null);
+  void resizeStorage(int? size) => super.noSuchMethod(
+        Invocation.method(
+          #resizeStorage,
+          [size],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i5.Future<void> reset() => (super.noSuchMethod(Invocation.method(#reset, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> reset() => (super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/pages/installation_complete/installatio
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [InstallationCompleteModel].
@@ -38,17 +43,30 @@ class MockInstallationCompleteModel extends _i1.Mock
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
   _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
@@ -28,8 +28,16 @@ class MockJournalService extends _i1.Mock implements _i2.JournalService {
   }
 
   @override
-  _i3.Stream<String> start(String? id,
-          {_i2.JournalOutput? output = _i2.JournalOutput.short}) =>
-      (super.noSuchMethod(Invocation.method(#start, [id], {#output: output}),
-          returnValue: _i3.Stream<String>.empty()) as _i3.Stream<String>);
+  _i3.Stream<String> start(
+    String? id, {
+    _i2.JournalOutput? output = _i2.JournalOutput.short,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [id],
+          {#output: output},
+        ),
+        returnValue: _i3.Stream<String>.empty(),
+      ) as _i3.Stream<String>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -26,8 +26,13 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i7;
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [InstallationSlidesModel].
@@ -41,75 +46,126 @@ class MockInstallationSlidesModel extends _i1.Mock
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
-  bool get isDone =>
-      (super.noSuchMethod(Invocation.getter(#isDone), returnValue: false)
-          as bool);
+  bool get isDone => (super.noSuchMethod(
+        Invocation.getter(#isDone),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasError =>
-      (super.noSuchMethod(Invocation.getter(#hasError), returnValue: false)
-          as bool);
+  bool get hasError => (super.noSuchMethod(
+        Invocation.getter(#hasError),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isInstalling =>
-      (super.noSuchMethod(Invocation.getter(#isInstalling), returnValue: false)
-          as bool);
+  bool get isInstalling => (super.noSuchMethod(
+        Invocation.getter(#isInstalling),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Stream<String> get log => (super.noSuchMethod(Invocation.getter(#log),
-      returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
+  _i4.Stream<String> get log => (super.noSuchMethod(
+        Invocation.getter(#log),
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
   @override
-  bool get isLogVisible =>
-      (super.noSuchMethod(Invocation.getter(#isLogVisible), returnValue: false)
-          as bool);
+  bool get isLogVisible => (super.noSuchMethod(
+        Invocation.getter(#isLogVisible),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void toggleLogVisibility() =>
-      super.noSuchMethod(Invocation.method(#toggleLogVisibility, []),
-          returnValueForMissingStub: null);
+  void toggleLogVisibility() => super.noSuchMethod(
+        Invocation.method(
+          #toggleLogVisibility,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> precacheSlideImages(_i5.BuildContext? context) =>
-      (super.noSuchMethod(Invocation.method(#precacheSlideImages, [context]),
-              returnValue: _i4.Future<void>.value(),
-              returnValueForMissingStub: _i4.Future<void>.value())
-          as _i4.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #precacheSlideImages,
+          [context],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [JournalService].
@@ -121,8 +177,16 @@ class MockJournalService extends _i1.Mock implements _i7.JournalService {
   }
 
   @override
-  _i4.Stream<String> start(String? id,
-          {_i7.JournalOutput? output = _i7.JournalOutput.short}) =>
-      (super.noSuchMethod(Invocation.method(#start, [id], {#output: output}),
-          returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
+  _i4.Stream<String> start(
+    String? id, {
+    _i7.JournalOutput? output = _i7.JournalOutput.short,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [id],
+          {#output: output},
+        ),
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.mocks.dart
@@ -28,7 +28,11 @@ class MockUrlLauncher extends _i1.Mock implements _i2.UrlLauncher {
   }
 
   @override
-  _i3.Future<bool> launchUrl(String? url) =>
-      (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: _i3.Future<bool>.value(false)) as _i3.Future<bool>);
+  _i3.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #launchUrl,
+          [url],
+        ),
+        returnValue: _i3.Future<bool>.value(false),
+      ) as _i3.Future<bool>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -27,8 +27,13 @@ import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -41,125 +46,215 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }
 
 /// A class which mocks [TelemetryService].
@@ -171,29 +266,56 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
   }
 
   @override
-  void addStage(String? name) =>
-      super.noSuchMethod(Invocation.method(#addStage, [name]),
-          returnValueForMissingStub: null);
+  void addStage(String? name) => super.noSuchMethod(
+        Invocation.method(
+          #addStage,
+          [name],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setLanguage(String? language) =>
-      super.noSuchMethod(Invocation.method(#setLanguage, [language]),
-          returnValueForMissingStub: null);
+  void setLanguage(String? language) => super.noSuchMethod(
+        Invocation.method(
+          #setLanguage,
+          [language],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setMinimal({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setMinimal, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setMinimal,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setRestrictedAddons({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setRestrictedAddons, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setRestrictedAddons,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setPartitionMethod(String? method) =>
-      super.noSuchMethod(Invocation.method(#setPartitionMethod, [method]),
-          returnValueForMissingStub: null);
+  void setPartitionMethod(String? method) => super.noSuchMethod(
+        Invocation.method(
+          #setPartitionMethod,
+          [method],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
-      (super.noSuchMethod(Invocation.method(#done, [], {#fs: fs}),
-              returnValue: _i4.Future<void>.value(),
-              returnValueForMissingStub: _i4.Future<void>.value())
-          as _i4.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #done,
+          [],
+          {#fs: fs},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wizard/utils.dart' as _i2;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeProductInfo_0 extends _i1.SmartFake implements _i2.ProductInfo {
-  _FakeProductInfo_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeProductInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [InstallationTypeModel].
@@ -38,77 +43,130 @@ class MockInstallationTypeModel extends _i1.Mock
   }
 
   @override
-  _i2.ProductInfo get productInfo =>
-      (super.noSuchMethod(Invocation.getter(#productInfo),
-              returnValue:
-                  _FakeProductInfo_0(this, Invocation.getter(#productInfo)))
-          as _i2.ProductInfo);
+  _i2.ProductInfo get productInfo => (super.noSuchMethod(
+        Invocation.getter(#productInfo),
+        returnValue: _FakeProductInfo_0(
+          this,
+          Invocation.getter(#productInfo),
+        ),
+      ) as _i2.ProductInfo);
   @override
-  _i3.InstallationType get installationType =>
-      (super.noSuchMethod(Invocation.getter(#installationType),
-          returnValue: _i3.InstallationType.erase) as _i3.InstallationType);
+  _i3.InstallationType get installationType => (super.noSuchMethod(
+        Invocation.getter(#installationType),
+        returnValue: _i3.InstallationType.erase,
+      ) as _i3.InstallationType);
   @override
-  set installationType(_i3.InstallationType? type) =>
-      super.noSuchMethod(Invocation.setter(#installationType, type),
-          returnValueForMissingStub: null);
+  set installationType(_i3.InstallationType? type) => super.noSuchMethod(
+        Invocation.setter(
+          #installationType,
+          type,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i3.AdvancedFeature get advancedFeature =>
-      (super.noSuchMethod(Invocation.getter(#advancedFeature),
-          returnValue: _i3.AdvancedFeature.none) as _i3.AdvancedFeature);
+  _i3.AdvancedFeature get advancedFeature => (super.noSuchMethod(
+        Invocation.getter(#advancedFeature),
+        returnValue: _i3.AdvancedFeature.none,
+      ) as _i3.AdvancedFeature);
   @override
-  set advancedFeature(_i3.AdvancedFeature? feature) =>
-      super.noSuchMethod(Invocation.setter(#advancedFeature, feature),
-          returnValueForMissingStub: null);
+  set advancedFeature(_i3.AdvancedFeature? feature) => super.noSuchMethod(
+        Invocation.setter(
+          #advancedFeature,
+          feature,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get encryption =>
-      (super.noSuchMethod(Invocation.getter(#encryption), returnValue: false)
-          as bool);
+  bool get encryption => (super.noSuchMethod(
+        Invocation.getter(#encryption),
+        returnValue: false,
+      ) as bool);
   @override
-  set encryption(bool? encryption) =>
-      super.noSuchMethod(Invocation.setter(#encryption, encryption),
-          returnValueForMissingStub: null);
+  set encryption(bool? encryption) => super.noSuchMethod(
+        Invocation.setter(
+          #encryption,
+          encryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get canInstallAlongside =>
-      (super.noSuchMethod(Invocation.getter(#canInstallAlongside),
-          returnValue: false) as bool);
+  bool get canInstallAlongside => (super.noSuchMethod(
+        Invocation.getter(#canInstallAlongside),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i5.GuidedStorageTarget? preselectTarget(_i3.InstallationType? type) =>
-      (super.noSuchMethod(Invocation.method(#preselectTarget, [type]))
-          as _i5.GuidedStorageTarget?);
+      (super.noSuchMethod(Invocation.method(
+        #preselectTarget,
+        [type],
+      )) as _i5.GuidedStorageTarget?);
   @override
-  _i4.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> resetStorage() => (super.noSuchMethod(
-      Invocation.method(#resetStorage, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.mocks.dart
@@ -31,93 +31,164 @@ class MockKeyboardLayoutModel extends _i1.Mock
   }
 
   @override
-  int get layoutCount =>
-      (super.noSuchMethod(Invocation.getter(#layoutCount), returnValue: 0)
-          as int);
+  int get layoutCount => (super.noSuchMethod(
+        Invocation.getter(#layoutCount),
+        returnValue: 0,
+      ) as int);
   @override
-  int get selectedLayoutIndex => (super
-          .noSuchMethod(Invocation.getter(#selectedLayoutIndex), returnValue: 0)
-      as int);
+  int get selectedLayoutIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedLayoutIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  _i3.Stream<int> get onLayoutSelected =>
-      (super.noSuchMethod(Invocation.getter(#onLayoutSelected),
-          returnValue: _i3.Stream<int>.empty()) as _i3.Stream<int>);
+  _i3.Stream<int> get onLayoutSelected => (super.noSuchMethod(
+        Invocation.getter(#onLayoutSelected),
+        returnValue: _i3.Stream<int>.empty(),
+      ) as _i3.Stream<int>);
   @override
-  _i3.Stream<int> get onVariantSelected =>
-      (super.noSuchMethod(Invocation.getter(#onVariantSelected),
-          returnValue: _i3.Stream<int>.empty()) as _i3.Stream<int>);
+  _i3.Stream<int> get onVariantSelected => (super.noSuchMethod(
+        Invocation.getter(#onVariantSelected),
+        returnValue: _i3.Stream<int>.empty(),
+      ) as _i3.Stream<int>);
   @override
-  int get variantCount =>
-      (super.noSuchMethod(Invocation.getter(#variantCount), returnValue: 0)
-          as int);
+  int get variantCount => (super.noSuchMethod(
+        Invocation.getter(#variantCount),
+        returnValue: 0,
+      ) as int);
   @override
-  int get selectedVariantIndex =>
-      (super.noSuchMethod(Invocation.getter(#selectedVariantIndex),
-          returnValue: 0) as int);
+  int get selectedVariantIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedVariantIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  String layoutName(int? index) =>
-      (super.noSuchMethod(Invocation.method(#layoutName, [index]),
-          returnValue: '') as String);
+  String layoutName(int? index) => (super.noSuchMethod(
+        Invocation.method(
+          #layoutName,
+          [index],
+        ),
+        returnValue: '',
+      ) as String);
   @override
-  _i3.Future<void> selectLayout(int? index, [int? variant = 0]) =>
-      (super.noSuchMethod(Invocation.method(#selectLayout, [index, variant]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
-  @override
-  _i3.Future<void> trySelectLayoutVariant(String? layout, String? variant) =>
+  _i3.Future<void> selectLayout(
+    int? index, [
+    int? variant = 0,
+  ]) =>
       (super.noSuchMethod(
-              Invocation.method(#trySelectLayoutVariant, [layout, variant]),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+        Invocation.method(
+          #selectLayout,
+          [
+            index,
+            variant,
+          ],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  String variantName(int? index) =>
-      (super.noSuchMethod(Invocation.method(#variantName, [index]),
-          returnValue: '') as String);
+  _i3.Future<void> trySelectLayoutVariant(
+    String? layout,
+    String? variant,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #trySelectLayoutVariant,
+          [
+            layout,
+            variant,
+          ],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  String variantName(int? index) => (super.noSuchMethod(
+        Invocation.method(
+          #variantName,
+          [index],
+        ),
+        returnValue: '',
+      ) as String);
   @override
   _i3.Future<void> selectVariant(int? index) => (super.noSuchMethod(
-      Invocation.method(#selectVariant, [index]),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #selectVariant,
+          [index],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> updateInputSource() => (super.noSuchMethod(
-      Invocation.method(#updateInputSource, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #updateInputSource,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(Invocation.method(#save, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> save() => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -37,123 +42,213 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.mocks.dart
@@ -30,41 +30,68 @@ class MockNotEnoughDiskSpaceModel extends _i1.Mock
   }
 
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void quit() => super.noSuchMethod(Invocation.method(#quit, []),
-      returnValueForMissingStub: null);
+  void quit() => super.noSuchMethod(
+        Invocation.method(
+          #quit,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i3.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i3.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i3.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i3.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -37,123 +42,213 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
@@ -32,61 +32,101 @@ class MockSelectGuidedStorageModel extends _i1.Mock
   }
 
   @override
-  List<_i3.GuidedStorageTarget> get storages =>
-      (super.noSuchMethod(Invocation.getter(#storages),
-              returnValue: <_i3.GuidedStorageTarget>[])
-          as List<_i3.GuidedStorageTarget>);
+  List<_i3.GuidedStorageTarget> get storages => (super.noSuchMethod(
+        Invocation.getter(#storages),
+        returnValue: <_i3.GuidedStorageTarget>[],
+      ) as List<_i3.GuidedStorageTarget>);
   @override
-  int get selectedIndex =>
-      (super.noSuchMethod(Invocation.getter(#selectedIndex), returnValue: 0)
-          as int);
+  int get selectedIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i3.GuidedStorageTargetReformat? getStorage(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getStorage, [index]))
-          as _i3.GuidedStorageTargetReformat?);
+      (super.noSuchMethod(Invocation.method(
+        #getStorage,
+        [index],
+      )) as _i3.GuidedStorageTargetReformat?);
   @override
-  _i3.Disk? getDisk(int? index) =>
-      (super.noSuchMethod(Invocation.method(#getDisk, [index])) as _i3.Disk?);
+  _i3.Disk? getDisk(int? index) => (super.noSuchMethod(Invocation.method(
+        #getDisk,
+        [index],
+      )) as _i3.Disk?);
   @override
-  void selectStorage(int? index) =>
-      super.noSuchMethod(Invocation.method(#selectStorage, [index]),
-          returnValueForMissingStub: null);
+  void selectStorage(int? index) => super.noSuchMethod(
+        Invocation.method(
+          #selectStorage,
+          [index],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> loadGuidedStorage() => (super.noSuchMethod(
-      Invocation.method(#loadGuidedStorage, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #loadGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> saveGuidedStorage() => (super.noSuchMethod(
-      Invocation.method(#saveGuidedStorage, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #saveGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> resetGuidedStorage() => (super.noSuchMethod(
-      Invocation.method(#resetGuidedStorage, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #resetGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.mocks.dart
@@ -22,8 +22,13 @@ import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i4;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeLocale_0 extends _i1.SmartFake implements _i2.Locale {
-  _FakeLocale_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeLocale_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [Settings].
@@ -35,40 +40,71 @@ class MockSettings extends _i1.Mock implements _i3.Settings {
   }
 
   @override
-  _i2.Locale get locale => (super.noSuchMethod(Invocation.getter(#locale),
-          returnValue: _FakeLocale_0(this, Invocation.getter(#locale)))
-      as _i2.Locale);
+  _i2.Locale get locale => (super.noSuchMethod(
+        Invocation.getter(#locale),
+        returnValue: _FakeLocale_0(
+          this,
+          Invocation.getter(#locale),
+        ),
+      ) as _i2.Locale);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void applyTheme(_i2.Brightness? brightness) =>
-      super.noSuchMethod(Invocation.method(#applyTheme, [brightness]),
-          returnValueForMissingStub: null);
+  void applyTheme(_i2.Brightness? brightness) => super.noSuchMethod(
+        Invocation.method(
+          #applyTheme,
+          [brightness],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void applyLocale(_i2.Locale? locale) =>
-      super.noSuchMethod(Invocation.method(#applyLocale, [locale]),
-          returnValueForMissingStub: null);
+  void applyLocale(_i2.Locale? locale) => super.noSuchMethod(
+        Invocation.method(
+          #applyLocale,
+          [locale],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UrlLauncher].
@@ -80,7 +116,11 @@ class MockUrlLauncher extends _i1.Mock implements _i4.UrlLauncher {
   }
 
   @override
-  _i5.Future<bool> launchUrl(String? url) =>
-      (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: _i5.Future<bool>.value(false)) as _i5.Future<bool>);
+  _i5.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #launchUrl,
+          [url],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wizard/utils.dart' as _i5;
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [TurnOffBitLockerModel].
@@ -39,19 +44,32 @@ class MockTurnOffBitLockerModel extends _i1.Mock
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
   _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [UrlLauncher].
@@ -63,7 +81,11 @@ class MockUrlLauncher extends _i1.Mock implements _i5.UrlLauncher {
   }
 
   @override
-  _i4.Future<bool> launchUrl(String? url) =>
-      (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #launchUrl,
+          [url],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wizard/utils.dart' as _i5;
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [TurnOffRSTModel].
@@ -38,19 +43,32 @@ class MockTurnOffRSTModel extends _i1.Mock implements _i3.TurnOffRSTModel {
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
   _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [UrlLauncher].
@@ -62,7 +80,11 @@ class MockUrlLauncher extends _i1.Mock implements _i5.UrlLauncher {
   }
 
   @override
-  _i4.Future<bool> launchUrl(String? url) =>
-      (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #launchUrl,
+          [url],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
 }

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_model_test.mocks.dart
@@ -22,13 +22,23 @@ import 'package:upower/upower.dart' as _i2;
 
 class _FakeUPowerKbdBacklight_0 extends _i1.SmartFake
     implements _i2.UPowerKbdBacklight {
-  _FakeUPowerKbdBacklight_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUPowerKbdBacklight_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeUPowerDevice_1 extends _i1.SmartFake implements _i2.UPowerDevice {
-  _FakeUPowerDevice_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUPowerDevice_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [PowerService].
@@ -41,66 +51,92 @@ class MockPowerService extends _i1.Mock implements _i3.PowerService {
 
   @override
   _i2.UPowerKbdBacklight get kbdBacklight => (super.noSuchMethod(
+        Invocation.getter(#kbdBacklight),
+        returnValue: _FakeUPowerKbdBacklight_0(
+          this,
           Invocation.getter(#kbdBacklight),
-          returnValue:
-              _FakeUPowerKbdBacklight_0(this, Invocation.getter(#kbdBacklight)))
-      as _i2.UPowerKbdBacklight);
+        ),
+      ) as _i2.UPowerKbdBacklight);
   @override
-  set kbdBacklight(_i2.UPowerKbdBacklight? _kbdBacklight) =>
-      super.noSuchMethod(Invocation.setter(#kbdBacklight, _kbdBacklight),
-          returnValueForMissingStub: null);
+  set kbdBacklight(_i2.UPowerKbdBacklight? _kbdBacklight) => super.noSuchMethod(
+        Invocation.setter(
+          #kbdBacklight,
+          _kbdBacklight,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get daemonVersion =>
-      (super.noSuchMethod(Invocation.getter(#daemonVersion), returnValue: '')
-          as String);
+  String get daemonVersion => (super.noSuchMethod(
+        Invocation.getter(#daemonVersion),
+        returnValue: '',
+      ) as String);
   @override
-  bool get onBattery =>
-      (super.noSuchMethod(Invocation.getter(#onBattery), returnValue: false)
-          as bool);
+  bool get onBattery => (super.noSuchMethod(
+        Invocation.getter(#onBattery),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get lidIsPresent =>
-      (super.noSuchMethod(Invocation.getter(#lidIsPresent), returnValue: false)
-          as bool);
+  bool get lidIsPresent => (super.noSuchMethod(
+        Invocation.getter(#lidIsPresent),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get lidIsClosed =>
-      (super.noSuchMethod(Invocation.getter(#lidIsClosed), returnValue: false)
-          as bool);
+  bool get lidIsClosed => (super.noSuchMethod(
+        Invocation.getter(#lidIsClosed),
+        returnValue: false,
+      ) as bool);
   @override
-  List<_i2.UPowerDevice> get devices =>
-      (super.noSuchMethod(Invocation.getter(#devices),
-          returnValue: <_i2.UPowerDevice>[]) as List<_i2.UPowerDevice>);
+  List<_i2.UPowerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.UPowerDevice>[],
+      ) as List<_i2.UPowerDevice>);
   @override
-  _i2.UPowerDevice get displayDevice =>
-      (super.noSuchMethod(Invocation.getter(#displayDevice),
-              returnValue:
-                  _FakeUPowerDevice_1(this, Invocation.getter(#displayDevice)))
-          as _i2.UPowerDevice);
+  _i2.UPowerDevice get displayDevice => (super.noSuchMethod(
+        Invocation.getter(#displayDevice),
+        returnValue: _FakeUPowerDevice_1(
+          this,
+          Invocation.getter(#displayDevice),
+        ),
+      ) as _i2.UPowerDevice);
   @override
-  _i4.Stream<_i2.UPowerDevice> get deviceAdded =>
-      (super.noSuchMethod(Invocation.getter(#deviceAdded),
-              returnValue: _i4.Stream<_i2.UPowerDevice>.empty())
-          as _i4.Stream<_i2.UPowerDevice>);
+  _i4.Stream<_i2.UPowerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i4.Stream<_i2.UPowerDevice>.empty(),
+      ) as _i4.Stream<_i2.UPowerDevice>);
   @override
-  _i4.Stream<_i2.UPowerDevice> get deviceRemoved =>
-      (super.noSuchMethod(Invocation.getter(#deviceRemoved),
-              returnValue: _i4.Stream<_i2.UPowerDevice>.empty())
-          as _i4.Stream<_i2.UPowerDevice>);
+  _i4.Stream<_i2.UPowerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i4.Stream<_i2.UPowerDevice>.empty(),
+      ) as _i4.Stream<_i2.UPowerDevice>);
   @override
-  _i4.Stream<List<String>> get propertiesChanged =>
-      (super.noSuchMethod(Invocation.getter(#propertiesChanged),
-              returnValue: _i4.Stream<List<String>>.empty())
-          as _i4.Stream<List<String>>);
+  _i4.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i4.Stream<List<String>>.empty(),
+      ) as _i4.Stream<List<String>>);
   @override
   _i4.Future<void> connect() => (super.noSuchMethod(
-      Invocation.method(#connect, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i4.Future<String> getCriticalAction() =>
-      (super.noSuchMethod(Invocation.method(#getCriticalAction, []),
-          returnValue: _i4.Future<String>.value('')) as _i4.Future<String>);
+  _i4.Future<String> getCriticalAction() => (super.noSuchMethod(
+        Invocation.method(
+          #getCriticalAction,
+          [],
+        ),
+        returnValue: _i4.Future<String>.value(''),
+      ) as _i4.Future<String>);
   @override
-  _i4.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
@@ -34,74 +34,136 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
   }
 
   @override
-  _i2.InstallationMode get installationMode =>
-      (super.noSuchMethod(Invocation.getter(#installationMode),
-          returnValue: _i2.InstallationMode.normal) as _i2.InstallationMode);
+  _i2.InstallationMode get installationMode => (super.noSuchMethod(
+        Invocation.getter(#installationMode),
+        returnValue: _i2.InstallationMode.normal,
+      ) as _i2.InstallationMode);
   @override
-  bool get installThirdParty =>
-      (super.noSuchMethod(Invocation.getter(#installThirdParty),
-          returnValue: false) as bool);
+  bool get installThirdParty => (super.noSuchMethod(
+        Invocation.getter(#installThirdParty),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get onBattery =>
-      (super.noSuchMethod(Invocation.getter(#onBattery), returnValue: false)
-          as bool);
+  bool get onBattery => (super.noSuchMethod(
+        Invocation.getter(#onBattery),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void setInstallationMode(_i2.InstallationMode? mode) =>
-      super.noSuchMethod(Invocation.method(#setInstallationMode, [mode]),
-          returnValueForMissingStub: null);
+  void setInstallationMode(_i2.InstallationMode? mode) => super.noSuchMethod(
+        Invocation.method(
+          #setInstallationMode,
+          [mode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setInstallThirdParty(bool? installThirdParty) => super.noSuchMethod(
-      Invocation.method(#setInstallThirdParty, [installThirdParty]),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setInstallThirdParty,
+          [installThirdParty],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i3.Future<void> selectInstallationSource() => (super.noSuchMethod(
-      Invocation.method(#selectInstallationSource, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #selectInstallationSource,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   void setProperties(_i3.Stream<List<String>>? properties) =>
-      super.noSuchMethod(Invocation.method(#setProperties, [properties]),
-          returnValueForMissingStub: null);
-  @override
-  void addPropertyListener(String? property, _i4.VoidCallback? onChanged) =>
       super.noSuchMethod(
-          Invocation.method(#addPropertyListener, [property, onChanged]),
-          returnValueForMissingStub: null);
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void enablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#enablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void addPropertyListener(
+    String? property,
+    _i4.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void disablePropertyListeners() =>
-      super.noSuchMethod(Invocation.method(#disablePropertyListeners, []),
-          returnValueForMissingStub: null);
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [TelemetryService].
@@ -113,29 +175,56 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
   }
 
   @override
-  void addStage(String? name) =>
-      super.noSuchMethod(Invocation.method(#addStage, [name]),
-          returnValueForMissingStub: null);
+  void addStage(String? name) => super.noSuchMethod(
+        Invocation.method(
+          #addStage,
+          [name],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setLanguage(String? language) =>
-      super.noSuchMethod(Invocation.method(#setLanguage, [language]),
-          returnValueForMissingStub: null);
+  void setLanguage(String? language) => super.noSuchMethod(
+        Invocation.method(
+          #setLanguage,
+          [language],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setMinimal({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setMinimal, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setMinimal,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setRestrictedAddons({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setRestrictedAddons, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setRestrictedAddons,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setPartitionMethod(String? method) =>
-      super.noSuchMethod(Invocation.method(#setPartitionMethod, [method]),
-          returnValueForMissingStub: null);
+  void setPartitionMethod(String? method) => super.noSuchMethod(
+        Invocation.method(
+          #setPartitionMethod,
+          [method],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i3.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
-      (super.noSuchMethod(Invocation.method(#done, [], {#fs: fs}),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #done,
+          [],
+          {#fs: fs},
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.mocks.dart
@@ -31,29 +31,56 @@ class MockTelemetryService extends _i1.Mock implements _i2.TelemetryService {
   }
 
   @override
-  void addStage(String? name) =>
-      super.noSuchMethod(Invocation.method(#addStage, [name]),
-          returnValueForMissingStub: null);
+  void addStage(String? name) => super.noSuchMethod(
+        Invocation.method(
+          #addStage,
+          [name],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setLanguage(String? language) =>
-      super.noSuchMethod(Invocation.method(#setLanguage, [language]),
-          returnValueForMissingStub: null);
+  void setLanguage(String? language) => super.noSuchMethod(
+        Invocation.method(
+          #setLanguage,
+          [language],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setMinimal({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setMinimal, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setMinimal,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void setRestrictedAddons({bool? enabled}) => super.noSuchMethod(
-      Invocation.method(#setRestrictedAddons, [], {#enabled: enabled}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #setRestrictedAddons,
+          [],
+          {#enabled: enabled},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void setPartitionMethod(String? method) =>
-      super.noSuchMethod(Invocation.method(#setPartitionMethod, [method]),
-          returnValueForMissingStub: null);
+  void setPartitionMethod(String? method) => super.noSuchMethod(
+        Invocation.method(
+          #setPartitionMethod,
+          [method],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i3.Future<void> done({_i4.FileSystem? fs = const _i5.LocalFileSystem()}) =>
-      (super.noSuchMethod(Invocation.method(#done, [], {#fs: fs}),
-              returnValue: _i3.Future<void>.value(),
-              returnValueForMissingStub: _i3.Future<void>.value())
-          as _i3.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #done,
+          [],
+          {#fs: fs},
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.mocks.dart
@@ -34,39 +34,69 @@ class MockGeoService extends _i1.Mock implements _i2.GeoService {
   }
 
   @override
-  void addSource(_i3.GeoSource? source) =>
-      super.noSuchMethod(Invocation.method(#addSource, [source]),
-          returnValueForMissingStub: null);
+  void addSource(_i3.GeoSource? source) => super.noSuchMethod(
+        Invocation.method(
+          #addSource,
+          [source],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeSource(_i3.GeoSource? source) =>
-      super.noSuchMethod(Invocation.method(#removeSource, [source]),
-          returnValueForMissingStub: null);
+  void removeSource(_i3.GeoSource? source) => super.noSuchMethod(
+        Invocation.method(
+          #removeSource,
+          [source],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<_i5.GeoLocation?> lookupLocation() =>
-      (super.noSuchMethod(Invocation.method(#lookupLocation, []),
-              returnValue: _i4.Future<_i5.GeoLocation?>.value())
-          as _i4.Future<_i5.GeoLocation?>);
+  _i4.Future<_i5.GeoLocation?> lookupLocation() => (super.noSuchMethod(
+        Invocation.method(
+          #lookupLocation,
+          [],
+        ),
+        returnValue: _i4.Future<_i5.GeoLocation?>.value(),
+      ) as _i4.Future<_i5.GeoLocation?>);
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchLocation(String? location) =>
-      (super.noSuchMethod(Invocation.method(#searchLocation, [location]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchLocation,
+          [location],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchCoordinates(
           _i5.LatLng? coordinates) =>
-      (super.noSuchMethod(Invocation.method(#searchCoordinates, [coordinates]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchCoordinates,
+          [coordinates],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchTimezone(String? timezone) =>
-      (super.noSuchMethod(Invocation.method(#searchTimezone, [timezone]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchTimezone,
+          [timezone],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
   _i4.Future<void> cancelSearch() => (super.noSuchMethod(
-      Invocation.method(#cancelSearch, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #cancelSearch,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [TimezoneController].
@@ -79,60 +109,104 @@ class MockTimezoneController extends _i1.Mock
   }
 
   @override
-  Iterable<_i5.GeoLocation> get locations =>
-      (super.noSuchMethod(Invocation.getter(#locations),
-          returnValue: <_i5.GeoLocation>[]) as Iterable<_i5.GeoLocation>);
+  Iterable<_i5.GeoLocation> get locations => (super.noSuchMethod(
+        Invocation.getter(#locations),
+        returnValue: <_i5.GeoLocation>[],
+      ) as Iterable<_i5.GeoLocation>);
   @override
-  Iterable<_i5.GeoLocation> get timezones =>
-      (super.noSuchMethod(Invocation.getter(#timezones),
-          returnValue: <_i5.GeoLocation>[]) as Iterable<_i5.GeoLocation>);
+  Iterable<_i5.GeoLocation> get timezones => (super.noSuchMethod(
+        Invocation.getter(#timezones),
+        returnValue: <_i5.GeoLocation>[],
+      ) as Iterable<_i5.GeoLocation>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void selectLocation(_i5.GeoLocation? location) =>
-      super.noSuchMethod(Invocation.method(#selectLocation, [location]),
-          returnValueForMissingStub: null);
+  void selectLocation(_i5.GeoLocation? location) => super.noSuchMethod(
+        Invocation.method(
+          #selectLocation,
+          [location],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void selectTimezone(_i5.GeoLocation? timezone) =>
-      super.noSuchMethod(Invocation.method(#selectTimezone, [timezone]),
-          returnValueForMissingStub: null);
+  void selectTimezone(_i5.GeoLocation? timezone) => super.noSuchMethod(
+        Invocation.method(
+          #selectTimezone,
+          [timezone],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchLocation(String? location) =>
-      (super.noSuchMethod(Invocation.method(#searchLocation, [location]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchLocation,
+          [location],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchCoordinates(
           _i5.LatLng? coordinates) =>
-      (super.noSuchMethod(Invocation.method(#searchCoordinates, [coordinates]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchCoordinates,
+          [coordinates],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
   _i4.Future<Iterable<_i5.GeoLocation>> searchTimezone(String? timezone) =>
-      (super.noSuchMethod(Invocation.method(#searchTimezone, [timezone]),
-          returnValue: _i4.Future<Iterable<_i5.GeoLocation>>.value(
-              <_i5.GeoLocation>[])) as _i4.Future<Iterable<_i5.GeoLocation>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchTimezone,
+          [timezone],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [WhereAreYouModel].
@@ -144,34 +218,62 @@ class MockWhereAreYouModel extends _i1.Mock implements _i8.WhereAreYouModel {
   }
 
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<String> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<String>.value('')) as _i4.Future<String>);
+  _i4.Future<String> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<String>.value(''),
+      ) as _i4.Future<String>);
   @override
   _i4.Future<void> save(String? timezone) => (super.noSuchMethod(
-      Invocation.method(#save, [timezone]),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #save,
+          [timezone],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i7.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
@@ -32,113 +32,184 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
   }
 
   @override
-  String get realName =>
-      (super.noSuchMethod(Invocation.getter(#realName), returnValue: '')
-          as String);
+  String get realName => (super.noSuchMethod(
+        Invocation.getter(#realName),
+        returnValue: '',
+      ) as String);
   @override
-  set realName(String? value) =>
-      super.noSuchMethod(Invocation.setter(#realName, value),
-          returnValueForMissingStub: null);
+  set realName(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #realName,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get hostname =>
-      (super.noSuchMethod(Invocation.getter(#hostname), returnValue: '')
-          as String);
+  String get hostname => (super.noSuchMethod(
+        Invocation.getter(#hostname),
+        returnValue: '',
+      ) as String);
   @override
-  set hostname(String? value) =>
-      super.noSuchMethod(Invocation.setter(#hostname, value),
-          returnValueForMissingStub: null);
+  set hostname(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #hostname,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get username =>
-      (super.noSuchMethod(Invocation.getter(#username), returnValue: '')
-          as String);
+  String get username => (super.noSuchMethod(
+        Invocation.getter(#username),
+        returnValue: '',
+      ) as String);
   @override
-  set username(String? value) =>
-      super.noSuchMethod(Invocation.setter(#username, value),
-          returnValueForMissingStub: null);
+  set username(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #username,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get password =>
-      (super.noSuchMethod(Invocation.getter(#password), returnValue: '')
-          as String);
+  String get password => (super.noSuchMethod(
+        Invocation.getter(#password),
+        returnValue: '',
+      ) as String);
   @override
-  set password(String? value) =>
-      super.noSuchMethod(Invocation.setter(#password, value),
-          returnValueForMissingStub: null);
+  set password(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #password,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get confirmedPassword => (super
-          .noSuchMethod(Invocation.getter(#confirmedPassword), returnValue: '')
-      as String);
+  String get confirmedPassword => (super.noSuchMethod(
+        Invocation.getter(#confirmedPassword),
+        returnValue: '',
+      ) as String);
   @override
-  set confirmedPassword(String? value) =>
-      super.noSuchMethod(Invocation.setter(#confirmedPassword, value),
-          returnValueForMissingStub: null);
+  set confirmedPassword(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #confirmedPassword,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i3.PasswordStrength get passwordStrength =>
-      (super.noSuchMethod(Invocation.getter(#passwordStrength),
-          returnValue: _i3.PasswordStrength.weak) as _i3.PasswordStrength);
+  _i3.PasswordStrength get passwordStrength => (super.noSuchMethod(
+        Invocation.getter(#passwordStrength),
+        returnValue: _i3.PasswordStrength.weak,
+      ) as _i3.PasswordStrength);
   @override
-  _i2.LoginStrategy get loginStrategy =>
-      (super.noSuchMethod(Invocation.getter(#loginStrategy),
-          returnValue: _i2.LoginStrategy.requirePassword) as _i2.LoginStrategy);
+  _i2.LoginStrategy get loginStrategy => (super.noSuchMethod(
+        Invocation.getter(#loginStrategy),
+        returnValue: _i2.LoginStrategy.requirePassword,
+      ) as _i2.LoginStrategy);
   @override
-  set loginStrategy(_i2.LoginStrategy? value) =>
-      super.noSuchMethod(Invocation.setter(#loginStrategy, value),
-          returnValueForMissingStub: null);
+  set loginStrategy(_i2.LoginStrategy? value) => super.noSuchMethod(
+        Invocation.setter(
+          #loginStrategy,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.UsernameValidation get usernameValidation =>
-      (super.noSuchMethod(Invocation.getter(#usernameValidation),
-          returnValue: _i4.UsernameValidation.OK) as _i4.UsernameValidation);
+  _i4.UsernameValidation get usernameValidation => (super.noSuchMethod(
+        Invocation.getter(#usernameValidation),
+        returnValue: _i4.UsernameValidation.OK,
+      ) as _i4.UsernameValidation);
   @override
-  bool get usernameOk =>
-      (super.noSuchMethod(Invocation.getter(#usernameOk), returnValue: false)
-          as bool);
+  bool get usernameOk => (super.noSuchMethod(
+        Invocation.getter(#usernameOk),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get showPassword =>
-      (super.noSuchMethod(Invocation.getter(#showPassword), returnValue: false)
-          as bool);
+  bool get showPassword => (super.noSuchMethod(
+        Invocation.getter(#showPassword),
+        returnValue: false,
+      ) as bool);
   @override
-  set showPassword(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#showPassword, value),
-          returnValueForMissingStub: null);
+  set showPassword(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #showPassword,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i5.Future<void> validate() => (super.noSuchMethod(
-      Invocation.method(#validate, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #validate,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> loadIdentity() => (super.noSuchMethod(
-      Invocation.method(#loadIdentity, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #loadIdentity,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> saveIdentity({String? salt}) => (super.noSuchMethod(
-      Invocation.method(#saveIdentity, [], {#salt: salt}),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #saveIdentity,
+          [],
+          {#salt: salt},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -23,8 +23,13 @@ import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
 
 class _FakeGuidedStorageResponseV2_0 extends _i1.SmartFake
     implements _i2.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiskStorageService].
@@ -37,123 +42,213 @@ class MockDiskStorageService extends _i1.Mock
   }
 
   @override
-  bool get hasMultipleDisks =>
-      (super.noSuchMethod(Invocation.getter(#hasMultipleDisks),
-          returnValue: false) as bool);
+  bool get hasMultipleDisks => (super.noSuchMethod(
+        Invocation.getter(#hasMultipleDisks),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needRoot =>
-      (super.noSuchMethod(Invocation.getter(#needRoot), returnValue: false)
-          as bool);
+  bool get needRoot => (super.noSuchMethod(
+        Invocation.getter(#needRoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get needBoot =>
-      (super.noSuchMethod(Invocation.getter(#needBoot), returnValue: false)
-          as bool);
+  bool get needBoot => (super.noSuchMethod(
+        Invocation.getter(#needBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasRst =>
-      (super.noSuchMethod(Invocation.getter(#hasRst), returnValue: false)
-          as bool);
+  bool get hasRst => (super.noSuchMethod(
+        Invocation.getter(#hasRst),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasBitLocker =>
-      (super.noSuchMethod(Invocation.getter(#hasBitLocker), returnValue: false)
-          as bool);
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasEncryption =>
-      (super.noSuchMethod(Invocation.getter(#hasEncryption), returnValue: false)
-          as bool);
+  bool get hasEncryption => (super.noSuchMethod(
+        Invocation.getter(#hasEncryption),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasSecureBoot =>
-      (super.noSuchMethod(Invocation.getter(#hasSecureBoot), returnValue: false)
-          as bool);
+  bool get hasSecureBoot => (super.noSuchMethod(
+        Invocation.getter(#hasSecureBoot),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get useLvm =>
-      (super.noSuchMethod(Invocation.getter(#useLvm), returnValue: false)
-          as bool);
+  bool get useLvm => (super.noSuchMethod(
+        Invocation.getter(#useLvm),
+        returnValue: false,
+      ) as bool);
   @override
-  set useLvm(bool? useLvm) =>
-      super.noSuchMethod(Invocation.setter(#useLvm, useLvm),
-          returnValueForMissingStub: null);
+  set useLvm(bool? useLvm) => super.noSuchMethod(
+        Invocation.setter(
+          #useLvm,
+          useLvm,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  set guidedTarget(_i2.GuidedStorageTarget? target) =>
-      super.noSuchMethod(Invocation.setter(#guidedTarget, target),
-          returnValueForMissingStub: null);
+  set guidedTarget(_i2.GuidedStorageTarget? target) => super.noSuchMethod(
+        Invocation.setter(
+          #guidedTarget,
+          target,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get installMinimumSize => (super
-          .noSuchMethod(Invocation.getter(#installMinimumSize), returnValue: 0)
-      as int);
+  int get installMinimumSize => (super.noSuchMethod(
+        Invocation.getter(#installMinimumSize),
+        returnValue: 0,
+      ) as int);
   @override
-  int get largestDiskSize =>
-      (super.noSuchMethod(Invocation.getter(#largestDiskSize), returnValue: 0)
-          as int);
+  int get largestDiskSize => (super.noSuchMethod(
+        Invocation.getter(#largestDiskSize),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get hasEnoughDiskSpace =>
-      (super.noSuchMethod(Invocation.getter(#hasEnoughDiskSpace),
-          returnValue: false) as bool);
+  bool get hasEnoughDiskSpace => (super.noSuchMethod(
+        Invocation.getter(#hasEnoughDiskSpace),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#getGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#getGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #getGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorage, []),
-              returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_0(
-                      this, Invocation.method(#setGuidedStorage, []))))
-          as _i4.Future<_i2.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorage,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_0(
+          this,
+          Invocation.method(
+            #setGuidedStorage,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<List<_i2.Disk>> getStorage() =>
-      (super.noSuchMethod(Invocation.method(#getStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> getOriginalStorage() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> getOriginalStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addPartition(
-          _i2.Disk? disk, _i2.Gap? gap, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Gap? gap,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartition, [disk, gap, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #addPartition,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> editPartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
-      (super.noSuchMethod(Invocation.method(#editPartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #editPartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> deletePartition(
-          _i2.Disk? disk, _i2.Partition? partition) =>
+    _i2.Disk? disk,
+    _i2.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartition, [disk, partition]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+        Invocation.method(
+          #deletePartition,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(Invocation.method(#setStorage, [disks]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setStorage,
+          [disks],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> resetStorage() =>
-      (super.noSuchMethod(Invocation.method(#resetStorage, []),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+  _i4.Future<List<_i2.Disk>> resetStorage() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorage,
+          [],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> addBootPartition(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartition, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartition,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
   @override
   _i4.Future<List<_i2.Disk>> reformatDisk(_i2.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDisk, [disk]),
-              returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]))
-          as _i4.Future<List<_i2.Disk>>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDisk,
+          [disk],
+        ),
+        returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
+      ) as _i4.Future<List<_i2.Disk>>);
 }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.mocks.dart
@@ -25,8 +25,13 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 class _FakeUdevDeviceInfo_0 extends _i1.SmartFake
     implements _i2.UdevDeviceInfo {
-  _FakeUdevDeviceInfo_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUdevDeviceInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [UdevDeviceInfo].
@@ -38,9 +43,10 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i2.UdevDeviceInfo {
   }
 
   @override
-  String get fullName =>
-      (super.noSuchMethod(Invocation.getter(#fullName), returnValue: '')
-          as String);
+  String get fullName => (super.noSuchMethod(
+        Invocation.getter(#fullName),
+        returnValue: '',
+      ) as String);
 }
 
 /// A class which mocks [UdevService].
@@ -52,17 +58,33 @@ class MockUdevService extends _i1.Mock implements _i2.UdevService {
   }
 
   @override
-  _i2.UdevDeviceInfo bySysname(String? sysname) =>
-      (super.noSuchMethod(Invocation.method(#bySysname, [sysname]),
-              returnValue: _FakeUdevDeviceInfo_0(
-                  this, Invocation.method(#bySysname, [sysname])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
+        Invocation.method(
+          #bySysname,
+          [sysname],
+        ),
+        returnValue: _FakeUdevDeviceInfo_0(
+          this,
+          Invocation.method(
+            #bySysname,
+            [sysname],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
   @override
-  _i2.UdevDeviceInfo bySyspath(String? syspath) =>
-      (super.noSuchMethod(Invocation.method(#bySyspath, [syspath]),
-              returnValue: _FakeUdevDeviceInfo_0(
-                  this, Invocation.method(#bySyspath, [syspath])))
-          as _i2.UdevDeviceInfo);
+  _i2.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
+        Invocation.method(
+          #bySyspath,
+          [syspath],
+        ),
+        returnValue: _FakeUdevDeviceInfo_0(
+          this,
+          Invocation.method(
+            #bySyspath,
+            [syspath],
+          ),
+        ),
+      ) as _i2.UdevDeviceInfo);
 }
 
 /// A class which mocks [WriteChangesToDiskModel].
@@ -75,49 +97,85 @@ class MockWriteChangesToDiskModel extends _i1.Mock
   }
 
   @override
-  List<_i4.Disk> get disks =>
-      (super.noSuchMethod(Invocation.getter(#disks), returnValue: <_i4.Disk>[])
-          as List<_i4.Disk>);
+  List<_i4.Disk> get disks => (super.noSuchMethod(
+        Invocation.getter(#disks),
+        returnValue: <_i4.Disk>[],
+      ) as List<_i4.Disk>);
   @override
-  Map<String, List<_i4.Partition>> get partitions =>
-      (super.noSuchMethod(Invocation.getter(#partitions),
-              returnValue: <String, List<_i4.Partition>>{})
-          as Map<String, List<_i4.Partition>>);
+  Map<String, List<_i4.Partition>> get partitions => (super.noSuchMethod(
+        Invocation.getter(#partitions),
+        returnValue: <String, List<_i4.Partition>>{},
+      ) as Map<String, List<_i4.Partition>>);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Partition? getOriginalPartition(String? sysname, int? number) =>
-      (super.noSuchMethod(
-              Invocation.method(#getOriginalPartition, [sysname, number]))
-          as _i4.Partition?);
+  _i4.Partition? getOriginalPartition(
+    String? sysname,
+    int? number,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #getOriginalPartition,
+        [
+          sysname,
+          number,
+        ],
+      )) as _i4.Partition?);
   @override
-  _i5.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> startInstallation() => (super.noSuchMethod(
-      Invocation.method(#startInstallation, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #startInstallation,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -26,85 +26,160 @@ import 'package:subiquity_client/src/types.dart' as _i3;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeDBusValue_0 extends _i1.SmartFake implements _i2.DBusValue {
-  _FakeDBusValue_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeDBusValue_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeUri_1 extends _i1.SmartFake implements Uri {
-  _FakeUri_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUri_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeSourceSelectionAndSetting_2 extends _i1.SmartFake
     implements _i3.SourceSelectionAndSetting {
-  _FakeSourceSelectionAndSetting_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSourceSelectionAndSetting_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeKeyboardSetup_3 extends _i1.SmartFake implements _i3.KeyboardSetup {
-  _FakeKeyboardSetup_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeKeyboardSetup_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeIdentityData_4 extends _i1.SmartFake implements _i3.IdentityData {
-  _FakeIdentityData_4(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeIdentityData_4(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeTimeZoneInfo_5 extends _i1.SmartFake implements _i3.TimeZoneInfo {
-  _FakeTimeZoneInfo_5(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeTimeZoneInfo_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeSSHData_6 extends _i1.SmartFake implements _i3.SSHData {
-  _FakeSSHData_6(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSSHData_6(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeApplicationStatus_7 extends _i1.SmartFake
     implements _i3.ApplicationStatus {
-  _FakeApplicationStatus_7(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeApplicationStatus_7(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeGuidedStorageResponseV2_8 extends _i1.SmartFake
     implements _i3.GuidedStorageResponseV2 {
-  _FakeGuidedStorageResponseV2_8(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGuidedStorageResponseV2_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeStorageResponseV2_9 extends _i1.SmartFake
     implements _i3.StorageResponseV2 {
-  _FakeStorageResponseV2_9(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeStorageResponseV2_9(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWSLSetupOptions_10 extends _i1.SmartFake
     implements _i3.WSLSetupOptions {
-  _FakeWSLSetupOptions_10(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWSLSetupOptions_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWSLConfigurationBase_11 extends _i1.SmartFake
     implements _i3.WSLConfigurationBase {
-  _FakeWSLConfigurationBase_11(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWSLConfigurationBase_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeWSLConfigurationAdvanced_12 extends _i1.SmartFake
     implements _i3.WSLConfigurationAdvanced {
-  _FakeWSLConfigurationAdvanced_12(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeWSLConfigurationAdvanced_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeAnyStep_13 extends _i1.SmartFake implements _i3.AnyStep {
-  _FakeAnyStep_13(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeAnyStep_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeEndpoint_14 extends _i1.SmartFake implements _i4.Endpoint {
-  _FakeEndpoint_14(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEndpoint_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [GSettings].
@@ -116,56 +191,103 @@ class MockGSettings extends _i1.Mock implements _i5.GSettings {
   }
 
   @override
-  String get schemaName =>
-      (super.noSuchMethod(Invocation.getter(#schemaName), returnValue: '')
-          as String);
+  String get schemaName => (super.noSuchMethod(
+        Invocation.getter(#schemaName),
+        returnValue: '',
+      ) as String);
   @override
-  _i6.Stream<List<String>> get keysChanged =>
-      (super.noSuchMethod(Invocation.getter(#keysChanged),
-              returnValue: _i6.Stream<List<String>>.empty())
-          as _i6.Stream<List<String>>);
+  _i6.Stream<List<String>> get keysChanged => (super.noSuchMethod(
+        Invocation.getter(#keysChanged),
+        returnValue: _i6.Stream<List<String>>.empty(),
+      ) as _i6.Stream<List<String>>);
   @override
-  _i6.Future<List<String>> list() =>
-      (super.noSuchMethod(Invocation.method(#list, []),
-              returnValue: _i6.Future<List<String>>.value(<String>[]))
-          as _i6.Future<List<String>>);
+  _i6.Future<List<String>> list() => (super.noSuchMethod(
+        Invocation.method(
+          #list,
+          [],
+        ),
+        returnValue: _i6.Future<List<String>>.value(<String>[]),
+      ) as _i6.Future<List<String>>);
   @override
-  _i6.Future<_i2.DBusValue> get(String? name) =>
-      (super.noSuchMethod(Invocation.method(#get, [name]),
-              returnValue: _i6.Future<_i2.DBusValue>.value(
-                  _FakeDBusValue_0(this, Invocation.method(#get, [name]))))
-          as _i6.Future<_i2.DBusValue>);
+  _i6.Future<_i2.DBusValue> get(String? name) => (super.noSuchMethod(
+        Invocation.method(
+          #get,
+          [name],
+        ),
+        returnValue: _i6.Future<_i2.DBusValue>.value(_FakeDBusValue_0(
+          this,
+          Invocation.method(
+            #get,
+            [name],
+          ),
+        )),
+      ) as _i6.Future<_i2.DBusValue>);
   @override
   _i6.Future<_i2.DBusValue> getDefault(String? name) => (super.noSuchMethod(
-          Invocation.method(#getDefault, [name]),
-          returnValue: _i6.Future<_i2.DBusValue>.value(
-              _FakeDBusValue_0(this, Invocation.method(#getDefault, [name]))))
-      as _i6.Future<_i2.DBusValue>);
+        Invocation.method(
+          #getDefault,
+          [name],
+        ),
+        returnValue: _i6.Future<_i2.DBusValue>.value(_FakeDBusValue_0(
+          this,
+          Invocation.method(
+            #getDefault,
+            [name],
+          ),
+        )),
+      ) as _i6.Future<_i2.DBusValue>);
   @override
-  _i6.Future<bool> isSet(String? name) =>
-      (super.noSuchMethod(Invocation.method(#isSet, [name]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> isSet(String? name) => (super.noSuchMethod(
+        Invocation.method(
+          #isSet,
+          [name],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
   @override
-  _i6.Future<void> set(String? name, _i2.DBusValue? value) =>
-      (super.noSuchMethod(Invocation.method(#set, [name, value]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+  _i6.Future<void> set(
+    String? name,
+    _i2.DBusValue? value,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #set,
+          [
+            name,
+            value,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> unset(String? name) => (super.noSuchMethod(
-      Invocation.method(#unset, [name]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #unset,
+          [name],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> setAll(Map<String, _i2.DBusValue?>? values) =>
-      (super.noSuchMethod(Invocation.method(#setAll, [values]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setAll,
+          [values],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+  _i6.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
 }
 
 /// A class which mocks [SubiquityClient].
@@ -177,314 +299,650 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
   }
 
   @override
-  _i6.Future<bool> get isOpen => (super.noSuchMethod(Invocation.getter(#isOpen),
-      returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> get isOpen => (super.noSuchMethod(
+        Invocation.getter(#isOpen),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
   @override
-  Uri url(String? unencodedPath, [Map<String, dynamic>? queryParameters]) =>
+  Uri url(
+    String? unencodedPath, [
+    Map<String, dynamic>? queryParameters,
+  ]) =>
       (super.noSuchMethod(
-              Invocation.method(#url, [unencodedPath, queryParameters]),
-              returnValue: _FakeUri_1(this,
-                  Invocation.method(#url, [unencodedPath, queryParameters])))
-          as Uri);
+        Invocation.method(
+          #url,
+          [
+            unencodedPath,
+            queryParameters,
+          ],
+        ),
+        returnValue: _FakeUri_1(
+          this,
+          Invocation.method(
+            #url,
+            [
+              unencodedPath,
+              queryParameters,
+            ],
+          ),
+        ),
+      ) as Uri);
   @override
-  void open(_i4.Endpoint? endpoint) =>
-      super.noSuchMethod(Invocation.method(#open, [endpoint]),
-          returnValueForMissingStub: null);
+  void open(_i4.Endpoint? endpoint) => super.noSuchMethod(
+        Invocation.method(
+          #open,
+          [endpoint],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i6.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+  _i6.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i7.Variant> variant() =>
-      (super.noSuchMethod(Invocation.method(#variant, []),
-              returnValue: _i6.Future<_i7.Variant>.value(_i7.Variant.SERVER))
-          as _i6.Future<_i7.Variant>);
+  _i6.Future<_i7.Variant> variant() => (super.noSuchMethod(
+        Invocation.method(
+          #variant,
+          [],
+        ),
+        returnValue: _i6.Future<_i7.Variant>.value(_i7.Variant.SERVER),
+      ) as _i6.Future<_i7.Variant>);
   @override
   _i6.Future<void> setVariant(_i7.Variant? variant) => (super.noSuchMethod(
-      Invocation.method(#setVariant, [variant]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setVariant,
+          [variant],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i3.SourceSelectionAndSetting> source() =>
-      (super.noSuchMethod(Invocation.method(#source, []),
-              returnValue: _i6.Future<_i3.SourceSelectionAndSetting>.value(
-                  _FakeSourceSelectionAndSetting_2(
-                      this, Invocation.method(#source, []))))
-          as _i6.Future<_i3.SourceSelectionAndSetting>);
+  _i6.Future<_i3.SourceSelectionAndSetting> source() => (super.noSuchMethod(
+        Invocation.method(
+          #source,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.SourceSelectionAndSetting>.value(
+            _FakeSourceSelectionAndSetting_2(
+          this,
+          Invocation.method(
+            #source,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.SourceSelectionAndSetting>);
   @override
   _i6.Future<void> setSource(String? sourceId) => (super.noSuchMethod(
-      Invocation.method(#setSource, [sourceId]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setSource,
+          [sourceId],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<String> locale() =>
-      (super.noSuchMethod(Invocation.method(#locale, []),
-          returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);
+  _i6.Future<String> locale() => (super.noSuchMethod(
+        Invocation.method(
+          #locale,
+          [],
+        ),
+        returnValue: _i6.Future<String>.value(''),
+      ) as _i6.Future<String>);
   @override
   _i6.Future<void> setLocale(String? locale) => (super.noSuchMethod(
-      Invocation.method(#setLocale, [locale]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setLocale,
+          [locale],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i3.KeyboardSetup> keyboard() =>
-      (super.noSuchMethod(Invocation.method(#keyboard, []),
-              returnValue: _i6.Future<_i3.KeyboardSetup>.value(
-                  _FakeKeyboardSetup_3(this, Invocation.method(#keyboard, []))))
-          as _i6.Future<_i3.KeyboardSetup>);
+  _i6.Future<_i3.KeyboardSetup> keyboard() => (super.noSuchMethod(
+        Invocation.method(
+          #keyboard,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.KeyboardSetup>.value(_FakeKeyboardSetup_3(
+          this,
+          Invocation.method(
+            #keyboard,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.KeyboardSetup>);
   @override
   _i6.Future<void> setKeyboard(_i3.KeyboardSetting? setting) =>
-      (super.noSuchMethod(Invocation.method(#setKeyboard, [setting]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setKeyboard,
+          [setting],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> setInputSource(_i3.KeyboardSetting? setting) =>
-      (super.noSuchMethod(Invocation.method(#setInputSource, [setting]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setInputSource,
+          [setting],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<String> proxy() =>
-      (super.noSuchMethod(Invocation.method(#proxy, []),
-          returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);
+  _i6.Future<String> proxy() => (super.noSuchMethod(
+        Invocation.method(
+          #proxy,
+          [],
+        ),
+        returnValue: _i6.Future<String>.value(''),
+      ) as _i6.Future<String>);
   @override
   _i6.Future<void> setProxy(String? proxy) => (super.noSuchMethod(
-      Invocation.method(#setProxy, [proxy]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setProxy,
+          [proxy],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<String> mirror() =>
-      (super.noSuchMethod(Invocation.method(#mirror, []),
-          returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);
+  _i6.Future<String> mirror() => (super.noSuchMethod(
+        Invocation.method(
+          #mirror,
+          [],
+        ),
+        returnValue: _i6.Future<String>.value(''),
+      ) as _i6.Future<String>);
   @override
   _i6.Future<void> setMirror(String? mirror) => (super.noSuchMethod(
-      Invocation.method(#setMirror, [mirror]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setMirror,
+          [mirror],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<bool> freeOnly() =>
-      (super.noSuchMethod(Invocation.method(#freeOnly, []),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> freeOnly() => (super.noSuchMethod(
+        Invocation.method(
+          #freeOnly,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
   @override
   _i6.Future<void> setFreeOnly(bool? enable) => (super.noSuchMethod(
-      Invocation.method(#setFreeOnly, [enable]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setFreeOnly,
+          [enable],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i3.IdentityData> identity() =>
-      (super.noSuchMethod(Invocation.method(#identity, []),
-              returnValue: _i6.Future<_i3.IdentityData>.value(
-                  _FakeIdentityData_4(this, Invocation.method(#identity, []))))
-          as _i6.Future<_i3.IdentityData>);
+  _i6.Future<_i3.IdentityData> identity() => (super.noSuchMethod(
+        Invocation.method(
+          #identity,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.IdentityData>.value(_FakeIdentityData_4(
+          this,
+          Invocation.method(
+            #identity,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.IdentityData>);
   @override
   _i6.Future<void> setIdentity(_i3.IdentityData? identity) =>
-      (super.noSuchMethod(Invocation.method(#setIdentity, [identity]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setIdentity,
+          [identity],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<_i3.UsernameValidation> validateUsername(String? username) =>
-      (super.noSuchMethod(Invocation.method(#validateUsername, [username]),
-              returnValue: _i6.Future<_i3.UsernameValidation>.value(
-                  _i3.UsernameValidation.OK))
-          as _i6.Future<_i3.UsernameValidation>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #validateUsername,
+          [username],
+        ),
+        returnValue:
+            _i6.Future<_i3.UsernameValidation>.value(_i3.UsernameValidation.OK),
+      ) as _i6.Future<_i3.UsernameValidation>);
   @override
-  _i6.Future<_i3.TimeZoneInfo> timezone() =>
-      (super.noSuchMethod(Invocation.method(#timezone, []),
-              returnValue: _i6.Future<_i3.TimeZoneInfo>.value(
-                  _FakeTimeZoneInfo_5(this, Invocation.method(#timezone, []))))
-          as _i6.Future<_i3.TimeZoneInfo>);
+  _i6.Future<_i3.TimeZoneInfo> timezone() => (super.noSuchMethod(
+        Invocation.method(
+          #timezone,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.TimeZoneInfo>.value(_FakeTimeZoneInfo_5(
+          this,
+          Invocation.method(
+            #timezone,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.TimeZoneInfo>);
   @override
   _i6.Future<void> setTimezone(String? timezone) => (super.noSuchMethod(
-      Invocation.method(#setTimezone, [timezone]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setTimezone,
+          [timezone],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i3.SSHData> ssh() =>
-      (super.noSuchMethod(Invocation.method(#ssh, []),
-              returnValue: _i6.Future<_i3.SSHData>.value(
-                  _FakeSSHData_6(this, Invocation.method(#ssh, []))))
-          as _i6.Future<_i3.SSHData>);
+  _i6.Future<_i3.SSHData> ssh() => (super.noSuchMethod(
+        Invocation.method(
+          #ssh,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.SSHData>.value(_FakeSSHData_6(
+          this,
+          Invocation.method(
+            #ssh,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.SSHData>);
   @override
   _i6.Future<void> setSsh(_i3.SSHData? ssh) => (super.noSuchMethod(
-      Invocation.method(#setSsh, [ssh]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #setSsh,
+          [ssh],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<_i3.ApplicationStatus> status({_i3.ApplicationState? current}) =>
-      (super.noSuchMethod(Invocation.method(#status, [], {#current: current}),
-              returnValue: _i6.Future<_i3.ApplicationStatus>.value(
-                  _FakeApplicationStatus_7(this,
-                      Invocation.method(#status, [], {#current: current}))))
-          as _i6.Future<_i3.ApplicationStatus>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #status,
+          [],
+          {#current: current},
+        ),
+        returnValue:
+            _i6.Future<_i3.ApplicationStatus>.value(_FakeApplicationStatus_7(
+          this,
+          Invocation.method(
+            #status,
+            [],
+            {#current: current},
+          ),
+        )),
+      ) as _i6.Future<_i3.ApplicationStatus>);
   @override
   _i6.Future<void> markConfigured(List<String>? endpointNames) =>
-      (super.noSuchMethod(Invocation.method(#markConfigured, [endpointNames]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #markConfigured,
+          [endpointNames],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> confirm(String? tty) => (super.noSuchMethod(
-      Invocation.method(#confirm, [tty]),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #confirm,
+          [tty],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<bool> hasRst() =>
-      (super.noSuchMethod(Invocation.method(#hasRst, []),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> hasRst() => (super.noSuchMethod(
+        Invocation.method(
+          #hasRst,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
   @override
-  _i6.Future<bool> hasBitLocker() =>
-      (super.noSuchMethod(Invocation.method(#hasBitLocker, []),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
   @override
   _i6.Future<_i3.GuidedStorageResponseV2> getGuidedStorageV2(
           {bool? wait = true}) =>
       (super.noSuchMethod(
-              Invocation.method(#getGuidedStorageV2, [], {#wait: wait}),
-              returnValue: _i6.Future<_i3.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_8(
-                      this,
-                      Invocation.method(
-                          #getGuidedStorageV2, [], {#wait: wait}))))
-          as _i6.Future<_i3.GuidedStorageResponseV2>);
+        Invocation.method(
+          #getGuidedStorageV2,
+          [],
+          {#wait: wait},
+        ),
+        returnValue: _i6.Future<_i3.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_8(
+          this,
+          Invocation.method(
+            #getGuidedStorageV2,
+            [],
+            {#wait: wait},
+          ),
+        )),
+      ) as _i6.Future<_i3.GuidedStorageResponseV2>);
   @override
   _i6.Future<_i3.GuidedStorageResponseV2> setGuidedStorageV2(
           _i3.GuidedChoiceV2? choice) =>
-      (super.noSuchMethod(Invocation.method(#setGuidedStorageV2, [choice]),
-              returnValue: _i6.Future<_i3.GuidedStorageResponseV2>.value(
-                  _FakeGuidedStorageResponseV2_8(
-                      this, Invocation.method(#setGuidedStorageV2, [choice]))))
-          as _i6.Future<_i3.GuidedStorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setGuidedStorageV2,
+          [choice],
+        ),
+        returnValue: _i6.Future<_i3.GuidedStorageResponseV2>.value(
+            _FakeGuidedStorageResponseV2_8(
+          this,
+          Invocation.method(
+            #setGuidedStorageV2,
+            [choice],
+          ),
+        )),
+      ) as _i6.Future<_i3.GuidedStorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> getOriginalStorageV2() =>
-      (super.noSuchMethod(Invocation.method(#getOriginalStorageV2, []),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this, Invocation.method(#getOriginalStorageV2, []))))
-          as _i6.Future<_i3.StorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getOriginalStorageV2,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #getOriginalStorageV2,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> getStorageV2({bool? wait = true}) =>
-      (super.noSuchMethod(Invocation.method(#getStorageV2, [], {#wait: wait}),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(this,
-                      Invocation.method(#getStorageV2, [], {#wait: wait}))))
-          as _i6.Future<_i3.StorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getStorageV2,
+          [],
+          {#wait: wait},
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #getStorageV2,
+            [],
+            {#wait: wait},
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i6.Future<_i3.StorageResponseV2> setStorageV2() =>
-      (super.noSuchMethod(Invocation.method(#setStorageV2, []),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this, Invocation.method(#setStorageV2, []))))
-          as _i6.Future<_i3.StorageResponseV2>);
+  _i6.Future<_i3.StorageResponseV2> setStorageV2() => (super.noSuchMethod(
+        Invocation.method(
+          #setStorageV2,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #setStorageV2,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
-  _i6.Future<_i3.StorageResponseV2> resetStorageV2() =>
-      (super.noSuchMethod(Invocation.method(#resetStorageV2, []),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this, Invocation.method(#resetStorageV2, []))))
-          as _i6.Future<_i3.StorageResponseV2>);
+  _i6.Future<_i3.StorageResponseV2> resetStorageV2() => (super.noSuchMethod(
+        Invocation.method(
+          #resetStorageV2,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #resetStorageV2,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> addPartitionV2(
-          _i3.Disk? disk, _i3.Gap? gap, _i3.Partition? partition) =>
+    _i3.Disk? disk,
+    _i3.Gap? gap,
+    _i3.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#addPartitionV2, [disk, gap, partition]),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this,
-                      Invocation.method(
-                          #addPartitionV2, [disk, gap, partition]))))
-          as _i6.Future<_i3.StorageResponseV2>);
+        Invocation.method(
+          #addPartitionV2,
+          [
+            disk,
+            gap,
+            partition,
+          ],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #addPartitionV2,
+            [
+              disk,
+              gap,
+              partition,
+            ],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> editPartitionV2(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+    _i3.Disk? disk,
+    _i3.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#editPartitionV2, [disk, partition]),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(this,
-                      Invocation.method(#editPartitionV2, [disk, partition]))))
-          as _i6.Future<_i3.StorageResponseV2>);
+        Invocation.method(
+          #editPartitionV2,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #editPartitionV2,
+            [
+              disk,
+              partition,
+            ],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> deletePartitionV2(
-          _i3.Disk? disk, _i3.Partition? partition) =>
+    _i3.Disk? disk,
+    _i3.Partition? partition,
+  ) =>
       (super.noSuchMethod(
-              Invocation.method(#deletePartitionV2, [disk, partition]),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this,
-                      Invocation.method(
-                          #deletePartitionV2, [disk, partition]))))
-          as _i6.Future<_i3.StorageResponseV2>);
+        Invocation.method(
+          #deletePartitionV2,
+          [
+            disk,
+            partition,
+          ],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #deletePartitionV2,
+            [
+              disk,
+              partition,
+            ],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> addBootPartitionV2(_i3.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#addBootPartitionV2, [disk]),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this, Invocation.method(#addBootPartitionV2, [disk]))))
-          as _i6.Future<_i3.StorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addBootPartitionV2,
+          [disk],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #addBootPartitionV2,
+            [disk],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<_i3.StorageResponseV2> reformatDiskV2(_i3.Disk? disk) =>
-      (super.noSuchMethod(Invocation.method(#reformatDiskV2, [disk]),
-              returnValue: _i6.Future<_i3.StorageResponseV2>.value(
-                  _FakeStorageResponseV2_9(
-                      this, Invocation.method(#reformatDiskV2, [disk]))))
-          as _i6.Future<_i3.StorageResponseV2>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #reformatDiskV2,
+          [disk],
+        ),
+        returnValue:
+            _i6.Future<_i3.StorageResponseV2>.value(_FakeStorageResponseV2_9(
+          this,
+          Invocation.method(
+            #reformatDiskV2,
+            [disk],
+          ),
+        )),
+      ) as _i6.Future<_i3.StorageResponseV2>);
   @override
   _i6.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
-  _i6.Future<_i3.WSLSetupOptions> wslSetupOptions() =>
-      (super.noSuchMethod(Invocation.method(#wslSetupOptions, []),
-              returnValue: _i6.Future<_i3.WSLSetupOptions>.value(
-                  _FakeWSLSetupOptions_10(
-                      this, Invocation.method(#wslSetupOptions, []))))
-          as _i6.Future<_i3.WSLSetupOptions>);
+  _i6.Future<_i3.WSLSetupOptions> wslSetupOptions() => (super.noSuchMethod(
+        Invocation.method(
+          #wslSetupOptions,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i3.WSLSetupOptions>.value(_FakeWSLSetupOptions_10(
+          this,
+          Invocation.method(
+            #wslSetupOptions,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.WSLSetupOptions>);
   @override
   _i6.Future<void> setWslSetupOptions(_i3.WSLSetupOptions? options) =>
-      (super.noSuchMethod(Invocation.method(#setWslSetupOptions, [options]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setWslSetupOptions,
+          [options],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<_i3.WSLConfigurationBase> wslConfigurationBase() =>
-      (super.noSuchMethod(Invocation.method(#wslConfigurationBase, []),
-              returnValue: _i6.Future<_i3.WSLConfigurationBase>.value(
-                  _FakeWSLConfigurationBase_11(
-                      this, Invocation.method(#wslConfigurationBase, []))))
-          as _i6.Future<_i3.WSLConfigurationBase>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #wslConfigurationBase,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.WSLConfigurationBase>.value(
+            _FakeWSLConfigurationBase_11(
+          this,
+          Invocation.method(
+            #wslConfigurationBase,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.WSLConfigurationBase>);
   @override
   _i6.Future<void> setWslConfigurationBase(_i3.WSLConfigurationBase? conf) =>
-      (super.noSuchMethod(Invocation.method(#setWslConfigurationBase, [conf]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #setWslConfigurationBase,
+          [conf],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<_i3.WSLConfigurationAdvanced> wslConfigurationAdvanced() =>
-      (super.noSuchMethod(Invocation.method(#wslConfigurationAdvanced, []),
-              returnValue: _i6.Future<_i3.WSLConfigurationAdvanced>.value(
-                  _FakeWSLConfigurationAdvanced_12(
-                      this, Invocation.method(#wslConfigurationAdvanced, []))))
-          as _i6.Future<_i3.WSLConfigurationAdvanced>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #wslConfigurationAdvanced,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.WSLConfigurationAdvanced>.value(
+            _FakeWSLConfigurationAdvanced_12(
+          this,
+          Invocation.method(
+            #wslConfigurationAdvanced,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.WSLConfigurationAdvanced>);
   @override
   _i6.Future<void> setWslConfigurationAdvanced(
           _i3.WSLConfigurationAdvanced? conf) =>
       (super.noSuchMethod(
-              Invocation.method(#setWslConfigurationAdvanced, [conf]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+        Invocation.method(
+          #setWslConfigurationAdvanced,
+          [conf],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
   @override
   _i6.Future<_i3.AnyStep> getKeyboardStep([String? step = r'0']) =>
-      (super.noSuchMethod(Invocation.method(#getKeyboardStep, [step]),
-              returnValue: _i6.Future<_i3.AnyStep>.value(_FakeAnyStep_13(
-                  this, Invocation.method(#getKeyboardStep, [step]))))
-          as _i6.Future<_i3.AnyStep>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #getKeyboardStep,
+          [step],
+        ),
+        returnValue: _i6.Future<_i3.AnyStep>.value(_FakeAnyStep_13(
+          this,
+          Invocation.method(
+            #getKeyboardStep,
+            [step],
+          ),
+        )),
+      ) as _i6.Future<_i3.AnyStep>);
 }
 
 /// A class which mocks [SubiquityServer].
@@ -496,24 +954,54 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   }
 
   @override
-  set process(_i9.SubiquityProcess? _process) =>
-      super.noSuchMethod(Invocation.setter(#process, _process),
-          returnValueForMissingStub: null);
+  set process(_i9.SubiquityProcess? _process) => super.noSuchMethod(
+        Invocation.setter(
+          #process,
+          _process,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Endpoint get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint),
-          returnValue: _FakeEndpoint_14(this, Invocation.getter(#endpoint)))
-      as _i4.Endpoint);
+  _i4.Endpoint get endpoint => (super.noSuchMethod(
+        Invocation.getter(#endpoint),
+        returnValue: _FakeEndpoint_14(
+          this,
+          Invocation.getter(#endpoint),
+        ),
+      ) as _i4.Endpoint);
   @override
-  _i6.Future<_i4.Endpoint> start(
-          {List<String>? args, Map<String, String>? environment}) =>
+  _i6.Future<_i4.Endpoint> start({
+    List<String>? args,
+    Map<String, String>? environment,
+  }) =>
       (super.noSuchMethod(
-              Invocation.method(
-                  #start, [], {#args: args, #environment: environment}),
-              returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_14(this,
-                  Invocation.method(#start, [], {#args: args, #environment: environment}))))
-          as _i6.Future<_i4.Endpoint>);
+        Invocation.method(
+          #start,
+          [],
+          {
+            #args: args,
+            #environment: environment,
+          },
+        ),
+        returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_14(
+          this,
+          Invocation.method(
+            #start,
+            [],
+            {
+              #args: args,
+              #environment: environment,
+            },
+          ),
+        )),
+      ) as _i6.Future<_i4.Endpoint>);
   @override
-  _i6.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
-      returnValue: _i6.Future<void>.value(),
-      returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+  _i6.Future<void> stop() => (super.noSuchMethod(
+        Invocation.method(
+          #stop,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
 }

--- a/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
+++ b/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/ubuntu_wizard/test/proxy_asset_bundle_test.mocks.dart
+++ b/packages/ubuntu_wizard/test/proxy_asset_bundle_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 import 'dart:typed_data' as _i2;
+import 'dart:ui' as _i3;
 
-import 'package:flutter/src/services/asset_bundle.dart' as _i3;
+import 'package:flutter/src/services/asset_bundle.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 
-import 'proxy_asset_bundle_test.dart' as _i5;
+import 'proxy_asset_bundle_test.dart' as _i6;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -23,38 +24,109 @@ import 'proxy_asset_bundle_test.dart' as _i5;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeByteData_0 extends _i1.SmartFake implements _i2.ByteData {
-  _FakeByteData_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeByteData_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeImmutableBuffer_1 extends _i1.SmartFake
+    implements _i3.ImmutableBuffer {
+  _FakeImmutableBuffer_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AssetBundle].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAssetBundle extends _i1.Mock implements _i3.AssetBundle {
+class MockAssetBundle extends _i1.Mock implements _i4.AssetBundle {
   MockAssetBundle() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i2.ByteData> load(String? key) =>
-      (super.noSuchMethod(Invocation.method(#load, [key]),
-              returnValue: _i4.Future<_i2.ByteData>.value(
-                  _FakeByteData_0(this, Invocation.method(#load, [key]))))
-          as _i4.Future<_i2.ByteData>);
+  _i5.Future<_i2.ByteData> load(String? key) => (super.noSuchMethod(
+        Invocation.method(
+          #load,
+          [key],
+        ),
+        returnValue: _i5.Future<_i2.ByteData>.value(_FakeByteData_0(
+          this,
+          Invocation.method(
+            #load,
+            [key],
+          ),
+        )),
+      ) as _i5.Future<_i2.ByteData>);
   @override
-  _i4.Future<String> loadString(String? key, {bool? cache = true}) => (super
-      .noSuchMethod(Invocation.method(#loadString, [key], {#cache: cache}),
-          returnValue: _i4.Future<String>.value('')) as _i4.Future<String>);
+  _i5.Future<_i3.ImmutableBuffer> loadBuffer(String? key) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadBuffer,
+          [key],
+        ),
+        returnValue:
+            _i5.Future<_i3.ImmutableBuffer>.value(_FakeImmutableBuffer_1(
+          this,
+          Invocation.method(
+            #loadBuffer,
+            [key],
+          ),
+        )),
+      ) as _i5.Future<_i3.ImmutableBuffer>);
   @override
-  _i4.Future<T> loadStructuredData<T>(
-          String? key, _i4.Future<T> Function(String)? parser) =>
-      (super.noSuchMethod(Invocation.method(#loadStructuredData, [key, parser]),
-          returnValue: _i5.loadMockData<T>(key, parser)) as _i4.Future<T>);
+  _i5.Future<String> loadString(
+    String? key, {
+    bool? cache = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadString,
+          [key],
+          {#cache: cache},
+        ),
+        returnValue: _i5.Future<String>.value(''),
+      ) as _i5.Future<String>);
   @override
-  void evict(String? key) =>
-      super.noSuchMethod(Invocation.method(#evict, [key]),
-          returnValueForMissingStub: null);
+  _i5.Future<T> loadStructuredData<T>(
+    String? key,
+    _i5.Future<T> Function(String)? parser,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadStructuredData,
+          [
+            key,
+            parser,
+          ],
+        ),
+        returnValue: _i6.loadMockData<T>(
+          key,
+          parser,
+        ),
+      ) as _i5.Future<T>);
   @override
-  void clear() => super.noSuchMethod(Invocation.method(#clear, []),
-      returnValueForMissingStub: null);
+  void evict(String? key) => super.noSuchMethod(
+        Invocation.method(
+          #evict,
+          [key],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void clear() => super.noSuchMethod(
+        Invocation.method(
+          #clear,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:subiquity_client/src/types.dart' as _i6;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeEncoding_0 extends _i1.SmartFake implements _i2.Encoding {
-  _FakeEncoding_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEncoding_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [IOSink].
@@ -37,52 +42,113 @@ class MockIOSink extends _i1.Mock implements _i3.IOSink {
   }
 
   @override
-  _i2.Encoding get encoding => (super.noSuchMethod(Invocation.getter(#encoding),
-          returnValue: _FakeEncoding_0(this, Invocation.getter(#encoding)))
-      as _i2.Encoding);
+  _i2.Encoding get encoding => (super.noSuchMethod(
+        Invocation.getter(#encoding),
+        returnValue: _FakeEncoding_0(
+          this,
+          Invocation.getter(#encoding),
+        ),
+      ) as _i2.Encoding);
   @override
-  set encoding(_i2.Encoding? _encoding) =>
-      super.noSuchMethod(Invocation.setter(#encoding, _encoding),
-          returnValueForMissingStub: null);
+  set encoding(_i2.Encoding? _encoding) => super.noSuchMethod(
+        Invocation.setter(
+          #encoding,
+          _encoding,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<dynamic> get done => (super.noSuchMethod(Invocation.getter(#done),
-      returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> get done => (super.noSuchMethod(
+        Invocation.getter(#done),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  void add(List<int>? data) =>
-      super.noSuchMethod(Invocation.method(#add, [data]),
-          returnValueForMissingStub: null);
+  void add(List<int>? data) => super.noSuchMethod(
+        Invocation.method(
+          #add,
+          [data],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void write(Object? object) =>
-      super.noSuchMethod(Invocation.method(#write, [object]),
-          returnValueForMissingStub: null);
+  void write(Object? object) => super.noSuchMethod(
+        Invocation.method(
+          #write,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeAll(Iterable<dynamic>? objects, [String? separator = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeAll, [objects, separator]),
-          returnValueForMissingStub: null);
+  void writeAll(
+    Iterable<dynamic>? objects, [
+    String? separator = r'',
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeAll,
+          [
+            objects,
+            separator,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeln([Object? object = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeln, [object]),
-          returnValueForMissingStub: null);
+  void writeln([Object? object = r'']) => super.noSuchMethod(
+        Invocation.method(
+          #writeln,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeCharCode(int? charCode) =>
-      super.noSuchMethod(Invocation.method(#writeCharCode, [charCode]),
-          returnValueForMissingStub: null);
+  void writeCharCode(int? charCode) => super.noSuchMethod(
+        Invocation.method(
+          #writeCharCode,
+          [charCode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addError(Object? error, [StackTrace? stackTrace]) =>
-      super.noSuchMethod(Invocation.method(#addError, [error, stackTrace]),
-          returnValueForMissingStub: null);
+  void addError(
+    Object? error, [
+    StackTrace? stackTrace,
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addError,
+          [
+            error,
+            stackTrace,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<dynamic> addStream(_i4.Stream<List<int>>? stream) =>
-      (super.noSuchMethod(Invocation.method(#addStream, [stream]),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addStream,
+          [stream],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<dynamic> flush() =>
-      (super.noSuchMethod(Invocation.method(#flush, []),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> flush() => (super.noSuchMethod(
+        Invocation.method(
+          #flush,
+          [],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<dynamic> close() =>
-      (super.noSuchMethod(Invocation.method(#close, []),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [SubiquityStatusMonitor].
@@ -95,16 +161,25 @@ class MockSubiquityStatusMonitor extends _i1.Mock
   }
 
   @override
-  _i4.Stream<_i6.ApplicationStatus?> get onStatusChanged =>
-      (super.noSuchMethod(Invocation.getter(#onStatusChanged),
-              returnValue: _i4.Stream<_i6.ApplicationStatus?>.empty())
-          as _i4.Stream<_i6.ApplicationStatus?>);
+  _i4.Stream<_i6.ApplicationStatus?> get onStatusChanged => (super.noSuchMethod(
+        Invocation.getter(#onStatusChanged),
+        returnValue: _i4.Stream<_i6.ApplicationStatus?>.empty(),
+      ) as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(_i7.Endpoint? endpoint) =>
-      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> start(_i7.Endpoint? endpoint) => (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [endpoint],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
-  _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> stop() => (super.noSuchMethod(
+        Invocation.method(
+          #stop,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -79,14 +78,14 @@ import 'app_localizations_uk.dart';
 import 'app_localizations_vi.dart';
 import 'app_localizations_zh.dart';
 
-/// Callers can lookup localized strings with an instance of AppLocalizations returned
-/// by `AppLocalizations.of(context)`.
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
 ///
 /// Applications need to include `AppLocalizations.delegate()` in their app's
-/// localizationDelegates list, and the locales they support in the app's
-/// supportedLocales list. For example:
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
 ///
-/// ```
+/// ```dart
 /// import 'l10n/app_localizations.dart';
 ///
 /// return MaterialApp(
@@ -101,14 +100,14 @@ import 'app_localizations_zh.dart';
 /// Please make sure to update your pubspec.yaml to include the following
 /// packages:
 ///
-/// ```
+/// ```yaml
 /// dependencies:
 ///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
 ///   intl: any # Use the pinned version from flutter_localizations
 ///
-///   # rest of dependencies
+///   # Rest of dependencies
 /// ```
 ///
 /// ## iOS Applications

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_am.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Amharic (`am`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ar.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Arabic (`ar`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_be.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Belarusian (`be`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bg.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bulgarian (`bg`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bengali Bangla (`bn`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tibetan (`bo`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_bs.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Bosnian (`bs`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ca.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Catalan Valencian (`ca`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cs.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Czech (`cs`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_cy.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Welsh (`cy`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_da.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Danish (`da`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_de.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for German (`de`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_dz.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Dzongkha (`dz`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_el.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Modern Greek (`el`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_en.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for English (`en`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Esperanto (`eo`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_es.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Spanish Castilian (`es`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_et.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Estonian (`et`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_eu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Basque (`eu`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fa.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Persian (`fa`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Finnish (`fi`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_fr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for French (`fr`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ga.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Irish (`ga`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Galician (`gl`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_gu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Gujarati (`gu`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_he.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hebrew (`he`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hindi (`hi`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Croatian (`hr`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_hu.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Hungarian (`hu`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_id.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Indonesian (`id`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_is.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Icelandic (`is`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_it.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Italian (`it`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ja.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Japanese (`ja`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ka.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Georgian (`ka`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kazakh (`kk`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_km.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Khmer Central Khmer (`km`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_kn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kannada (`kn`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ko.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Korean (`ko`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ku.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Kurdish (`ku`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lo.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Lao (`lo`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lt.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Lithuanian (`lt`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_lv.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Latvian (`lv`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Macedonian (`mk`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ml.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Malayalam (`ml`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_mr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Marathi (`mr`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_my.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Burmese (`my`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nb.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Norwegian Bokmål (`nb`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ne.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Nepali (`ne`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Dutch Flemish (`nl`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_nn.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Norwegian Nynorsk (`nn`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pa.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Panjabi Punjabi (`pa`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Polish (`pl`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_pt.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Portuguese (`pt`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ro.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Romanian Moldavian Moldovan (`ro`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ru.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Russian (`ru`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_se.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Northern Sami (`se`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_si.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Sinhala Sinhalese (`si`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Slovak (`sk`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Slovenian (`sl`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sq.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Albanian (`sq`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Serbian (`sr`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_sv.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Swedish (`sv`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ta.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tamil (`ta`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_te.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Telugu (`te`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tg.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tajik (`tg`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_th.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Thai (`th`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tl.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Tagalog (`tl`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_tr.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Turkish (`tr`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_ug.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Uighur Uyghur (`ug`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_uk.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Ukrainian (`uk`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_vi.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Vietnamese (`vi`).

--- a/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_wsl_setup/lib/l10n/app_localizations_zh.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'app_localizations.dart';
 
 /// The translations for Chinese (`zh`).

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.mocks.dart
@@ -31,72 +31,120 @@ class MockAdvancedSetupModel extends _i1.Mock
   }
 
   @override
-  String get mountLocation =>
-      (super.noSuchMethod(Invocation.getter(#mountLocation), returnValue: '')
-          as String);
+  String get mountLocation => (super.noSuchMethod(
+        Invocation.getter(#mountLocation),
+        returnValue: '',
+      ) as String);
   @override
-  set mountLocation(String? value) =>
-      super.noSuchMethod(Invocation.setter(#mountLocation, value),
-          returnValueForMissingStub: null);
+  set mountLocation(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #mountLocation,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get mountOption =>
-      (super.noSuchMethod(Invocation.getter(#mountOption), returnValue: '')
-          as String);
+  String get mountOption => (super.noSuchMethod(
+        Invocation.getter(#mountOption),
+        returnValue: '',
+      ) as String);
   @override
-  set mountOption(String? value) =>
-      super.noSuchMethod(Invocation.setter(#mountOption, value),
-          returnValueForMissingStub: null);
+  set mountOption(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #mountOption,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get enableHostGeneration =>
-      (super.noSuchMethod(Invocation.getter(#enableHostGeneration),
-          returnValue: false) as bool);
+  bool get enableHostGeneration => (super.noSuchMethod(
+        Invocation.getter(#enableHostGeneration),
+        returnValue: false,
+      ) as bool);
   @override
-  set enableHostGeneration(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#enableHostGeneration, value),
-          returnValueForMissingStub: null);
+  set enableHostGeneration(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #enableHostGeneration,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get enableResolvConfGeneration =>
-      (super.noSuchMethod(Invocation.getter(#enableResolvConfGeneration),
-          returnValue: false) as bool);
+  bool get enableResolvConfGeneration => (super.noSuchMethod(
+        Invocation.getter(#enableResolvConfGeneration),
+        returnValue: false,
+      ) as bool);
   @override
-  set enableResolvConfGeneration(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#enableResolvConfGeneration, value),
-          returnValueForMissingStub: null);
+  set enableResolvConfGeneration(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #enableResolvConfGeneration,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i3.Future<void> loadAdvancedSetup() => (super.noSuchMethod(
-      Invocation.method(#loadAdvancedSetup, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #loadAdvancedSetup,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> saveAdvancedSetup() => (super.noSuchMethod(
-      Invocation.method(#saveAdvancedSetup, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #saveAdvancedSetup,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:subiquity_client/src/types.dart' as _i6;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeEncoding_0 extends _i1.SmartFake implements _i2.Encoding {
-  _FakeEncoding_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeEncoding_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [IOSink].
@@ -37,52 +42,113 @@ class MockIOSink extends _i1.Mock implements _i3.IOSink {
   }
 
   @override
-  _i2.Encoding get encoding => (super.noSuchMethod(Invocation.getter(#encoding),
-          returnValue: _FakeEncoding_0(this, Invocation.getter(#encoding)))
-      as _i2.Encoding);
+  _i2.Encoding get encoding => (super.noSuchMethod(
+        Invocation.getter(#encoding),
+        returnValue: _FakeEncoding_0(
+          this,
+          Invocation.getter(#encoding),
+        ),
+      ) as _i2.Encoding);
   @override
-  set encoding(_i2.Encoding? _encoding) =>
-      super.noSuchMethod(Invocation.setter(#encoding, _encoding),
-          returnValueForMissingStub: null);
+  set encoding(_i2.Encoding? _encoding) => super.noSuchMethod(
+        Invocation.setter(
+          #encoding,
+          _encoding,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<dynamic> get done => (super.noSuchMethod(Invocation.getter(#done),
-      returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> get done => (super.noSuchMethod(
+        Invocation.getter(#done),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  void add(List<int>? data) =>
-      super.noSuchMethod(Invocation.method(#add, [data]),
-          returnValueForMissingStub: null);
+  void add(List<int>? data) => super.noSuchMethod(
+        Invocation.method(
+          #add,
+          [data],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void write(Object? object) =>
-      super.noSuchMethod(Invocation.method(#write, [object]),
-          returnValueForMissingStub: null);
+  void write(Object? object) => super.noSuchMethod(
+        Invocation.method(
+          #write,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeAll(Iterable<dynamic>? objects, [String? separator = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeAll, [objects, separator]),
-          returnValueForMissingStub: null);
+  void writeAll(
+    Iterable<dynamic>? objects, [
+    String? separator = r'',
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeAll,
+          [
+            objects,
+            separator,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeln([Object? object = r'']) =>
-      super.noSuchMethod(Invocation.method(#writeln, [object]),
-          returnValueForMissingStub: null);
+  void writeln([Object? object = r'']) => super.noSuchMethod(
+        Invocation.method(
+          #writeln,
+          [object],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void writeCharCode(int? charCode) =>
-      super.noSuchMethod(Invocation.method(#writeCharCode, [charCode]),
-          returnValueForMissingStub: null);
+  void writeCharCode(int? charCode) => super.noSuchMethod(
+        Invocation.method(
+          #writeCharCode,
+          [charCode],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addError(Object? error, [StackTrace? stackTrace]) =>
-      super.noSuchMethod(Invocation.method(#addError, [error, stackTrace]),
-          returnValueForMissingStub: null);
+  void addError(
+    Object? error, [
+    StackTrace? stackTrace,
+  ]) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addError,
+          [
+            error,
+            stackTrace,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<dynamic> addStream(_i4.Stream<List<int>>? stream) =>
-      (super.noSuchMethod(Invocation.method(#addStream, [stream]),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+      (super.noSuchMethod(
+        Invocation.method(
+          #addStream,
+          [stream],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<dynamic> flush() =>
-      (super.noSuchMethod(Invocation.method(#flush, []),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> flush() => (super.noSuchMethod(
+        Invocation.method(
+          #flush,
+          [],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
   @override
-  _i4.Future<dynamic> close() =>
-      (super.noSuchMethod(Invocation.method(#close, []),
-          returnValue: _i4.Future<dynamic>.value()) as _i4.Future<dynamic>);
+  _i4.Future<dynamic> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [SubiquityStatusMonitor].
@@ -95,16 +161,25 @@ class MockSubiquityStatusMonitor extends _i1.Mock
   }
 
   @override
-  _i4.Stream<_i6.ApplicationStatus?> get onStatusChanged =>
-      (super.noSuchMethod(Invocation.getter(#onStatusChanged),
-              returnValue: _i4.Stream<_i6.ApplicationStatus?>.empty())
-          as _i4.Stream<_i6.ApplicationStatus?>);
+  _i4.Stream<_i6.ApplicationStatus?> get onStatusChanged => (super.noSuchMethod(
+        Invocation.getter(#onStatusChanged),
+        returnValue: _i4.Stream<_i6.ApplicationStatus?>.empty(),
+      ) as _i4.Stream<_i6.ApplicationStatus?>);
   @override
-  _i4.Future<bool> start(_i7.Endpoint? endpoint) =>
-      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
-          returnValue: _i4.Future<bool>.value(false)) as _i4.Future<bool>);
+  _i4.Future<bool> start(_i7.Endpoint? endpoint) => (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [endpoint],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
-  _i4.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> stop() => (super.noSuchMethod(
+        Invocation.method(
+          #stop,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.d
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [ApplyingChangesModel].
@@ -39,46 +44,83 @@ class MockApplyingChangesModel extends _i1.Mock
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   void init({_i4.VoidCallback? onDoneTransition}) => super.noSuchMethod(
-      Invocation.method(#init, [], {#onDoneTransition: onDoneTransition}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #init,
+          [],
+          {#onDoneTransition: onDoneTransition},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i5.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [SubiquityStatusMonitor].
@@ -91,16 +133,25 @@ class MockSubiquityStatusMonitor extends _i1.Mock
   }
 
   @override
-  _i5.Stream<_i2.ApplicationStatus?> get onStatusChanged =>
-      (super.noSuchMethod(Invocation.getter(#onStatusChanged),
-              returnValue: _i5.Stream<_i2.ApplicationStatus?>.empty())
-          as _i5.Stream<_i2.ApplicationStatus?>);
+  _i5.Stream<_i2.ApplicationStatus?> get onStatusChanged => (super.noSuchMethod(
+        Invocation.getter(#onStatusChanged),
+        returnValue: _i5.Stream<_i2.ApplicationStatus?>.empty(),
+      ) as _i5.Stream<_i2.ApplicationStatus?>);
   @override
-  _i5.Future<bool> start(_i2.Endpoint? endpoint) =>
-      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
-          returnValue: _i5.Future<bool>.value(false)) as _i5.Future<bool>);
+  _i5.Future<bool> start(_i2.Endpoint? endpoint) => (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [endpoint],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
   @override
-  _i5.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+  _i5.Future<void> stop() => (super.noSuchMethod(
+        Invocation.method(
+          #stop,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.mocks.dart
@@ -31,72 +31,120 @@ class MockConfigurationUIModel extends _i1.Mock
   }
 
   @override
-  bool get interopAppendwindowspath =>
-      (super.noSuchMethod(Invocation.getter(#interopAppendwindowspath),
-          returnValue: false) as bool);
+  bool get interopAppendwindowspath => (super.noSuchMethod(
+        Invocation.getter(#interopAppendwindowspath),
+        returnValue: false,
+      ) as bool);
   @override
-  set interopAppendwindowspath(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#interopAppendwindowspath, value),
-          returnValueForMissingStub: null);
+  set interopAppendwindowspath(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #interopAppendwindowspath,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get interopEnabled => (super
-          .noSuchMethod(Invocation.getter(#interopEnabled), returnValue: false)
-      as bool);
+  bool get interopEnabled => (super.noSuchMethod(
+        Invocation.getter(#interopEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  set interopEnabled(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#interopEnabled, value),
-          returnValueForMissingStub: null);
+  set interopEnabled(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #interopEnabled,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get automountEnabled =>
-      (super.noSuchMethod(Invocation.getter(#automountEnabled),
-          returnValue: false) as bool);
+  bool get automountEnabled => (super.noSuchMethod(
+        Invocation.getter(#automountEnabled),
+        returnValue: false,
+      ) as bool);
   @override
-  set automountEnabled(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#automountEnabled, value),
-          returnValueForMissingStub: null);
+  set automountEnabled(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #automountEnabled,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get automountMountfstab =>
-      (super.noSuchMethod(Invocation.getter(#automountMountfstab),
-          returnValue: false) as bool);
+  bool get automountMountfstab => (super.noSuchMethod(
+        Invocation.getter(#automountMountfstab),
+        returnValue: false,
+      ) as bool);
   @override
-  set automountMountfstab(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#automountMountfstab, value),
-          returnValueForMissingStub: null);
+  set automountMountfstab(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #automountMountfstab,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i3.Future<void> loadConfiguration() => (super.noSuchMethod(
-      Invocation.method(#loadConfiguration, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #loadConfiguration,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   _i3.Future<void> saveConfiguration() => (super.noSuchMethod(
-      Invocation.method(#saveConfiguration, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+        Invocation.method(
+          #saveConfiguration,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i4.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_wsl_setup/test/installation_slides_model_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_model_test.mocks.dart
@@ -31,16 +31,25 @@ class MockSubiquityStatusMonitor extends _i1.Mock
   }
 
   @override
-  _i3.Stream<_i4.ApplicationStatus?> get onStatusChanged =>
-      (super.noSuchMethod(Invocation.getter(#onStatusChanged),
-              returnValue: _i3.Stream<_i4.ApplicationStatus?>.empty())
-          as _i3.Stream<_i4.ApplicationStatus?>);
+  _i3.Stream<_i4.ApplicationStatus?> get onStatusChanged => (super.noSuchMethod(
+        Invocation.getter(#onStatusChanged),
+        returnValue: _i3.Stream<_i4.ApplicationStatus?>.empty(),
+      ) as _i3.Stream<_i4.ApplicationStatus?>);
   @override
-  _i3.Future<bool> start(_i5.Endpoint? endpoint) =>
-      (super.noSuchMethod(Invocation.method(#start, [endpoint]),
-          returnValue: _i3.Future<bool>.value(false)) as _i3.Future<bool>);
+  _i3.Future<bool> start(_i5.Endpoint? endpoint) => (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [endpoint],
+        ),
+        returnValue: _i3.Future<bool>.value(false),
+      ) as _i3.Future<bool>);
   @override
-  _i3.Future<void> stop() => (super.noSuchMethod(Invocation.method(#stop, []),
-      returnValue: _i3.Future<void>.value(),
-      returnValueForMissingStub: _i3.Future<void>.value()) as _i3.Future<void>);
+  _i3.Future<void> stop() => (super.noSuchMethod(
+        Invocation.method(
+          #stop,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
@@ -25,8 +25,13 @@ import 'package:ubuntu_wsl_setup/services/journal.dart' as _i6;
 
 class _FakeSubiquityStatusMonitor_0 extends _i1.SmartFake
     implements _i2.SubiquityStatusMonitor {
-  _FakeSubiquityStatusMonitor_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityStatusMonitor_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [InstallationSlidesModel].
@@ -40,65 +45,101 @@ class MockInstallationSlidesModel extends _i1.Mock
 
   @override
   _i2.SubiquityStatusMonitor get monitor => (super.noSuchMethod(
+        Invocation.getter(#monitor),
+        returnValue: _FakeSubiquityStatusMonitor_0(
+          this,
           Invocation.getter(#monitor),
-          returnValue:
-              _FakeSubiquityStatusMonitor_0(this, Invocation.getter(#monitor)))
-      as _i2.SubiquityStatusMonitor);
+        ),
+      ) as _i2.SubiquityStatusMonitor);
   @override
   _i3.InstallationState get state => (super.noSuchMethod(
-      Invocation.getter(#state),
-      returnValue: _i3.InstallationState.registering) as _i3.InstallationState);
+        Invocation.getter(#state),
+        returnValue: _i3.InstallationState.registering,
+      ) as _i3.InstallationState);
   @override
-  _i4.Stream<String> get journal =>
-      (super.noSuchMethod(Invocation.getter(#journal),
-          returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
+  _i4.Stream<String> get journal => (super.noSuchMethod(
+        Invocation.getter(#journal),
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
   @override
-  bool get hasError =>
-      (super.noSuchMethod(Invocation.getter(#hasError), returnValue: false)
-          as bool);
+  bool get hasError => (super.noSuchMethod(
+        Invocation.getter(#hasError),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isRegistering =>
-      (super.noSuchMethod(Invocation.getter(#isRegistering), returnValue: false)
-          as bool);
+  bool get isRegistering => (super.noSuchMethod(
+        Invocation.getter(#isRegistering),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isLogVisible =>
-      (super.noSuchMethod(Invocation.getter(#isLogVisible), returnValue: false)
-          as bool);
+  bool get isLogVisible => (super.noSuchMethod(
+        Invocation.getter(#isLogVisible),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isServerUp =>
-      (super.noSuchMethod(Invocation.getter(#isServerUp), returnValue: false)
-          as bool);
+  bool get isServerUp => (super.noSuchMethod(
+        Invocation.getter(#isServerUp),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   void init({void Function()? onServerUp}) => super.noSuchMethod(
-      Invocation.method(#init, [], {#onServerUp: onServerUp}),
-      returnValueForMissingStub: null);
+        Invocation.method(
+          #init,
+          [],
+          {#onServerUp: onServerUp},
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void toggleLogVisibility() =>
-      super.noSuchMethod(Invocation.method(#toggleLogVisibility, []),
-          returnValueForMissingStub: null);
+  void toggleLogVisibility() => super.noSuchMethod(
+        Invocation.method(
+          #toggleLogVisibility,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [JournalService].
@@ -110,11 +151,17 @@ class MockJournalService extends _i1.Mock implements _i6.JournalService {
   }
 
   @override
-  _i4.Stream<String> get stream =>
-      (super.noSuchMethod(Invocation.getter(#stream),
-          returnValue: _i4.Stream<String>.empty()) as _i4.Stream<String>);
+  _i4.Stream<String> get stream => (super.noSuchMethod(
+        Invocation.getter(#stream),
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
   @override
-  _i4.Future<void> close() => (super.noSuchMethod(Invocation.method(#close, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.mocks.dart
@@ -32,99 +32,160 @@ class MockProfileSetupModel extends _i1.Mock implements _i2.ProfileSetupModel {
   }
 
   @override
-  String get realname =>
-      (super.noSuchMethod(Invocation.getter(#realname), returnValue: '')
-          as String);
+  String get realname => (super.noSuchMethod(
+        Invocation.getter(#realname),
+        returnValue: '',
+      ) as String);
   @override
-  set realname(String? realname) =>
-      super.noSuchMethod(Invocation.setter(#realname, realname),
-          returnValueForMissingStub: null);
+  set realname(String? realname) => super.noSuchMethod(
+        Invocation.setter(
+          #realname,
+          realname,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get username =>
-      (super.noSuchMethod(Invocation.getter(#username), returnValue: '')
-          as String);
+  String get username => (super.noSuchMethod(
+        Invocation.getter(#username),
+        returnValue: '',
+      ) as String);
   @override
-  set username(String? username) =>
-      super.noSuchMethod(Invocation.setter(#username, username),
-          returnValueForMissingStub: null);
+  set username(String? username) => super.noSuchMethod(
+        Invocation.setter(
+          #username,
+          username,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get password =>
-      (super.noSuchMethod(Invocation.getter(#password), returnValue: '')
-          as String);
+  String get password => (super.noSuchMethod(
+        Invocation.getter(#password),
+        returnValue: '',
+      ) as String);
   @override
-  set password(String? password) =>
-      super.noSuchMethod(Invocation.setter(#password, password),
-          returnValueForMissingStub: null);
+  set password(String? password) => super.noSuchMethod(
+        Invocation.setter(
+          #password,
+          password,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  String get confirmedPassword => (super
-          .noSuchMethod(Invocation.getter(#confirmedPassword), returnValue: '')
-      as String);
+  String get confirmedPassword => (super.noSuchMethod(
+        Invocation.getter(#confirmedPassword),
+        returnValue: '',
+      ) as String);
   @override
-  set confirmedPassword(String? password) =>
-      super.noSuchMethod(Invocation.setter(#confirmedPassword, password),
-          returnValueForMissingStub: null);
+  set confirmedPassword(String? password) => super.noSuchMethod(
+        Invocation.setter(
+          #confirmedPassword,
+          password,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i3.PasswordStrength get passwordStrength =>
-      (super.noSuchMethod(Invocation.getter(#passwordStrength),
-          returnValue: _i3.PasswordStrength.weak) as _i3.PasswordStrength);
+  _i3.PasswordStrength get passwordStrength => (super.noSuchMethod(
+        Invocation.getter(#passwordStrength),
+        returnValue: _i3.PasswordStrength.weak,
+      ) as _i3.PasswordStrength);
   @override
-  bool get showAdvancedOptions =>
-      (super.noSuchMethod(Invocation.getter(#showAdvancedOptions),
-          returnValue: false) as bool);
+  bool get showAdvancedOptions => (super.noSuchMethod(
+        Invocation.getter(#showAdvancedOptions),
+        returnValue: false,
+      ) as bool);
   @override
-  set showAdvancedOptions(bool? value) =>
-      super.noSuchMethod(Invocation.setter(#showAdvancedOptions, value),
-          returnValueForMissingStub: null);
+  set showAdvancedOptions(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #showAdvancedOptions,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  bool get isValid =>
-      (super.noSuchMethod(Invocation.getter(#isValid), returnValue: false)
-          as bool);
+  bool get isValid => (super.noSuchMethod(
+        Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.UsernameValidation get usernameValidation =>
-      (super.noSuchMethod(Invocation.getter(#usernameValidation),
-          returnValue: _i4.UsernameValidation.OK) as _i4.UsernameValidation);
+  _i4.UsernameValidation get usernameValidation => (super.noSuchMethod(
+        Invocation.getter(#usernameValidation),
+        returnValue: _i4.UsernameValidation.OK,
+      ) as _i4.UsernameValidation);
   @override
-  bool get usernameOk =>
-      (super.noSuchMethod(Invocation.getter(#usernameOk), returnValue: false)
-          as bool);
+  bool get usernameOk => (super.noSuchMethod(
+        Invocation.getter(#usernameOk),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
   _i5.Future<void> validate() => (super.noSuchMethod(
-      Invocation.method(#validate, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #validate,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> loadProfileSetup() => (super.noSuchMethod(
-      Invocation.method(#loadProfileSetup, []),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #loadProfileSetup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<void> saveProfileSetup({String? salt}) => (super.noSuchMethod(
-      Invocation.method(#saveProfileSetup, [], {#salt: salt}),
-      returnValue: _i5.Future<void>.value(),
-      returnValueForMissingStub: _i5.Future<void>.value()) as _i5.Future<void>);
+        Invocation.method(
+          #saveProfileSetup,
+          [],
+          {#salt: salt},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i6.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UrlLauncher].
@@ -136,7 +197,11 @@ class MockUrlLauncher extends _i1.Mock implements _i3.UrlLauncher {
   }
 
   @override
-  _i5.Future<bool> launchUrl(String? url) =>
-      (super.noSuchMethod(Invocation.method(#launchUrl, [url]),
-          returnValue: _i5.Future<bool>.value(false)) as _i5.Future<bool>);
+  _i5.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #launchUrl,
+          [url],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 }

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.mocks.dart
@@ -22,8 +22,13 @@ import 'package:ubuntu_wsl_setup/pages/select_language/select_language_model.dar
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeLocale_0 extends _i1.SmartFake implements _i2.Locale {
-  _FakeLocale_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeLocale_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [SelectLanguageModel].
@@ -36,91 +41,170 @@ class MockSelectLanguageModel extends _i1.Mock
   }
 
   @override
-  bool get installLanguagePacks =>
-      (super.noSuchMethod(Invocation.getter(#installLanguagePacks),
-          returnValue: false) as bool);
+  bool get installLanguagePacks => (super.noSuchMethod(
+        Invocation.getter(#installLanguagePacks),
+        returnValue: false,
+      ) as bool);
   @override
-  int get selectedLanguageIndex =>
-      (super.noSuchMethod(Invocation.getter(#selectedLanguageIndex),
-          returnValue: 0) as int);
+  int get selectedLanguageIndex => (super.noSuchMethod(
+        Invocation.getter(#selectedLanguageIndex),
+        returnValue: 0,
+      ) as int);
   @override
-  set selectedLanguageIndex(int? index) =>
-      super.noSuchMethod(Invocation.setter(#selectedLanguageIndex, index),
-          returnValueForMissingStub: null);
+  set selectedLanguageIndex(int? index) => super.noSuchMethod(
+        Invocation.setter(
+          #selectedLanguageIndex,
+          index,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  int get languageCount =>
-      (super.noSuchMethod(Invocation.getter(#languageCount), returnValue: 0)
-          as int);
+  int get languageCount => (super.noSuchMethod(
+        Invocation.getter(#languageCount),
+        returnValue: 0,
+      ) as int);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  void setInstallLanguagePacks(bool? value) =>
-      super.noSuchMethod(Invocation.method(#setInstallLanguagePacks, [value]),
-          returnValueForMissingStub: null);
+  void setInstallLanguagePacks(bool? value) => super.noSuchMethod(
+        Invocation.method(
+          #setInstallLanguagePacks,
+          [value],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> getInstallLanguagePacks() => (super.noSuchMethod(
-      Invocation.method(#getInstallLanguagePacks, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #getInstallLanguagePacks,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> applyInstallLanguagePacks() => (super.noSuchMethod(
-      Invocation.method(#applyInstallLanguagePacks, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #applyInstallLanguagePacks,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> loadLanguages() => (super.noSuchMethod(
-      Invocation.method(#loadLanguages, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #loadLanguages,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i2.Locale locale(int? index) => (super.noSuchMethod(
-          Invocation.method(#locale, [index]),
-          returnValue: _FakeLocale_0(this, Invocation.method(#locale, [index])))
-      as _i2.Locale);
+        Invocation.method(
+          #locale,
+          [index],
+        ),
+        returnValue: _FakeLocale_0(
+          this,
+          Invocation.method(
+            #locale,
+            [index],
+          ),
+        ),
+      ) as _i2.Locale);
   @override
-  _i2.Locale uiLocale(int? index) =>
-      (super.noSuchMethod(Invocation.method(#uiLocale, [index]),
-              returnValue:
-                  _FakeLocale_0(this, Invocation.method(#uiLocale, [index])))
-          as _i2.Locale);
+  _i2.Locale uiLocale(int? index) => (super.noSuchMethod(
+        Invocation.method(
+          #uiLocale,
+          [index],
+        ),
+        returnValue: _FakeLocale_0(
+          this,
+          Invocation.method(
+            #uiLocale,
+            [index],
+          ),
+        ),
+      ) as _i2.Locale);
   @override
   _i4.Future<void> applyLocale(_i2.Locale? locale) => (super.noSuchMethod(
-      Invocation.method(#applyLocale, [locale]),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #applyLocale,
+          [locale],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  String language(int? index) => (super
-          .noSuchMethod(Invocation.method(#language, [index]), returnValue: '')
-      as String);
+  String language(int? index) => (super.noSuchMethod(
+        Invocation.method(
+          #language,
+          [index],
+        ),
+        returnValue: '',
+      ) as String);
   @override
-  void selectLocale(_i2.Locale? locale) =>
-      super.noSuchMethod(Invocation.method(#selectLocale, [locale]),
-          returnValueForMissingStub: null);
+  void selectLocale(_i2.Locale? locale) => super.noSuchMethod(
+        Invocation.method(
+          #selectLocale,
+          [locale],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  _i4.Future<_i2.Locale> getServerLocale() =>
-      (super.noSuchMethod(Invocation.method(#getServerLocale, []),
-              returnValue: _i4.Future<_i2.Locale>.value(
-                  _FakeLocale_0(this, Invocation.method(#getServerLocale, []))))
-          as _i4.Future<_i2.Locale>);
+  _i4.Future<_i2.Locale> getServerLocale() => (super.noSuchMethod(
+        Invocation.method(
+          #getServerLocale,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.Locale>.value(_FakeLocale_0(
+          this,
+          Invocation.method(
+            #getServerLocale,
+            [],
+          ),
+        )),
+      ) as _i4.Future<_i2.Locale>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i2.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i2.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/setup_complete_page_test.mocks.dart
@@ -24,8 +24,13 @@ import 'package:ubuntu_wsl_setup/pages/setup_complete/setup_complete_model.dart'
 
 class _FakeSubiquityClient_0 extends _i1.SmartFake
     implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSubiquityClient_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [SetupCompleteModel].
@@ -39,48 +44,86 @@ class MockSetupCompleteModel extends _i1.Mock
 
   @override
   _i2.SubiquityClient get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeSubiquityClient_0(
+          this,
           Invocation.getter(#client),
-          returnValue: _FakeSubiquityClient_0(this, Invocation.getter(#client)))
-      as _i2.SubiquityClient);
+        ),
+      ) as _i2.SubiquityClient);
   @override
-  String get username =>
-      (super.noSuchMethod(Invocation.getter(#username), returnValue: '')
-          as String);
+  String get username => (super.noSuchMethod(
+        Invocation.getter(#username),
+        returnValue: '',
+      ) as String);
   @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(Invocation.method(#init, []),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void notifyListeners() =>
-      super.noSuchMethod(Invocation.method(#notifyListeners, []),
-          returnValueForMissingStub: null);
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void addListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#addListener, [listener]),
-          returnValueForMissingStub: null);
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void removeListener(_i5.VoidCallback? listener) =>
-      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
-          returnValueForMissingStub: null);
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i4.Future<void> reboot({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#reboot, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<void> shutdown({bool? immediate}) => (super.noSuchMethod(
-      Invocation.method(#shutdown, [], {#immediate: immediate}),
-      returnValue: _i4.Future<void>.value(),
-      returnValueForMissingStub: _i4.Future<void>.value()) as _i4.Future<void>);
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }


### PR DESCRIPTION
[Flutter 3.3.2](https://groups.google.com/g/flutter-announce/c/YGf90mszrAw/m/7q1a3UmrBgAJ) reportedly fixes the raster cache rendering issues that motivated pinning the version in the CI workflows.

But since https://github.com/flutter/flutter/commit/bbdf617034171ab1128a594fb24e1c72a09e072e `Uint8List` is exported by `flutter/services.dart` library, thus one small patch in one test file was necessary to avoid linter complains.

Yet, recent changes in [`code_builder`](https://github.com/dart-lang/code_builder/pull/376) caused `mockito` to add trailing commas all around the generated mocks. I considered finding a way to disable it, but it appears to improve the code generation run time, so I opted in for pushing the regenerated files. The same stands for l10n code generation.

Unfortunately I didn't see a way to break those changes in smaller pieces because they are motivated by the Flutter version upgrades.