### PR TITLE
TelemetryService: write the report on the disk as we go

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -368,14 +369,14 @@ class _UbuntuDesktopInstallerWizardObserver extends WizardObserver {
   @override
   void onInit(Route route) {
     if (route.settings.name != null) {
-      _telemetryService.addStage(route.settings.name!);
+      _telemetryService.addStage(route.settings.name!.removePrefix('/'));
     }
   }
 
   @override
   void onNext(Route route, Route previousRoute) {
     if (route.settings.name != null) {
-      _telemetryService.addStage(route.settings.name!);
+      _telemetryService.addStage(route.settings.name!.removePrefix('/'));
     }
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -78,13 +78,20 @@ Future<void> runInstallerApp(
 
   final baseName = p.basename(Platform.resolvedExecutable);
 
+  final telemetry = TelemetryService();
+  await telemetry.init({
+    'Type': 'Flutter',
+    'OEM': false,
+    'Media': ProductInfoExtractor().getProductInfo().toString(),
+  });
+
   registerService(() => ConfigService('/tmp/$baseName.conf'));
   registerService(() => DiskStorageService(subiquityClient));
   registerService(() => GeoService(sources: [geodata, geoname]));
   registerService(JournalService.new);
   registerService(() => NetworkService(subiquityClient));
   registerService(PowerService.new);
-  registerService(TelemetryService.new);
+  registerServiceInstance(telemetry);
   registerService(UdevService.new);
   registerService(UrlLauncher.new);
 
@@ -370,10 +377,5 @@ class _UbuntuDesktopInstallerWizardObserver extends WizardObserver {
     if (route.settings.name != null) {
       _telemetryService.addStage(route.settings.name!);
     }
-  }
-
-  @override
-  Future<void> onDone(Route route, Object? result) {
-    return _telemetryService.done();
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -95,9 +95,10 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
           context,
           onNext: () async {
             final telemetry = getService<TelemetryService>();
-            telemetry.setMinimal(
-                enabled: model.installationMode == InstallationMode.minimal);
-            telemetry.setRestrictedAddons(enabled: model.installThirdParty);
+            await telemetry.addMetrics({
+              'Minimal': model.installationMode == InstallationMode.minimal,
+              'RestrictedAddons': model.installThirdParty,
+            });
             await model.selectInstallationSource();
           },
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -102,7 +102,8 @@ class _WelcomePageState extends State<WelcomePage> {
           onNext: () {
             final locale = model.locale(model.selectedLanguageIndex);
             model.applyLocale(locale);
-            getService<TelemetryService>().setLanguage(locale.languageCode);
+            getService<TelemetryService>()
+                .addMetric('Language', locale.languageCode);
           },
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/services/telemetry_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/telemetry_service.dart
@@ -11,7 +11,9 @@ import 'package:ubuntu_logger/ubuntu_logger.dart';
 final log = Logger('telemetry');
 
 class TelemetryService {
-  TelemetryService() : _startTime = _uptime();
+  TelemetryService({@visibleForTesting FileSystem? fs})
+      : _fs = fs ?? const LocalFileSystem(),
+        _startTime = _uptime();
 
   static String get reportLocation {
     if (kDebugMode) {
@@ -22,9 +24,7 @@ class TelemetryService {
   }
 
   final int _startTime;
-  final Map<String, dynamic> _metrics = {};
-  final Map<String, String> _stages = {};
-  bool _done = false;
+  final FileSystem _fs;
 
   static int _uptime() {
     return sysinfo()?.uptime.inSeconds ?? 0;
@@ -34,39 +34,50 @@ class TelemetryService {
     return _uptime() - _startTime;
   }
 
-  void addStage(String name) {
-    _stages[_timestamp().toString()] = name;
-  }
-
-  void setLanguage(String language) {
-    _metrics['Language'] = language;
-  }
-
-  void setMinimal({required bool enabled}) {
-    _metrics['Minimal'] = enabled;
-  }
-
-  void setRestrictedAddons({required bool enabled}) {
-    _metrics['RestrictedAddons'] = enabled;
-  }
-
-  void setPartitionMethod(String method) {
-    _metrics['PartitionMethod'] = method;
-  }
-
-  Future<void> done({
-    @visibleForTesting FileSystem fs = const LocalFileSystem(),
-  }) async {
-    assert(!_done);
-    _done = true;
-    addStage('done');
-    _metrics['Type'] = 'Flutter';
-    _metrics['OEM'] = false;
-    _metrics['Stages'] = _stages;
-    final file = fs.file(reportLocation);
-    try {
+  Future<void> init([Map<String, dynamic> metrics = const {}]) async {
+    final file = _fs.file(reportLocation);
+    if (await file.exists()) {
+      await file.delete();
+    } else {
       await file.parent.create(recursive: true);
-      await file.writeAsString(json.encode(_metrics), flush: true);
+    }
+    return _writeMetrics(metrics);
+  }
+
+  Future<void> addStage(String name) async {
+    final metrics = await _readMetrics();
+    final stages = metrics['Stages'] ?? {};
+    stages[_timestamp().toString()] = name;
+    metrics['Stages'] = stages;
+    return _writeMetrics(metrics);
+  }
+
+  Future<void> addMetric(String key, dynamic value) {
+    return addMetrics({key: value});
+  }
+
+  Future<void> addMetrics(Map<String, dynamic> entries) async {
+    final metrics = await _readMetrics();
+    metrics.addAll(entries);
+    return _writeMetrics(metrics);
+  }
+
+  Future<Map<String, dynamic>> _readMetrics() async {
+    try {
+      final file = _fs.file(reportLocation);
+      final metrics = await file.readAsString();
+      return json.decode(metrics) as Map<String, dynamic>;
+    } on FileSystemException {
+      return {};
+    } on FormatException {
+      return {};
+    }
+  }
+
+  Future<void> _writeMetrics(Map<String, dynamic> metrics) async {
+    try {
+      final file = _fs.file(reportLocation);
+      await file.writeAsString(json.encode(metrics), flush: true);
       log.debug('Wrote report to $reportLocation');
     } on FileSystemException catch (e) {
       log.error('Failed to write report to $reportLocation (${e.message})');

--- a/packages/ubuntu_desktop_installer/lib/services/telemetry_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/telemetry_service.dart
@@ -41,6 +41,7 @@ class TelemetryService {
     } else {
       await file.parent.create(recursive: true);
     }
+    log.debug('Writing report to $reportLocation');
     return _writeMetrics(metrics);
   }
 
@@ -78,7 +79,6 @@ class TelemetryService {
     try {
       final file = _fs.file(reportLocation);
       await file.writeAsString(json.encode(metrics), flush: true);
-      log.debug('Wrote report to $reportLocation');
     } on FileSystemException catch (e) {
       log.error('Failed to write report to $reportLocation (${e.message})');
     }

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -73,42 +73,43 @@ void main() {
 
     final telemetry = MockTelemetryService();
     final model = InstallationTypeModel(disks, telemetry);
-    verifyNever(telemetry.setPartitionMethod(any));
+    verifyNever(telemetry.addMetric('PartitionMethod', any));
 
     model.installationType = InstallationType.erase;
     await model.save();
-    verify(telemetry.setPartitionMethod('use_device')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'use_device')).called(1);
     reset(telemetry);
 
     model.installationType = InstallationType.reinstall;
     await model.save();
-    verify(telemetry.setPartitionMethod('reinstall_partition')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'reinstall_partition'))
+        .called(1);
     reset(telemetry);
 
     model.installationType = InstallationType.alongside;
     await model.save();
-    verify(telemetry.setPartitionMethod('resize_use_free')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'resize_use_free')).called(1);
     reset(telemetry);
 
     model.installationType = InstallationType.manual;
     await model.save();
-    verify(telemetry.setPartitionMethod('manual')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'manual')).called(1);
     reset(telemetry);
 
     model.advancedFeature = AdvancedFeature.lvm;
     await model.save();
-    verify(telemetry.setPartitionMethod('use_lvm')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'use_lvm')).called(1);
     reset(telemetry);
 
     model.advancedFeature = AdvancedFeature.zfs;
     await model.save();
-    verify(telemetry.setPartitionMethod('use_zfs')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'use_zfs')).called(1);
     reset(telemetry);
 
     when(disks.useEncryption).thenReturn(true);
     model.advancedFeature = AdvancedFeature.none;
     await model.save();
-    verify(telemetry.setPartitionMethod('use_crypto')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'use_crypto')).called(1);
     reset(telemetry);
   });
 

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -5,8 +5,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
 
-import 'package:file/file.dart' as _i6;
-import 'package:file/local.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart'
@@ -282,54 +280,46 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
   }
 
   @override
-  void addStage(String? name) => super.noSuchMethod(
+  _i4.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [metrics],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> addStage(String? name) => (super.noSuchMethod(
         Invocation.method(
           #addStage,
           [name],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void setLanguage(String? language) => super.noSuchMethod(
-        Invocation.method(
-          #setLanguage,
-          [language],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setMinimal({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setMinimal,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setRestrictedAddons({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setRestrictedAddons,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setPartitionMethod(String? method) => super.noSuchMethod(
-        Invocation.method(
-          #setPartitionMethod,
-          [method],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  _i4.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
+  _i4.Future<void> addMetric(
+    String? key,
+    dynamic value,
+  ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #done,
-          [],
-          {#fs: fs},
+          #addMetric,
+          [
+            key,
+            value,
+          ],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> addMetrics(Map<String, dynamic>? entries) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addMetrics,
+          [entries],
         ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
@@ -6,8 +6,6 @@
 import 'dart:async' as _i3;
 import 'dart:ui' as _i4;
 
-import 'package:file/file.dart' as _i6;
-import 'package:file/local.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_model.dart'
     as _i2;
@@ -175,54 +173,46 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
   }
 
   @override
-  void addStage(String? name) => super.noSuchMethod(
+  _i3.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [metrics],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> addStage(String? name) => (super.noSuchMethod(
         Invocation.method(
           #addStage,
           [name],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void setLanguage(String? language) => super.noSuchMethod(
-        Invocation.method(
-          #setLanguage,
-          [language],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setMinimal({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setMinimal,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setRestrictedAddons({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setRestrictedAddons,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setPartitionMethod(String? method) => super.noSuchMethod(
-        Invocation.method(
-          #setPartitionMethod,
-          [method],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  _i3.Future<void> done({_i6.FileSystem? fs = const _i7.LocalFileSystem()}) =>
+  _i3.Future<void> addMetric(
+    String? key,
+    dynamic value,
+  ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #done,
-          [],
-          {#fs: fs},
+          #addMetric,
+          [
+            key,
+            value,
+          ],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> addMetrics(Map<String, dynamic>? entries) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addMetrics,
+          [entries],
         ),
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.mocks.dart
@@ -5,8 +5,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
 
-import 'package:file/file.dart' as _i4;
-import 'package:file/local.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
     as _i2;
@@ -31,54 +29,46 @@ class MockTelemetryService extends _i1.Mock implements _i2.TelemetryService {
   }
 
   @override
-  void addStage(String? name) => super.noSuchMethod(
+  _i3.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [metrics],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> addStage(String? name) => (super.noSuchMethod(
         Invocation.method(
           #addStage,
           [name],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  void setLanguage(String? language) => super.noSuchMethod(
-        Invocation.method(
-          #setLanguage,
-          [language],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setMinimal({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setMinimal,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setRestrictedAddons({required bool? enabled}) => super.noSuchMethod(
-        Invocation.method(
-          #setRestrictedAddons,
-          [],
-          {#enabled: enabled},
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void setPartitionMethod(String? method) => super.noSuchMethod(
-        Invocation.method(
-          #setPartitionMethod,
-          [method],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  _i3.Future<void> done({_i4.FileSystem? fs = const _i5.LocalFileSystem()}) =>
+  _i3.Future<void> addMetric(
+    String? key,
+    dynamic value,
+  ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #done,
-          [],
-          {#fs: fs},
+          #addMetric,
+          [
+            key,
+            value,
+          ],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> addMetrics(Map<String, dynamic>? entries) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addMetrics,
+          [entries],
         ),
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),


### PR DESCRIPTION
Instead of waiting until the GUI is closed, write stages and metrics right away on the disk. This ensures that the report is available for the telemetry post-install script (#1201) when Subiquity is just about to finish the installation and copy the telemetry report on the target.

Ref: #1057