### PR TITLE
Clear the security key after installation begins

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -43,6 +43,7 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
   /// Starts the installation process.
   Future<void> startInstallation() async {
     await _service.setStorage(disks.toList());
+    _service.securityKey = null; // no longer needed
     await _client.confirm('/dev/tty1');
   }
 

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -71,8 +71,10 @@ class DiskStorageService {
   /// A security key for full disk encryption.
   String? get securityKey => _securityKey;
   set securityKey(String? securityKey) {
-    final hiddenKey = securityKey == null ? null : '*' * securityKey.length;
-    log.debug('set security key: $hiddenKey');
+    if (securityKey != null) {
+      final hiddenKey = '*' * securityKey.length;
+      log.debug('set security key: $hiddenKey');
+    }
     _securityKey = securityKey;
   }
 

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -111,6 +111,7 @@ void main() {
     await model.startInstallation();
 
     verify(service.setStorage(nonPreservedDisks)).called(1);
+    verify(service.securityKey = null).called(1);
     verify(client.confirm('/dev/tty1')).called(1);
   });
 }


### PR DESCRIPTION
At that point, the GUI no longer needs the security key. This does not erase the key from memory but allows the area to be reallocated for something else.

See https://github.com/canonical/ubuntu-desktop-installer/pull/1115#discussion_r976446414 for related discussion.