### PR TITLE
Use ubuntu_logger 0.0.1

### DIFF
--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -15,10 +15,7 @@ dependencies:
   package_config: ^2.0.2
   path: ^1.8.0
   synchronized: ^3.0.0
-  ubuntu_logger:
-    git:
-      url: https://github.com/canonical/ubuntu-flutter-plugins.git
-      path: packages/ubuntu_logger
+  ubuntu_logger: ^0.0.1
   xdg_directories: ^0.2.0
 
 dev_dependencies:

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -46,10 +46,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_localizations
-  ubuntu_logger:
-    git:
-      url: https://github.com/canonical/ubuntu-flutter-plugins.git
-      path: packages/ubuntu_logger
+  ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0
   ubuntu_widgets:
     git:

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -27,10 +27,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_localizations
-  ubuntu_logger:
-    git:
-      url: https://github.com/canonical/ubuntu-flutter-plugins.git
-      path: packages/ubuntu_logger
+  ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0
   ubuntu_widgets:
     git:

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -24,10 +24,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_localizations
-  ubuntu_logger:
-    git:
-      url: https://github.com/canonical/ubuntu-flutter-plugins.git
-      path: packages/ubuntu_logger
+  ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.0
   ubuntu_widgets:
     git:


### PR DESCRIPTION
This takes us one step closer to deterministic builds. Now that we have the Renovate bot automatically proposing updates, convenience is no longer an excuse to use the latest main straight from Git. :)

Ref: #1158