### PR TITLE
[WSL] Enabling integration tests as an automation tool

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/e2e/reconfigure_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/reconfigure_test.dart
@@ -1,0 +1,36 @@
+@TestOn('windows')
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+
+import '../test_pages.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // enter all WSLConfigurationAdvanced values
+  testWidgets('reconfiguration', (tester) async {
+    await app.main(<String>['--reconfigure', '--no-dry-run']);
+    await tester.pumpAndSettle();
+
+    await testSplashPage(tester);
+    await tester.pumpAndSettle();
+
+    await testAdvancedSetupPage(tester);
+    await tester.pumpAndSettle();
+
+    // NOTE: opposites of the default values to force writing the config
+    await testConfigurationUIPage(
+      tester,
+      config: const WSLConfigurationAdvanced(
+        interopEnabled: false,
+        interopAppendwindowspath: false,
+        automountEnabled: false,
+        automountMountfstab: false,
+      ),
+    );
+
+    await testApplyingChangesPage(tester, expectClose: true);
+  });
+}

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
@@ -1,0 +1,36 @@
+@TestOn('windows')
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+
+import '../test_pages.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('basic setup', (tester) async {
+    app.main(<String>['--no-dry-run']);
+
+    await testInstallationSlidesPage(tester);
+    await tester.pumpAndSettle();
+
+    await testSelectYourLanguagePage(tester, language: 'Français');
+    await tester.pumpAndSettle();
+
+    await testProfileSetupPage(
+      tester,
+      profile: const IdentityData(realname: 'Ubuntu', username: 'ubuntu'),
+      password: 'password123',
+      confirmedPassword: 'password123',
+    );
+    await tester.pumpAndSettle();
+
+    await testAdvancedSetupPage(tester);
+    await testApplyingChangesPage(tester);
+    await tester.pumpAndSettle();
+
+    await testSetupCompletePage(tester, username: 'ubuntu');
+    await tester.pumpAndSettle();
+  });
+}

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
@@ -1,0 +1,35 @@
+@TestOn('windows')
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+
+import '../test_pages.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('basic setup with prefill info', (tester) async {
+    const prefill = String.fromEnvironment('PREFILL', defaultValue: '');
+    app.main(<String>['--no-dry-run', '--prefill=$prefill']);
+
+    await testInstallationSlidesPage(tester);
+    await tester.pumpAndSettle();
+
+    await testSelectYourLanguagePage(tester, language: 'Français');
+    await tester.pumpAndSettle();
+
+    await testProfileSetupPage(
+      tester,
+      password: 'password123',
+      confirmedPassword: 'password123',
+    );
+    await tester.pumpAndSettle();
+
+    await testAdvancedSetupPage(tester);
+    await testApplyingChangesPage(tester);
+    await tester.pumpAndSettle();
+
+    await testSetupCompletePage(tester);
+    await tester.pumpAndSettle();
+  });
+}

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -18,6 +18,20 @@ Future<void> testSplashPage(
   await tester.pumpUntil(find.byType(UbuntuWslSetupWizard));
 }
 
+Future<void> testInstallationSlidesPage(WidgetTester tester) async {
+  await tester.pumpUntil(find.byType(InstallationSlidesPage));
+  await tester.pump();
+  expectPage(
+    tester,
+    InstallationSlidesPage,
+    (lang) => lang.installationSlidesWelcome,
+  );
+  final rightIcon = find.byIcon(Icons.chevron_right);
+  expect(rightIcon, findsOneWidget);
+  await tester.tap(rightIcon);
+  await tester.pump();
+}
+
 Future<void> testSelectYourLanguagePage(
   WidgetTester tester, {
   String? language,

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -4,8 +4,19 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages.dart';
+import 'package:ubuntu_wsl_setup/splash_screen.dart';
+import 'package:ubuntu_wsl_setup/wizard.dart';
 
 import '../test/test_utils.dart';
+
+Future<void> testSplashPage(
+  WidgetTester tester, {
+  bool expectClose = false,
+}) async {
+  await tester.pumpUntil(find.byType(SplashScreen));
+  expect(find.byType(AnimatedSwitcher), findsOneWidget);
+  await tester.pumpUntil(find.byType(UbuntuWslSetupWizard));
+}
 
 Future<void> testSelectYourLanguagePage(
   WidgetTester tester, {

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -158,5 +158,5 @@ void expectPage(
 ) {
   LangTester.type = page;
   expect(find.byType(page), findsOneWidget);
-  expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);
+  expect(find.widgetWithText(AppBar, title(tester.lang)), findsWidgets);
 }

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_test/utils.dart';
+import 'package:ubuntu_wsl_setup/l10n.dart';
+import 'package:ubuntu_wsl_setup/pages.dart';
+
+import '../test/test_utils.dart';
+
+Future<void> testSelectYourLanguagePage(
+  WidgetTester tester, {
+  String? language,
+}) async {
+  expectPage(tester, SelectLanguagePage, (lang) => lang.selectLanguageTitle);
+
+  if (language != null) {
+    final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
+    expect(tile, findsOneWidget);
+    final viewRect = tester.getRect(find.byType(ListView));
+    await tester.scrollUntilVisible(tile, viewRect.height / 2);
+    await tester.pump();
+    await tester.tap(tile);
+    await tester.pump();
+  }
+  await tester.pumpAndSettle();
+
+  // For now toggling this check box won't cause any noticeable behavior change in dry-run.
+  await tester.toggleCheckbox(
+    label: tester.lang.installLangPacksTitle(language ?? ''),
+    value: false,
+  );
+
+  await tester.tapContinue();
+}
+
+Future<void> testProfileSetupPage(
+  WidgetTester tester, {
+  IdentityData? profile,
+  String? password,
+  String? confirmedPassword,
+  bool? showAdvancedOptions,
+}) async {
+  expectPage(tester, ProfileSetupPage, (lang) => lang.profileSetupTitle);
+
+  await tester.enterTextValue(
+    label: tester.lang.profileSetupRealnameLabel,
+    value: profile?.realname,
+  );
+  await tester.enterTextValue(
+    label: tester.lang.profileSetupUsernameHint,
+    value: profile?.username,
+  );
+  await tester.enterTextValue(
+    label: tester.lang.profileSetupPasswordHint,
+    value: password,
+  );
+  await tester.enterTextValue(
+    label: tester.lang.profileSetupConfirmPasswordHint,
+    value: confirmedPassword,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.profileSetupShowAdvancedOptions,
+    value: showAdvancedOptions,
+  );
+  await tester.pumpAndSettle();
+
+  await tester.tapContinue();
+}
+
+Future<void> testAdvancedSetupPage(
+  WidgetTester tester, {
+  WSLConfigurationBase? config,
+}) async {
+  expectPage(tester, AdvancedSetupPage, (lang) => lang.advancedSetupTitle);
+
+  await tester.enterTextValue(
+    label: tester.lang.advancedSetupMountLocationHint,
+    value: config?.automountRoot,
+  );
+  await tester.enterTextValue(
+    label: tester.lang.advancedSetupMountOptionHint,
+    value: config?.automountOptions,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.advancedSetupHostGenerationTitle,
+    value: config?.networkGeneratehosts,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.advancedSetupResolvConfGenerationTitle,
+    value: config?.networkGenerateresolvconf,
+  );
+  await tester.pumpAndSettle();
+
+  await tester.tapButton(label: tester.lang.setupButton, highlighted: true);
+}
+
+Future<void> testApplyingChangesPage(
+  WidgetTester tester, {
+  bool expectClose = false,
+}) async {
+  await tester.pumpUntil(find.byType(ApplyingChangesPage));
+  expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
+
+  if (expectClose) {
+    expect(await waitForWindowClosed(), isTrue);
+  }
+}
+
+Future<void> testConfigurationUIPage(
+  WidgetTester tester, {
+  WSLConfigurationAdvanced? config,
+}) async {
+  expectPage(tester, ConfigurationUIPage, (lang) => lang.configurationUITitle);
+
+  await tester.toggleCheckbox(
+    label: tester.lang.configurationUIAutoMountSubtitle,
+    value: config?.automountEnabled,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.configurationUIMountFstabSubtitle,
+    value: config?.automountMountfstab,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.configurationUIInteroperabilitySubtitle,
+    value: config?.interopEnabled,
+  );
+  await tester.toggleCheckbox(
+    label: tester.lang.configurationUIInteropAppendWindowsPathSubtitle,
+    value: config?.interopAppendwindowspath,
+  );
+  await tester.pumpAndSettle();
+
+  await tester.tapButton(label: tester.lang.saveButton, highlighted: true);
+}
+
+Future<void> testSetupCompletePage(
+  WidgetTester tester, {
+  String? username,
+}) async {
+  expectPage(tester, SetupCompletePage, (lang) => lang.setupCompleteTitle);
+
+  if (username != null) {
+    expect(
+      find.text(tester.lang.setupCompleteHeader(username)),
+      findsOneWidget,
+    );
+  }
+
+  final windowClosed = waitForWindowClosed();
+  await tester.tapButton(label: tester.lang.finishButton);
+  await expectLater(windowClosed, completion(isTrue));
+}
+
+void expectPage(
+  WidgetTester tester,
+  Type page,
+  String Function(AppLocalizations lang) title,
+) {
+  LangTester.type = page;
+  expect(find.byType(page), findsOneWidget);
+  expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);
+}

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -1,15 +1,12 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/main.dart' as app;
-import 'package:ubuntu_wsl_setup/pages.dart';
 import 'package:ubuntu_wsl_setup/routes.dart';
 
-import '../test/test_utils.dart';
+import 'test_pages.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -97,158 +94,4 @@ void main() {
 
     await verifyConfigFile('reconfiguration/wsl.conf');
   });
-}
-
-Future<void> testSelectYourLanguagePage(
-  WidgetTester tester, {
-  String? language,
-}) async {
-  expectPage(tester, SelectLanguagePage, (lang) => lang.selectLanguageTitle);
-
-  if (language != null) {
-    final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
-    expect(tile, findsOneWidget);
-    final viewRect = tester.getRect(find.byType(ListView));
-    await tester.scrollUntilVisible(tile, viewRect.height / 2);
-    await tester.pump();
-    await tester.tap(tile);
-    await tester.pump();
-  }
-  await tester.pumpAndSettle();
-
-  // For now toggling this check box won't cause any noticeable behavior change in dry-run.
-  await tester.toggleCheckbox(
-    label: tester.lang.installLangPacksTitle(language ?? ''),
-    value: false,
-  );
-
-  await tester.tapContinue();
-}
-
-Future<void> testProfileSetupPage(
-  WidgetTester tester, {
-  IdentityData? profile,
-  String? password,
-  String? confirmedPassword,
-  bool? showAdvancedOptions,
-}) async {
-  expectPage(tester, ProfileSetupPage, (lang) => lang.profileSetupTitle);
-
-  await tester.enterTextValue(
-    label: tester.lang.profileSetupRealnameLabel,
-    value: profile?.realname,
-  );
-  await tester.enterTextValue(
-    label: tester.lang.profileSetupUsernameHint,
-    value: profile?.username,
-  );
-  await tester.enterTextValue(
-    label: tester.lang.profileSetupPasswordHint,
-    value: password,
-  );
-  await tester.enterTextValue(
-    label: tester.lang.profileSetupConfirmPasswordHint,
-    value: confirmedPassword,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.profileSetupShowAdvancedOptions,
-    value: showAdvancedOptions,
-  );
-  await tester.pumpAndSettle();
-
-  await tester.tapContinue();
-}
-
-Future<void> testAdvancedSetupPage(
-  WidgetTester tester, {
-  WSLConfigurationBase? config,
-}) async {
-  expectPage(tester, AdvancedSetupPage, (lang) => lang.advancedSetupTitle);
-
-  await tester.enterTextValue(
-    label: tester.lang.advancedSetupMountLocationHint,
-    value: config?.automountRoot,
-  );
-  await tester.enterTextValue(
-    label: tester.lang.advancedSetupMountOptionHint,
-    value: config?.automountOptions,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.advancedSetupHostGenerationTitle,
-    value: config?.networkGeneratehosts,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.advancedSetupResolvConfGenerationTitle,
-    value: config?.networkGenerateresolvconf,
-  );
-  await tester.pumpAndSettle();
-
-  await tester.tapButton(label: tester.lang.setupButton, highlighted: true);
-}
-
-Future<void> testApplyingChangesPage(
-  WidgetTester tester, {
-  bool expectClose = false,
-}) async {
-  await tester.pumpUntil(find.byType(ApplyingChangesPage));
-  expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
-
-  if (expectClose) {
-    expect(await waitForWindowClosed(), isTrue);
-  }
-}
-
-Future<void> testConfigurationUIPage(
-  WidgetTester tester, {
-  WSLConfigurationAdvanced? config,
-}) async {
-  expectPage(tester, ConfigurationUIPage, (lang) => lang.configurationUITitle);
-
-  await tester.toggleCheckbox(
-    label: tester.lang.configurationUIAutoMountSubtitle,
-    value: config?.automountEnabled,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.configurationUIMountFstabSubtitle,
-    value: config?.automountMountfstab,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.configurationUIInteroperabilitySubtitle,
-    value: config?.interopEnabled,
-  );
-  await tester.toggleCheckbox(
-    label: tester.lang.configurationUIInteropAppendWindowsPathSubtitle,
-    value: config?.interopAppendwindowspath,
-  );
-  await tester.pumpAndSettle();
-
-  await tester.tapButton(label: tester.lang.saveButton, highlighted: true);
-}
-
-Future<void> testSetupCompletePage(
-  WidgetTester tester, {
-  String? username,
-}) async {
-  expectPage(tester, SetupCompletePage, (lang) => lang.setupCompleteTitle);
-
-  if (username != null) {
-    expect(
-      find.text(tester.lang.setupCompleteHeader(username)),
-      findsOneWidget,
-    );
-  }
-
-  final windowClosed = waitForWindowClosed();
-  await tester.tapButton(label: tester.lang.finishButton);
-  await expectLater(windowClosed, completion(isTrue));
-}
-
-void expectPage(
-  WidgetTester tester,
-  Type page,
-  String Function(AppLocalizations lang) title,
-) {
-  LangTester.type = page;
-  expect(find.byType(page), findsOneWidget);
-  expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);
 }


### PR DESCRIPTION
This reuses most of the existing code for the `ubuntu_wsl_setup` package integration tests to create new scenarios that will run as part of the end-to-end test I demonstrated last Friday. Since those test cases depend on WSL, the files were tagged with `@TestOn('windows')` to avoid disturbing this repository CI workflows.

The aim of those additional test scenarios is drive the GUI until the end of a certain workflow. We can assert specific UI elements, but goldens should not be checked in here, because some effects are only possible after the parent process of the test drive exits.

There is a subtle change in the `expectPage()` function introduced due the desire to test the slideshow, which places more than one widget with the same appbar title, thus we match against `findsWidgets` instead of `findsOneWidget` (662e9d8f8103cc73b0d116097a66c4bbe149d2a3).

```diff
void expectPage(
  WidgetTester tester,
  Type page,
  String Function(AppLocalizations lang) title,
) {
  LangTester.type = page;
  expect(find.byType(page), findsOneWidget);
-  expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);
+  expect(find.widgetWithText(AppBar, title(tester.lang)), findsWidgets);
}
``` 