### PR TITLE
Where are you: swap timezone map & dropdowns

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -73,20 +73,9 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
       title: YaruWindowTitleBar(
         title: Text(lang.whereAreYouPageTitle),
       ),
-      headerPadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
       content: Column(
         children: <Widget>[
-          Expanded(
-            child: TimezoneMap(
-              offset: controller.selectedLocation?.offset,
-              marker: controller.selectedLocation?.coordinates,
-              onPressed: (coordinates) => controller
-                  .searchMap(coordinates)
-                  .then(controller.selectLocation),
-            ),
-          ),
-          const SizedBox(height: kContentSpacing),
           Padding(
             padding: kContentPadding,
             child: Row(
@@ -147,6 +136,16 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
                   ),
                 ),
               ],
+            ),
+          ),
+          const SizedBox(height: kContentSpacing),
+          Expanded(
+            child: TimezoneMap(
+              offset: controller.selectedLocation?.offset,
+              marker: controller.selectedLocation?.coordinates,
+              onPressed: (coordinates) => controller
+                  .searchMap(coordinates)
+                  .then(controller.selectLocation),
             ),
           ),
         ],


### PR DESCRIPTION
Leaving a 180px vertical gap below the dropdowns makes the timezone map look squeezed (the slightly wrong window height (#697) makes it even worse). Therefore, I'd propose swapping the order to let the popups open over the timezone map.

| Before | Design | Proposal |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/140617/196179995-6e5e7e99-2efa-4c1e-b575-8d380745a925.png) | ![image](https://user-images.githubusercontent.com/140617/196180429-e52195d0-29c6-4dbc-99c1-37331bda344b.png) | ![image](https://user-images.githubusercontent.com/140617/196180744-3c76a442-0bf4-460d-86a1-d0389a6a1762.png) |
| ![image](https://user-images.githubusercontent.com/140617/196180048-9958d9e8-5d8c-442d-9421-f56d2127ac2e.png) | ![image](https://user-images.githubusercontent.com/140617/196180493-b7a9aabb-ff56-4e74-bc06-68bf51354116.png) | ![image](https://user-images.githubusercontent.com/140617/196180812-cd0305e1-6154-46d1-9e77-c322af0c1260.png) |
| ![image](https://user-images.githubusercontent.com/140617/196180096-3bf2bc4e-1bb4-4209-a8b6-001033d5a77f.png) | ![image](https://user-images.githubusercontent.com/140617/196180543-ccdf87a6-32e7-46b9-b2b6-1e60a5dcb61d.png) | ![image](https://user-images.githubusercontent.com/140617/196180873-d6bebc9b-fe7c-4b86-b12e-f1e23ddabe0e.png) |

Design: https://people.canonical.com/~platform/desktop/installer/13.%20Where%20Are%20You/#artboard0
Resolves: #1189