### PR TITLE
[WSL] Fix error reporting on NamedEvent native code

### DIFF
--- a/packages/ubuntu_wsl_setup/windows/runner/flutter_window.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/flutter_window.cpp
@@ -12,7 +12,7 @@ namespace ChannelConstants {
 const char* channel = "ubuntuWslSetupChannel";
 const char* onEventSet = "onEventSet";
 const char* addListenerFor = "addListenerFor";
-};  // namespace NamedEventConstants
+};  // namespace ChannelConstants
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -40,8 +40,7 @@ bool FlutterWindow::OnCreate() {
   // method channel setup
   ubuntuWslSetupChannel =
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-          flutter_controller_->engine()->messenger(),
-          ChannelConstants::channel,
+          flutter_controller_->engine()->messenger(), ChannelConstants::channel,
           &flutter::StandardMethodCodec::GetInstance());
 
   ubuntuWslSetupChannel->SetMethodCallHandler(
@@ -85,6 +84,7 @@ void FlutterWindow::handleMethodCall(
                           [self = this, eventName = *eventNamePtr]() {
                             self->onEventSet(eventName);
                           });
+      result->Success();
     } catch (const std::runtime_error& e) {
       result->Error(ChannelConstants::channel, e.what());
     } catch (const std::invalid_argument& e) {
@@ -94,7 +94,6 @@ void FlutterWindow::handleMethodCall(
       result->Error(ChannelConstants::channel, msg);
     }
 
-    result->Success();
   } else {
     result->NotImplemented();
   }

--- a/packages/ubuntu_wsl_setup/windows/runner/flutter_window.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/flutter_window.cpp
@@ -89,7 +89,8 @@ void FlutterWindow::handleMethodCall(
       result->Error(ChannelConstants::channel, e.what());
     } catch (const std::invalid_argument& e) {
       std::string msg{e.what()};
-      msg.append(". Wass the event ever created?");
+      msg.append(": ");
+      msg.append(*eventNamePtr);
       result->Error(ChannelConstants::channel, msg);
     }
 

--- a/packages/ubuntu_wsl_setup/windows/runner/named_event.cpp
+++ b/packages/ubuntu_wsl_setup/windows/runner/named_event.cpp
@@ -37,7 +37,7 @@ NamedEvent::NamedEvent(std::string name, std::function<void()> callback)
   if (event == nullptr || event == INVALID_HANDLE_VALUE) {
     // the most likely error
     if (GetLastError() == ERROR_FILE_NOT_FOUND) {
-      throw std::invalid_argument(name);
+      throw std::invalid_argument("Event never created");
     } else {
       throw std::runtime_error("Cannot open event");
     }


### PR DESCRIPTION
The OOBE uses an abstraction created on top of Win32 named events to receive notifications from the distro launcher of certain milestones achieved during the setup workflow. It presumes that the event object will have been previously created by the distro launcher, thus an exception is thrown if the call to `OpenEvent()` fails. Some gibberish is being transported by `std::invalid_argument` in such cases, causing the Dart UTF-8 parser to crash.

Using a literal instead of a variable from the scope where the exception is thrown prevents that error.

Besides, the call to `result->Success()` was misplaced, allowing it to happen on exceptional cases as well.