### PR TITLE
snapcraft.yaml: clean up flutter commands

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,6 +132,7 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/libexec
       cp -r $SNAPCRAFT_PART_SRC $SNAPCRAFT_PART_INSTALL/usr/libexec/flutter
       ln -s $SNAPCRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $SNAPCRAFT_PART_INSTALL/usr/bin/flutter
+      $SNAPCRAFT_PART_INSTALL/usr/bin/flutter doctor
     build-packages:
       - clang
       - cmake
@@ -157,9 +158,6 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/etc/subiquity
       cp -r snap/local/postinst.d $SNAPCRAFT_PART_INSTALL/etc/subiquity
       cd packages/ubuntu_desktop_installer
-      flutter channel stable
-      flutter upgrade
-      flutter doctor
       flutter pub get
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $SNAPCRAFT_PART_INSTALL/bin/
@@ -175,9 +173,6 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/libexec
       cd packages/ubuntu_wsl_setup
-      flutter channel stable
-      flutter upgrade
-      flutter doctor
       flutter pub get
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $SNAPCRAFT_PART_INSTALL/usr/libexec


### PR DESCRIPTION
flutter-git clones the latest stable branch/channel straight from git so there's no need to switch channels and upgrade. Also, running flutter doctor once after installing flutter is enough.