### PR TITLE
Use new simplified API in yaru.dart 0.4

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -172,9 +172,8 @@ class UbuntuDesktopInstallerApp extends StatelessWidget {
                   setWindowTitle(lang.windowTitle(flavor.name));
                   return lang.appTitle;
                 },
-                theme: flavor.theme ?? yaru.variant?.theme ?? yaruLight,
-                darkTheme:
-                    flavor.darkTheme ?? yaru.variant?.darkTheme ?? yaruDark,
+                theme: flavor.theme ?? yaru.theme,
+                darkTheme: flavor.darkTheme ?? yaru.darkTheme,
                 debugShowCheckedModeBanner: false,
                 localizationsDelegates: <LocalizationsDelegate>[
                   ...localizationsDelegates,


### PR DESCRIPTION
The YaruThemeData object passed to builder has gained new theme and darkTheme getters that automatically fallback to the appropriate light and dark themes if a variant could not be detected from the system.