### PR TITLE
Desktop installer: add generic service for config values

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gsettings/gsettings.dart';
+import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
@@ -75,6 +76,9 @@ Future<void> runInstallerApp(
   final geodata = Geodata.asset();
   final geoname = Geoname.ubuntu(geodata: geodata);
 
+  final baseName = p.basename(Platform.resolvedExecutable);
+
+  registerService(() => ConfigService('/tmp/$baseName.conf'));
   registerService(() => DiskStorageService(subiquityClient));
   registerService(() => GeoService(sources: [geodata, geoname]));
   registerService(JournalService.new);

--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -1,5 +1,6 @@
 export 'package:ubuntu_service/ubuntu_service.dart';
 
+export 'services/config_service.dart' hide log;
 export 'services/disk_storage_service.dart' hide log;
 export 'services/journal_service.dart';
 export 'services/network_service.dart';

--- a/packages/ubuntu_desktop_installer/lib/services/config_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/config_service.dart
@@ -1,0 +1,82 @@
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:meta/meta.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+/// @internal
+final log = Logger('config');
+
+class ConfigService {
+  ConfigService(this._path, {@visibleForTesting FileSystem? fs})
+      : _fs = fs ?? const LocalFileSystem();
+
+  final String _path;
+  final FileSystem _fs;
+
+  Future<Map<String, String?>> load() async {
+    final file = _fs.file(_path);
+    try {
+      final config =
+          await file.readAsLines().then((lines) => lines.toKeyValueMap());
+      log.debug('loaded ${config.length} entries from $_path');
+      return config;
+    } on FileSystemException catch (e) {
+      if (file.existsSync()) {
+        log.error('failed to load $_path', e);
+      }
+      return {};
+    }
+  }
+
+  Future<void> save(Map<String, String?> config) async {
+    try {
+      final file = _fs.file(_path);
+      final data = config.toKeyValueList().join('\n');
+      await file.create(recursive: true);
+      await file.writeAsString('$data\n');
+      log.debug('saved ${config.length} entries to $_path');
+    } on FileSystemException catch (e) {
+      log.error('failed to save $_path', e);
+    }
+  }
+}
+
+extension _KeyValueList on List<String> {
+  Map<String, String?> toKeyValueMap() {
+    return Map.fromEntries(
+      where((line) => !line.startsWith('#'))
+          .map((line) => line.split('='))
+          .where((parts) => parts.length == 2)
+          .map((parts) => MapEntry(parts.first, parts.last.unquote())),
+    );
+  }
+}
+
+extension _KeyValueMap on Map<String, String?> {
+  List<String> toKeyValueList() {
+    return entries
+        .map((entry) => '${entry.key}=${entry.value?.maybeQuote() ?? ''}')
+        .toList();
+  }
+}
+
+extension _StringX on String {
+  String removePrefix(String prefix) {
+    if (!startsWith(prefix)) return this;
+    return substring(prefix.length);
+  }
+
+  String removeSuffix(String suffix) {
+    if (!endsWith(suffix)) return this;
+    return substring(0, length - suffix.length);
+  }
+
+  String unquote() {
+    return removePrefix('"')
+        .removePrefix("'")
+        .removeSuffix('"')
+        .removeSuffix("'");
+  }
+
+  String maybeQuote() => contains(' ') ? '"$this"' : this;
+}

--- a/packages/ubuntu_desktop_installer/test/services/config_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/config_service_test.dart
@@ -1,0 +1,51 @@
+import 'package:file/memory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+
+void main() {
+  test('load existing config', () async {
+    final fs = MemoryFileSystem.test();
+    final file = fs.file('/foo/bar.conf');
+
+    file.createSync(recursive: true);
+    file.writeAsStringSync('''
+Num=1
+Empty=
+Str="foo bar"
+''');
+
+    final config = ConfigService(file.path, fs: fs);
+    expect(await config.load(), {
+      'Num': '1',
+      'Empty': '',
+      'Str': 'foo bar',
+    });
+  });
+
+  test('missing config', () async {
+    final fs = MemoryFileSystem.test();
+    final file = fs.file('/foo/bar.conf');
+
+    final config = ConfigService(file.path, fs: fs);
+    expect(await config.load(), isEmpty);
+  });
+
+  test('save config', () async {
+    final fs = MemoryFileSystem.test();
+    final file = fs.file('/foo/bar.conf');
+
+    final config = ConfigService(file.path, fs: fs);
+    await config.save({
+      'Num': '1',
+      'Empty': '',
+      'Str': 'foo bar',
+    });
+
+    expect(file.existsSync(), isTrue);
+    expect(file.readAsStringSync(), '''
+Num=1
+Empty=
+Str="foo bar"
+''');
+  });
+}


### PR DESCRIPTION
The first and foremost use-case is to write the auto-login user name, which is then read and used in subiquity postinst scripts.

/tmp/ubuntu_desktop_installer.conf:
```
AutoLoginUser=ubuntu
```

P.S. I did consider using the existing `ini` or `ini_file` packages but neither of them allows .ini files without sections. I ended up rolling my own overly simple `key=value` file helper that can be sourced straight into subiquity postinst scripts.