### PR TITLE
Add postinst script for telemetry

### DIFF
--- a/snap/local/postinst.d/99_telemetry_done
+++ b/snap/local/postinst.d/99_telemetry_done
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+telemetry=/var/log/installer/telemetry
+
+if [ ! -f $telemetry ]; then
+    exit
+fi
+
+current_time=$(date +%s)
+created_at=$(stat --format %W $telemetry)
+duration=$(($current_time - $created_at))
+
+# {
+#   ...
+#   "Stages": {
+#     "0": "welcome",
+#     ...
+#     "1234": "done" // <==
+#   }
+# }
+
+jq ".Stages.\"$duration\"=\"done\"" $telemetry > $telemetry.tmp
+mv $telemetry.tmp $telemetry

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,7 @@ parts:
       - cloud-init
       - libsystemd0
       - iso-codes
+      - jq
       - lsb-release
       - ssh-import-id
       - ntfs-3g


### PR DESCRIPTION
The script inserts the "done" stage into the telemetry JSON. The duration is calculated based on the creation time of the telemetry report.

The telemetry report is edited in place at `/var/log/installer/telemetry`. Subiquity copies the whole directory to `/target` right after the post-install step.

```json
{
  "Language": "en",
  "Minimal": false,
  "RestrictedAddons": false,
  "PartitionMethod": "use_device",
  "Type": "Flutter",
  "OEM": false,
  "Stages": {
    "0": "/welcome",
    "35": "/tryorinstall",
    "38": "/keyboardlayout",
    "39": "/updateothersoftware",
    "40": "/installationtype",
    "42": "/whereareyou",
    "44": "/whoareyou",
    "48": "/chooseyourlook",
    "49": "/installationslides",
    "80": "/installationcomplete",
    "1234": "done"
  }
}
```
Ref: #1057