### PR TITLE
[WSL] Skip listening to server status change if it's not installing - PART II

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -39,11 +39,13 @@ class _ApplyingChangesPageState extends State<ApplyingChangesPage> {
     super.initState();
     final model = Provider.of<ApplyingChangesModel>(context, listen: false);
     model.init(onDoneTransition: () {
-      if (Wizard.of(context).hasNext) {
-        Wizard.of(context).next();
-      } else {
-        model.reboot(immediate: false);
-      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && Wizard.of(context).hasNext) {
+          Wizard.of(context).next();
+        } else {
+          model.reboot(immediate: false);
+        }
+      });
     });
   }
 

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -56,9 +56,7 @@ void main() {
     final model = MockApplyingChangesModel();
     when(model.init(onDoneTransition: captureAnyNamed('onDoneTransition')))
         .thenAnswer((realInvocation) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        realInvocation.namedArguments[Symbol('onDoneTransition')]();
-      });
+      realInvocation.namedArguments[Symbol('onDoneTransition')]();
     });
     await tester.pumpWidget(buildApp(
       builder: (_) => buildPage(model),
@@ -73,9 +71,7 @@ void main() {
     final model = MockApplyingChangesModel();
     when(model.init(onDoneTransition: captureAnyNamed('onDoneTransition')))
         .thenAnswer((realInvocation) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        realInvocation.namedArguments[Symbol('onDoneTransition')]();
-      });
+      realInvocation.namedArguments[Symbol('onDoneTransition')]();
     });
 
     await tester.pumpWidget(buildApp(


### PR DESCRIPTION
Since #1178 it is now possible that the page causes the router to call setState during build. The solution was already present on tests, but ideally that should have been moved into the page itself as part of that PR.
This completes that job.