### PR TITLE
subiquity_client: send utf-8

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -85,9 +85,12 @@ class SubiquityClient {
     return jsonDecode(responseStr) as Map<String, dynamic>;
   }
 
-  Future<HttpClientRequest> _openUrl(String method, Uri url) {
+  Future<HttpClientRequest> _openUrl(String method, Uri url) async {
     log.debug('$method $url');
-    return _client.openUrl(method, url);
+    final request = await _client.openUrl(method, url);
+    request.headers.contentType =
+        ContentType('application', 'json', charset: 'utf-8');
+    return request;
   }
 
   Future<Variant> variant() async {

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -346,7 +346,7 @@ void main() {
 
     test('identity', () async {
       var newId = IdentityData(
-        realname: 'ubuntu',
+        realname: 'übuntù', // utf-8
         username: 'ubuntu',
         cryptedPassword:
             r'$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0',
@@ -356,7 +356,7 @@ void main() {
       await client.setIdentity(newId);
 
       var id = await client.identity();
-      expect(id.realname, 'ubuntu');
+      expect(id.realname, 'übuntù');
       expect(id.username, 'ubuntu');
       expect(id.cryptedPassword, '');
       expect(id.hostname, 'ubuntu-desktop');


### PR DESCRIPTION
> When writing string data through the IOSink the encoding used is
> determined from the "charset" parameter of the "Content-Type" header.

https://api.dart.dev/stable/2.18.1/dart-io/HttpClientRequest-class.html