### PR TITLE
Pin flutter_html to fix build

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   filesize: ^2.0.0
   flutter:
     sdk: flutter
-  flutter_html: ^3.0.0-0
+  flutter_html: 3.0.0-alpha.5
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.6.2

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   diacritic: ^0.1.3
   flutter:
     sdk: flutter
-  flutter_html: ^3.0.0-0
+  flutter_html: 3.0.0-alpha.5
   flutter_svg: ^1.1.0
   form_field_validator: ^1.1.0
   path: ^1.8.0


### PR DESCRIPTION
We're currently using a flutter_html 3.0 pre-release (#883) to avoid problematic transitive dependencies. The latest alpha 6 pre-release from 2 days ago has some breaking API changes. Pin the current version to avoid having to adapt to breaking changes until the final 3.0 is released.