### PR TITLE
[WSL] Skip listening to server status change if it's not installing

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
@@ -23,6 +23,11 @@ class ApplyingChangesModel extends SafeChangeNotifier with SystemShutdown {
   bool _previousState = true;
 
   void init({required VoidCallback onDoneTransition}) {
+    if (null != _monitor.status && !_monitor.status!.state.isInstalling) {
+      _previousState = false;
+      onDoneTransition();
+      return;
+    }
     _sub = _monitor.onStatusChanged.listen((status) {
       if (status?.state.isInstalling == false && _previousState == true) {
         _previousState = false;

--- a/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_model_test.dart
@@ -22,6 +22,7 @@ void main() {
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
+    when(monitor.status).thenAnswer((_) => statuses[0]);
     final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
     model.init(onDoneTransition: () => calledBack = true);
@@ -42,6 +43,7 @@ void main() {
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
+    when(monitor.status).thenAnswer((_) => statuses[0]);
     final model = ApplyingChangesModel(client, monitor);
     var calledBackCount = 0;
     model.init(onDoneTransition: () => calledBackCount++);
@@ -59,6 +61,7 @@ void main() {
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((realInvocation) => Stream.fromIterable(statuses));
+    when(monitor.status).thenAnswer((_) => statuses[0]);
     final client = MockSubiquityClient();
     final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
@@ -79,12 +82,26 @@ void main() {
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged)
         .thenAnswer((_) => Stream.fromIterable(statuses));
+    when(monitor.status).thenAnswer((_) => statuses[0]);
     final model = ApplyingChangesModel(client, monitor);
     var calledBack = false;
     model.init(onDoneTransition: () => calledBack = true);
     // Forces the stream to emit.
     await expectLater(monitor.onStatusChanged, emitsThrough(last));
     await expectLater(calledBack, isFalse);
+  });
+  test('skip listening if already DONE', () async {
+    final done = testStatus(ApplicationState.DONE);
+    final client = MockSubiquityClient();
+    final monitor = MockSubiquityStatusMonitor();
+    when(monitor.status).thenAnswer((_) => done);
+    when(monitor.onStatusChanged).thenAnswer((_) => const Stream.empty());
+    final model = ApplyingChangesModel(client, monitor);
+    var calledBack = false;
+    model.init(onDoneTransition: () => calledBack = true);
+
+    expect(calledBack, isTrue);
+    verifyNever(monitor.onStatusChanged);
   });
 }
 

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -104,6 +104,7 @@ void main() {
     final client = MockSubiquityClient();
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.onStatusChanged).thenAnswer((_) => Stream.value(null));
+    when(monitor.status).thenAnswer((_) => null);
     registerMockService<SubiquityClient>(client);
     registerMockService<SubiquityStatusMonitor>(monitor);
     await tester.pumpWidget(buildApp(


### PR DESCRIPTION
During integration testing it's possible that `ApplyingChangesModel` start listening after the server is already DONE. If so, the next state change would be to null (shutdown) which only happens if the GUI ends. But GUI won't exit because it's expecting a status change. Thus, infinite loop.
We've seen this consistently with the end-to-end workflow on Windows with a broken rootfs image, causing the server to exit sooner than anticipated. It's possible that a similar situation is also happening on the Linux integration testing.
