### PR TITLE
DiskStorageService: rename hasEncryption to useEncryption

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -291,7 +291,7 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
               } else if (settings.arguments == InstallationType.alongside) {
                 return Routes.installAlongside;
               }
-            } else if (service.hasEncryption) {
+            } else if (service.useEncryption) {
               return Routes.chooseSecurityKey;
             }
             return Routes.writeChangesToDisk;
@@ -300,13 +300,13 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
         Routes.installAlongside: WizardRoute(
           builder: InstallAlongsidePage.create,
           onReplace: (_) => Routes.allocateDiskSpace,
-          onNext: (_) => service.hasEncryption
+          onNext: (_) => service.useEncryption
               ? Routes.chooseSecurityKey
               : Routes.writeChangesToDisk,
         ),
         Routes.selectGuidedStorage: WizardRoute(
           builder: SelectGuidedStoragePage.create,
-          onNext: (_) => service.hasEncryption
+          onNext: (_) => service.useEncryption
               ? Routes.chooseSecurityKey
               : Routes.writeChangesToDisk,
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -143,7 +143,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
     } else if (advancedFeature == AdvancedFeature.zfs) {
       _telemetryService.setPartitionMethod('use_zfs');
     }
-    if (_diskService.hasEncryption && advancedFeature != AdvancedFeature.zfs) {
+    if (_diskService.useEncryption && advancedFeature != AdvancedFeature.zfs) {
       _telemetryService.setPartitionMethod('use_crypto');
     }
     // TODO: map upgrading the current Ubuntu installation without

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -28,6 +28,7 @@ class DiskStorageService {
   bool? _needRoot;
   bool? _needBoot;
   bool? _useLvm;
+  bool? _useEncryption;
   bool? _hasRst;
   bool? _hasBitLocker;
   bool? _hasMultipleDisks;
@@ -50,8 +51,12 @@ class DiskStorageService {
 
   bool get hasBitLocker => _hasBitLocker ?? false;
 
-  /// Whether FDE (Full Disk Encryption) is enabled.
-  bool get hasEncryption => false; // TODO: add support for it
+  /// Whether FDE (Full Disk Encryption) should be used.
+  bool get useEncryption => _useEncryption ?? false;
+  set useEncryption(bool useEncryption) {
+    log.debug('use encryption: $useEncryption');
+    _useEncryption = useEncryption;
+  }
 
   /// Whether Secure Boot is enabled.
   bool get hasSecureBoot => false; // TODO: add support for it

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -69,7 +69,7 @@ void main() {
   test('save talks to telemetry service', () async {
     final disks = MockDiskStorageService();
     when(disks.hasMultipleDisks).thenReturn(false);
-    when(disks.hasEncryption).thenReturn(false);
+    when(disks.useEncryption).thenReturn(false);
 
     final telemetry = MockTelemetryService();
     final model = InstallationTypeModel(disks, telemetry);
@@ -105,7 +105,7 @@ void main() {
     verify(telemetry.setPartitionMethod('use_zfs')).called(1);
     reset(telemetry);
 
-    when(disks.hasEncryption).thenReturn(true);
+    when(disks.useEncryption).thenReturn(true);
     model.advancedFeature = AdvancedFeature.none;
     await model.save();
     verify(telemetry.setPartitionMethod('use_crypto')).called(1);
@@ -115,7 +115,7 @@ void main() {
   test('save lvm', () {
     final storage = MockDiskStorageService();
     when(storage.hasMultipleDisks).thenReturn(false);
-    when(storage.hasEncryption).thenReturn(false);
+    when(storage.useEncryption).thenReturn(false);
 
     final model = InstallationTypeModel(
       storage,
@@ -135,7 +135,7 @@ void main() {
     final reformat = GuidedStorageTargetReformat(diskId: '');
 
     final service = MockDiskStorageService();
-    when(service.hasEncryption).thenReturn(false);
+    when(service.useEncryption).thenReturn(false);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: [reformat]));
 

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -71,10 +71,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -67,10 +67,18 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasEncryption => (super.noSuchMethod(
-        Invocation.getter(#hasEncryption),
+  bool get useEncryption => (super.noSuchMethod(
+        Invocation.getter(#useEncryption),
         returnValue: false,
       ) as bool);
+  @override
+  set useEncryption(bool? useEncryption) => super.noSuchMethod(
+        Invocation.setter(
+          #useEncryption,
+          useEncryption,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasSecureBoot => (super.noSuchMethod(
         Invocation.getter(#hasSecureBoot),


### PR DESCRIPTION
This change was extracted from #951.

The "hasEncryption" property was somewhat confusingly named because it's supposed to describe whether the installation should use encryption, not whether the system has encryption.