### PR TITLE
Update subiquity

### DIFF
--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -375,10 +375,44 @@ class GuidedChoice with _$GuidedChoice {
     required String diskId,
     @Default(false) bool useLvm,
     String? password,
+    @Default(false) bool useTpm,
   }) = _GuidedChoice;
 
   factory GuidedChoice.fromJson(Map<String, dynamic> json) =>
       _$GuidedChoiceFromJson(json);
+}
+
+enum StorageEncryptionSupport {
+  DISABLED,
+  AVAILABLE,
+  UNAVAILABLE,
+  DEFECTIVE,
+}
+
+enum StorageSafety {
+  UNSET,
+  ENCRYPTED,
+  PREFER_ENCRYPTED,
+  PREFER_UNENCRYPTED,
+}
+
+enum EncryptionType {
+  NONE,
+  CRYPTSETUP,
+  DEVICE_SETUP_HOOK,
+}
+
+@freezed
+class StorageEncryption with _$StorageEncryption {
+  const factory StorageEncryption({
+    required StorageEncryptionSupport support,
+    required StorageSafety storageSafety,
+    required EncryptionType encryptionType,
+    required String unavailableReason,
+  }) = _StorageEncryption;
+
+  factory StorageEncryption.fromJson(Map<String, dynamic> json) =>
+      _$StorageEncryptionFromJson(json);
 }
 
 @freezed
@@ -387,6 +421,8 @@ class GuidedStorageResponse with _$GuidedStorageResponse {
     required ProbeStatus status,
     ErrorReportRef? errorReport,
     List<Disk>? disks,
+    @Default('') String coreBootClassicError,
+    StorageEncryption? storageEncryption,
   }) = _GuidedStorageResponse;
 
   factory GuidedStorageResponse.fromJson(Map<String, dynamic> json) =>
@@ -610,6 +646,16 @@ class DriversResponse with _$DriversResponse {
 }
 
 @freezed
+class CodecsData with _$CodecsData {
+  const factory CodecsData({
+    required bool install,
+  }) = _CodecsData;
+
+  factory CodecsData.fromJson(Map<String, dynamic> json) =>
+      _$CodecsDataFromJson(json);
+}
+
+@freezed
 class DriversPayload with _$DriversPayload {
   const factory DriversPayload({
     required bool install,
@@ -785,4 +831,56 @@ class WSLSetupOptions with _$WSLSetupOptions {
 
   factory WSLSetupOptions.fromJson(Map<String, dynamic> json) =>
       _$WSLSetupOptionsFromJson(json);
+}
+
+enum TaskStatus {
+  DO,
+  DOING,
+  DONE,
+  ABORT,
+  UNDO,
+  UNDOING,
+  HOLD,
+  ERROR,
+}
+
+@freezed
+class TaskProgress with _$TaskProgress {
+  const factory TaskProgress({
+    @Default('') String label,
+    @Default(0) int done,
+    @Default(0) int total,
+  }) = _TaskProgress;
+
+  factory TaskProgress.fromJson(Map<String, dynamic> json) =>
+      _$TaskProgressFromJson(json);
+}
+
+@freezed
+class Task with _$Task {
+  const factory Task({
+    required String id,
+    required String kind,
+    required String summary,
+    required TaskStatus status,
+    required TaskProgress progress,
+  }) = _Task;
+
+  factory Task.fromJson(Map<String, dynamic> json) => _$TaskFromJson(json);
+}
+
+@freezed
+class Change with _$Change {
+  const factory Change({
+    required String id,
+    required String kind,
+    required String summary,
+    required TaskStatus status,
+    required List<Task> tasks,
+    required bool ready,
+    String? err,
+    dynamic data,
+  }) = _Change;
+
+  factory Change.fromJson(Map<String, dynamic> json) => _$ChangeFromJson(json);
 }

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -4718,6 +4718,7 @@ mixin _$GuidedChoice {
   String get diskId => throw _privateConstructorUsedError;
   bool get useLvm => throw _privateConstructorUsedError;
   String? get password => throw _privateConstructorUsedError;
+  bool get useTpm => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -4731,7 +4732,7 @@ abstract class $GuidedChoiceCopyWith<$Res> {
           GuidedChoice value, $Res Function(GuidedChoice) then) =
       _$GuidedChoiceCopyWithImpl<$Res, GuidedChoice>;
   @useResult
-  $Res call({String diskId, bool useLvm, String? password});
+  $Res call({String diskId, bool useLvm, String? password, bool useTpm});
 }
 
 /// @nodoc
@@ -4750,6 +4751,7 @@ class _$GuidedChoiceCopyWithImpl<$Res, $Val extends GuidedChoice>
     Object? diskId = null,
     Object? useLvm = null,
     Object? password = freezed,
+    Object? useTpm = null,
   }) {
     return _then(_value.copyWith(
       diskId: null == diskId
@@ -4764,6 +4766,10 @@ class _$GuidedChoiceCopyWithImpl<$Res, $Val extends GuidedChoice>
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
               as String?,
+      useTpm: null == useTpm
+          ? _value.useTpm
+          : useTpm // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -4776,7 +4782,7 @@ abstract class _$$_GuidedChoiceCopyWith<$Res>
       __$$_GuidedChoiceCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String diskId, bool useLvm, String? password});
+  $Res call({String diskId, bool useLvm, String? password, bool useTpm});
 }
 
 /// @nodoc
@@ -4793,6 +4799,7 @@ class __$$_GuidedChoiceCopyWithImpl<$Res>
     Object? diskId = null,
     Object? useLvm = null,
     Object? password = freezed,
+    Object? useTpm = null,
   }) {
     return _then(_$_GuidedChoice(
       diskId: null == diskId
@@ -4807,6 +4814,10 @@ class __$$_GuidedChoiceCopyWithImpl<$Res>
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
               as String?,
+      useTpm: null == useTpm
+          ? _value.useTpm
+          : useTpm // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -4815,7 +4826,10 @@ class __$$_GuidedChoiceCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_GuidedChoice implements _GuidedChoice {
   const _$_GuidedChoice(
-      {required this.diskId, this.useLvm = false, this.password});
+      {required this.diskId,
+      this.useLvm = false,
+      this.password,
+      this.useTpm = false});
 
   factory _$_GuidedChoice.fromJson(Map<String, dynamic> json) =>
       _$$_GuidedChoiceFromJson(json);
@@ -4827,10 +4841,13 @@ class _$_GuidedChoice implements _GuidedChoice {
   final bool useLvm;
   @override
   final String? password;
+  @override
+  @JsonKey()
+  final bool useTpm;
 
   @override
   String toString() {
-    return 'GuidedChoice(diskId: $diskId, useLvm: $useLvm, password: $password)';
+    return 'GuidedChoice(diskId: $diskId, useLvm: $useLvm, password: $password, useTpm: $useTpm)';
   }
 
   @override
@@ -4841,12 +4858,14 @@ class _$_GuidedChoice implements _GuidedChoice {
             (identical(other.diskId, diskId) || other.diskId == diskId) &&
             (identical(other.useLvm, useLvm) || other.useLvm == useLvm) &&
             (identical(other.password, password) ||
-                other.password == password));
+                other.password == password) &&
+            (identical(other.useTpm, useTpm) || other.useTpm == useTpm));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, diskId, useLvm, password);
+  int get hashCode =>
+      Object.hash(runtimeType, diskId, useLvm, password, useTpm);
 
   @JsonKey(ignore: true)
   @override
@@ -4866,7 +4885,8 @@ abstract class _GuidedChoice implements GuidedChoice {
   const factory _GuidedChoice(
       {required final String diskId,
       final bool useLvm,
-      final String? password}) = _$_GuidedChoice;
+      final String? password,
+      final bool useTpm}) = _$_GuidedChoice;
 
   factory _GuidedChoice.fromJson(Map<String, dynamic> json) =
       _$_GuidedChoice.fromJson;
@@ -4878,8 +4898,215 @@ abstract class _GuidedChoice implements GuidedChoice {
   @override
   String? get password;
   @override
+  bool get useTpm;
+  @override
   @JsonKey(ignore: true)
   _$$_GuidedChoiceCopyWith<_$_GuidedChoice> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+StorageEncryption _$StorageEncryptionFromJson(Map<String, dynamic> json) {
+  return _StorageEncryption.fromJson(json);
+}
+
+/// @nodoc
+mixin _$StorageEncryption {
+  StorageEncryptionSupport get support => throw _privateConstructorUsedError;
+  StorageSafety get storageSafety => throw _privateConstructorUsedError;
+  EncryptionType get encryptionType => throw _privateConstructorUsedError;
+  String get unavailableReason => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $StorageEncryptionCopyWith<StorageEncryption> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StorageEncryptionCopyWith<$Res> {
+  factory $StorageEncryptionCopyWith(
+          StorageEncryption value, $Res Function(StorageEncryption) then) =
+      _$StorageEncryptionCopyWithImpl<$Res, StorageEncryption>;
+  @useResult
+  $Res call(
+      {StorageEncryptionSupport support,
+      StorageSafety storageSafety,
+      EncryptionType encryptionType,
+      String unavailableReason});
+}
+
+/// @nodoc
+class _$StorageEncryptionCopyWithImpl<$Res, $Val extends StorageEncryption>
+    implements $StorageEncryptionCopyWith<$Res> {
+  _$StorageEncryptionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? support = null,
+    Object? storageSafety = null,
+    Object? encryptionType = null,
+    Object? unavailableReason = null,
+  }) {
+    return _then(_value.copyWith(
+      support: null == support
+          ? _value.support
+          : support // ignore: cast_nullable_to_non_nullable
+              as StorageEncryptionSupport,
+      storageSafety: null == storageSafety
+          ? _value.storageSafety
+          : storageSafety // ignore: cast_nullable_to_non_nullable
+              as StorageSafety,
+      encryptionType: null == encryptionType
+          ? _value.encryptionType
+          : encryptionType // ignore: cast_nullable_to_non_nullable
+              as EncryptionType,
+      unavailableReason: null == unavailableReason
+          ? _value.unavailableReason
+          : unavailableReason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_StorageEncryptionCopyWith<$Res>
+    implements $StorageEncryptionCopyWith<$Res> {
+  factory _$$_StorageEncryptionCopyWith(_$_StorageEncryption value,
+          $Res Function(_$_StorageEncryption) then) =
+      __$$_StorageEncryptionCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {StorageEncryptionSupport support,
+      StorageSafety storageSafety,
+      EncryptionType encryptionType,
+      String unavailableReason});
+}
+
+/// @nodoc
+class __$$_StorageEncryptionCopyWithImpl<$Res>
+    extends _$StorageEncryptionCopyWithImpl<$Res, _$_StorageEncryption>
+    implements _$$_StorageEncryptionCopyWith<$Res> {
+  __$$_StorageEncryptionCopyWithImpl(
+      _$_StorageEncryption _value, $Res Function(_$_StorageEncryption) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? support = null,
+    Object? storageSafety = null,
+    Object? encryptionType = null,
+    Object? unavailableReason = null,
+  }) {
+    return _then(_$_StorageEncryption(
+      support: null == support
+          ? _value.support
+          : support // ignore: cast_nullable_to_non_nullable
+              as StorageEncryptionSupport,
+      storageSafety: null == storageSafety
+          ? _value.storageSafety
+          : storageSafety // ignore: cast_nullable_to_non_nullable
+              as StorageSafety,
+      encryptionType: null == encryptionType
+          ? _value.encryptionType
+          : encryptionType // ignore: cast_nullable_to_non_nullable
+              as EncryptionType,
+      unavailableReason: null == unavailableReason
+          ? _value.unavailableReason
+          : unavailableReason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_StorageEncryption implements _StorageEncryption {
+  const _$_StorageEncryption(
+      {required this.support,
+      required this.storageSafety,
+      required this.encryptionType,
+      required this.unavailableReason});
+
+  factory _$_StorageEncryption.fromJson(Map<String, dynamic> json) =>
+      _$$_StorageEncryptionFromJson(json);
+
+  @override
+  final StorageEncryptionSupport support;
+  @override
+  final StorageSafety storageSafety;
+  @override
+  final EncryptionType encryptionType;
+  @override
+  final String unavailableReason;
+
+  @override
+  String toString() {
+    return 'StorageEncryption(support: $support, storageSafety: $storageSafety, encryptionType: $encryptionType, unavailableReason: $unavailableReason)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_StorageEncryption &&
+            (identical(other.support, support) || other.support == support) &&
+            (identical(other.storageSafety, storageSafety) ||
+                other.storageSafety == storageSafety) &&
+            (identical(other.encryptionType, encryptionType) ||
+                other.encryptionType == encryptionType) &&
+            (identical(other.unavailableReason, unavailableReason) ||
+                other.unavailableReason == unavailableReason));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, support, storageSafety, encryptionType, unavailableReason);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_StorageEncryptionCopyWith<_$_StorageEncryption> get copyWith =>
+      __$$_StorageEncryptionCopyWithImpl<_$_StorageEncryption>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_StorageEncryptionToJson(
+      this,
+    );
+  }
+}
+
+abstract class _StorageEncryption implements StorageEncryption {
+  const factory _StorageEncryption(
+      {required final StorageEncryptionSupport support,
+      required final StorageSafety storageSafety,
+      required final EncryptionType encryptionType,
+      required final String unavailableReason}) = _$_StorageEncryption;
+
+  factory _StorageEncryption.fromJson(Map<String, dynamic> json) =
+      _$_StorageEncryption.fromJson;
+
+  @override
+  StorageEncryptionSupport get support;
+  @override
+  StorageSafety get storageSafety;
+  @override
+  EncryptionType get encryptionType;
+  @override
+  String get unavailableReason;
+  @override
+  @JsonKey(ignore: true)
+  _$$_StorageEncryptionCopyWith<_$_StorageEncryption> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4893,6 +5120,9 @@ mixin _$GuidedStorageResponse {
   ProbeStatus get status => throw _privateConstructorUsedError;
   ErrorReportRef? get errorReport => throw _privateConstructorUsedError;
   List<Disk>? get disks => throw _privateConstructorUsedError;
+  String get coreBootClassicError => throw _privateConstructorUsedError;
+  StorageEncryption? get storageEncryption =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -4907,9 +5137,14 @@ abstract class $GuidedStorageResponseCopyWith<$Res> {
       _$GuidedStorageResponseCopyWithImpl<$Res, GuidedStorageResponse>;
   @useResult
   $Res call(
-      {ProbeStatus status, ErrorReportRef? errorReport, List<Disk>? disks});
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      List<Disk>? disks,
+      String coreBootClassicError,
+      StorageEncryption? storageEncryption});
 
   $ErrorReportRefCopyWith<$Res>? get errorReport;
+  $StorageEncryptionCopyWith<$Res>? get storageEncryption;
 }
 
 /// @nodoc
@@ -4929,6 +5164,8 @@ class _$GuidedStorageResponseCopyWithImpl<$Res,
     Object? status = null,
     Object? errorReport = freezed,
     Object? disks = freezed,
+    Object? coreBootClassicError = null,
+    Object? storageEncryption = freezed,
   }) {
     return _then(_value.copyWith(
       status: null == status
@@ -4943,6 +5180,14 @@ class _$GuidedStorageResponseCopyWithImpl<$Res,
           ? _value.disks
           : disks // ignore: cast_nullable_to_non_nullable
               as List<Disk>?,
+      coreBootClassicError: null == coreBootClassicError
+          ? _value.coreBootClassicError
+          : coreBootClassicError // ignore: cast_nullable_to_non_nullable
+              as String,
+      storageEncryption: freezed == storageEncryption
+          ? _value.storageEncryption
+          : storageEncryption // ignore: cast_nullable_to_non_nullable
+              as StorageEncryption?,
     ) as $Val);
   }
 
@@ -4957,6 +5202,18 @@ class _$GuidedStorageResponseCopyWithImpl<$Res,
       return _then(_value.copyWith(errorReport: value) as $Val);
     });
   }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $StorageEncryptionCopyWith<$Res>? get storageEncryption {
+    if (_value.storageEncryption == null) {
+      return null;
+    }
+
+    return $StorageEncryptionCopyWith<$Res>(_value.storageEncryption!, (value) {
+      return _then(_value.copyWith(storageEncryption: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -4968,10 +5225,16 @@ abstract class _$$_GuidedStorageResponseCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {ProbeStatus status, ErrorReportRef? errorReport, List<Disk>? disks});
+      {ProbeStatus status,
+      ErrorReportRef? errorReport,
+      List<Disk>? disks,
+      String coreBootClassicError,
+      StorageEncryption? storageEncryption});
 
   @override
   $ErrorReportRefCopyWith<$Res>? get errorReport;
+  @override
+  $StorageEncryptionCopyWith<$Res>? get storageEncryption;
 }
 
 /// @nodoc
@@ -4988,6 +5251,8 @@ class __$$_GuidedStorageResponseCopyWithImpl<$Res>
     Object? status = null,
     Object? errorReport = freezed,
     Object? disks = freezed,
+    Object? coreBootClassicError = null,
+    Object? storageEncryption = freezed,
   }) {
     return _then(_$_GuidedStorageResponse(
       status: null == status
@@ -5002,6 +5267,14 @@ class __$$_GuidedStorageResponseCopyWithImpl<$Res>
           ? _value._disks
           : disks // ignore: cast_nullable_to_non_nullable
               as List<Disk>?,
+      coreBootClassicError: null == coreBootClassicError
+          ? _value.coreBootClassicError
+          : coreBootClassicError // ignore: cast_nullable_to_non_nullable
+              as String,
+      storageEncryption: freezed == storageEncryption
+          ? _value.storageEncryption
+          : storageEncryption // ignore: cast_nullable_to_non_nullable
+              as StorageEncryption?,
     ));
   }
 }
@@ -5010,7 +5283,11 @@ class __$$_GuidedStorageResponseCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_GuidedStorageResponse implements _GuidedStorageResponse {
   const _$_GuidedStorageResponse(
-      {required this.status, this.errorReport, final List<Disk>? disks})
+      {required this.status,
+      this.errorReport,
+      final List<Disk>? disks,
+      this.coreBootClassicError = '',
+      this.storageEncryption})
       : _disks = disks;
 
   factory _$_GuidedStorageResponse.fromJson(Map<String, dynamic> json) =>
@@ -5030,8 +5307,14 @@ class _$_GuidedStorageResponse implements _GuidedStorageResponse {
   }
 
   @override
+  @JsonKey()
+  final String coreBootClassicError;
+  @override
+  final StorageEncryption? storageEncryption;
+
+  @override
   String toString() {
-    return 'GuidedStorageResponse(status: $status, errorReport: $errorReport, disks: $disks)';
+    return 'GuidedStorageResponse(status: $status, errorReport: $errorReport, disks: $disks, coreBootClassicError: $coreBootClassicError, storageEncryption: $storageEncryption)';
   }
 
   @override
@@ -5042,13 +5325,22 @@ class _$_GuidedStorageResponse implements _GuidedStorageResponse {
             (identical(other.status, status) || other.status == status) &&
             (identical(other.errorReport, errorReport) ||
                 other.errorReport == errorReport) &&
-            const DeepCollectionEquality().equals(other._disks, _disks));
+            const DeepCollectionEquality().equals(other._disks, _disks) &&
+            (identical(other.coreBootClassicError, coreBootClassicError) ||
+                other.coreBootClassicError == coreBootClassicError) &&
+            (identical(other.storageEncryption, storageEncryption) ||
+                other.storageEncryption == storageEncryption));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, status, errorReport,
-      const DeepCollectionEquality().hash(_disks));
+  int get hashCode => Object.hash(
+      runtimeType,
+      status,
+      errorReport,
+      const DeepCollectionEquality().hash(_disks),
+      coreBootClassicError,
+      storageEncryption);
 
   @JsonKey(ignore: true)
   @override
@@ -5069,7 +5361,9 @@ abstract class _GuidedStorageResponse implements GuidedStorageResponse {
   const factory _GuidedStorageResponse(
       {required final ProbeStatus status,
       final ErrorReportRef? errorReport,
-      final List<Disk>? disks}) = _$_GuidedStorageResponse;
+      final List<Disk>? disks,
+      final String coreBootClassicError,
+      final StorageEncryption? storageEncryption}) = _$_GuidedStorageResponse;
 
   factory _GuidedStorageResponse.fromJson(Map<String, dynamic> json) =
       _$_GuidedStorageResponse.fromJson;
@@ -5080,6 +5374,10 @@ abstract class _GuidedStorageResponse implements GuidedStorageResponse {
   ErrorReportRef? get errorReport;
   @override
   List<Disk>? get disks;
+  @override
+  String get coreBootClassicError;
+  @override
+  StorageEncryption? get storageEncryption;
   @override
   @JsonKey(ignore: true)
   _$$_GuidedStorageResponseCopyWith<_$_GuidedStorageResponse> get copyWith =>
@@ -8687,6 +8985,142 @@ abstract class _DriversResponse implements DriversResponse {
       throw _privateConstructorUsedError;
 }
 
+CodecsData _$CodecsDataFromJson(Map<String, dynamic> json) {
+  return _CodecsData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$CodecsData {
+  bool get install => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $CodecsDataCopyWith<CodecsData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CodecsDataCopyWith<$Res> {
+  factory $CodecsDataCopyWith(
+          CodecsData value, $Res Function(CodecsData) then) =
+      _$CodecsDataCopyWithImpl<$Res, CodecsData>;
+  @useResult
+  $Res call({bool install});
+}
+
+/// @nodoc
+class _$CodecsDataCopyWithImpl<$Res, $Val extends CodecsData>
+    implements $CodecsDataCopyWith<$Res> {
+  _$CodecsDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? install = null,
+  }) {
+    return _then(_value.copyWith(
+      install: null == install
+          ? _value.install
+          : install // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_CodecsDataCopyWith<$Res>
+    implements $CodecsDataCopyWith<$Res> {
+  factory _$$_CodecsDataCopyWith(
+          _$_CodecsData value, $Res Function(_$_CodecsData) then) =
+      __$$_CodecsDataCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool install});
+}
+
+/// @nodoc
+class __$$_CodecsDataCopyWithImpl<$Res>
+    extends _$CodecsDataCopyWithImpl<$Res, _$_CodecsData>
+    implements _$$_CodecsDataCopyWith<$Res> {
+  __$$_CodecsDataCopyWithImpl(
+      _$_CodecsData _value, $Res Function(_$_CodecsData) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? install = null,
+  }) {
+    return _then(_$_CodecsData(
+      install: null == install
+          ? _value.install
+          : install // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_CodecsData implements _CodecsData {
+  const _$_CodecsData({required this.install});
+
+  factory _$_CodecsData.fromJson(Map<String, dynamic> json) =>
+      _$$_CodecsDataFromJson(json);
+
+  @override
+  final bool install;
+
+  @override
+  String toString() {
+    return 'CodecsData(install: $install)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_CodecsData &&
+            (identical(other.install, install) || other.install == install));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, install);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_CodecsDataCopyWith<_$_CodecsData> get copyWith =>
+      __$$_CodecsDataCopyWithImpl<_$_CodecsData>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_CodecsDataToJson(
+      this,
+    );
+  }
+}
+
+abstract class _CodecsData implements CodecsData {
+  const factory _CodecsData({required final bool install}) = _$_CodecsData;
+
+  factory _CodecsData.fromJson(Map<String, dynamic> json) =
+      _$_CodecsData.fromJson;
+
+  @override
+  bool get install;
+  @override
+  @JsonKey(ignore: true)
+  _$$_CodecsDataCopyWith<_$_CodecsData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
 DriversPayload _$DriversPayloadFromJson(Map<String, dynamic> json) {
   return _DriversPayload.fromJson(json);
 }
@@ -11122,5 +11556,692 @@ abstract class _WSLSetupOptions implements WSLSetupOptions {
   @override
   @JsonKey(ignore: true)
   _$$_WSLSetupOptionsCopyWith<_$_WSLSetupOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+TaskProgress _$TaskProgressFromJson(Map<String, dynamic> json) {
+  return _TaskProgress.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TaskProgress {
+  String get label => throw _privateConstructorUsedError;
+  int get done => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TaskProgressCopyWith<TaskProgress> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TaskProgressCopyWith<$Res> {
+  factory $TaskProgressCopyWith(
+          TaskProgress value, $Res Function(TaskProgress) then) =
+      _$TaskProgressCopyWithImpl<$Res, TaskProgress>;
+  @useResult
+  $Res call({String label, int done, int total});
+}
+
+/// @nodoc
+class _$TaskProgressCopyWithImpl<$Res, $Val extends TaskProgress>
+    implements $TaskProgressCopyWith<$Res> {
+  _$TaskProgressCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? label = null,
+    Object? done = null,
+    Object? total = null,
+  }) {
+    return _then(_value.copyWith(
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
+      done: null == done
+          ? _value.done
+          : done // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_TaskProgressCopyWith<$Res>
+    implements $TaskProgressCopyWith<$Res> {
+  factory _$$_TaskProgressCopyWith(
+          _$_TaskProgress value, $Res Function(_$_TaskProgress) then) =
+      __$$_TaskProgressCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String label, int done, int total});
+}
+
+/// @nodoc
+class __$$_TaskProgressCopyWithImpl<$Res>
+    extends _$TaskProgressCopyWithImpl<$Res, _$_TaskProgress>
+    implements _$$_TaskProgressCopyWith<$Res> {
+  __$$_TaskProgressCopyWithImpl(
+      _$_TaskProgress _value, $Res Function(_$_TaskProgress) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? label = null,
+    Object? done = null,
+    Object? total = null,
+  }) {
+    return _then(_$_TaskProgress(
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
+      done: null == done
+          ? _value.done
+          : done // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_TaskProgress implements _TaskProgress {
+  const _$_TaskProgress({this.label = '', this.done = 0, this.total = 0});
+
+  factory _$_TaskProgress.fromJson(Map<String, dynamic> json) =>
+      _$$_TaskProgressFromJson(json);
+
+  @override
+  @JsonKey()
+  final String label;
+  @override
+  @JsonKey()
+  final int done;
+  @override
+  @JsonKey()
+  final int total;
+
+  @override
+  String toString() {
+    return 'TaskProgress(label: $label, done: $done, total: $total)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_TaskProgress &&
+            (identical(other.label, label) || other.label == label) &&
+            (identical(other.done, done) || other.done == done) &&
+            (identical(other.total, total) || other.total == total));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, label, done, total);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_TaskProgressCopyWith<_$_TaskProgress> get copyWith =>
+      __$$_TaskProgressCopyWithImpl<_$_TaskProgress>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_TaskProgressToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TaskProgress implements TaskProgress {
+  const factory _TaskProgress(
+      {final String label, final int done, final int total}) = _$_TaskProgress;
+
+  factory _TaskProgress.fromJson(Map<String, dynamic> json) =
+      _$_TaskProgress.fromJson;
+
+  @override
+  String get label;
+  @override
+  int get done;
+  @override
+  int get total;
+  @override
+  @JsonKey(ignore: true)
+  _$$_TaskProgressCopyWith<_$_TaskProgress> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Task _$TaskFromJson(Map<String, dynamic> json) {
+  return _Task.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Task {
+  String get id => throw _privateConstructorUsedError;
+  String get kind => throw _privateConstructorUsedError;
+  String get summary => throw _privateConstructorUsedError;
+  TaskStatus get status => throw _privateConstructorUsedError;
+  TaskProgress get progress => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TaskCopyWith<Task> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TaskCopyWith<$Res> {
+  factory $TaskCopyWith(Task value, $Res Function(Task) then) =
+      _$TaskCopyWithImpl<$Res, Task>;
+  @useResult
+  $Res call(
+      {String id,
+      String kind,
+      String summary,
+      TaskStatus status,
+      TaskProgress progress});
+
+  $TaskProgressCopyWith<$Res> get progress;
+}
+
+/// @nodoc
+class _$TaskCopyWithImpl<$Res, $Val extends Task>
+    implements $TaskCopyWith<$Res> {
+  _$TaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? kind = null,
+    Object? summary = null,
+    Object? status = null,
+    Object? progress = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+      summary: null == summary
+          ? _value.summary
+          : summary // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TaskStatus,
+      progress: null == progress
+          ? _value.progress
+          : progress // ignore: cast_nullable_to_non_nullable
+              as TaskProgress,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $TaskProgressCopyWith<$Res> get progress {
+    return $TaskProgressCopyWith<$Res>(_value.progress, (value) {
+      return _then(_value.copyWith(progress: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_TaskCopyWith<$Res> implements $TaskCopyWith<$Res> {
+  factory _$$_TaskCopyWith(_$_Task value, $Res Function(_$_Task) then) =
+      __$$_TaskCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String kind,
+      String summary,
+      TaskStatus status,
+      TaskProgress progress});
+
+  @override
+  $TaskProgressCopyWith<$Res> get progress;
+}
+
+/// @nodoc
+class __$$_TaskCopyWithImpl<$Res> extends _$TaskCopyWithImpl<$Res, _$_Task>
+    implements _$$_TaskCopyWith<$Res> {
+  __$$_TaskCopyWithImpl(_$_Task _value, $Res Function(_$_Task) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? kind = null,
+    Object? summary = null,
+    Object? status = null,
+    Object? progress = null,
+  }) {
+    return _then(_$_Task(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+      summary: null == summary
+          ? _value.summary
+          : summary // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TaskStatus,
+      progress: null == progress
+          ? _value.progress
+          : progress // ignore: cast_nullable_to_non_nullable
+              as TaskProgress,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Task implements _Task {
+  const _$_Task(
+      {required this.id,
+      required this.kind,
+      required this.summary,
+      required this.status,
+      required this.progress});
+
+  factory _$_Task.fromJson(Map<String, dynamic> json) => _$$_TaskFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String kind;
+  @override
+  final String summary;
+  @override
+  final TaskStatus status;
+  @override
+  final TaskProgress progress;
+
+  @override
+  String toString() {
+    return 'Task(id: $id, kind: $kind, summary: $summary, status: $status, progress: $progress)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Task &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.kind, kind) || other.kind == kind) &&
+            (identical(other.summary, summary) || other.summary == summary) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.progress, progress) ||
+                other.progress == progress));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, kind, summary, status, progress);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_TaskCopyWith<_$_Task> get copyWith =>
+      __$$_TaskCopyWithImpl<_$_Task>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_TaskToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Task implements Task {
+  const factory _Task(
+      {required final String id,
+      required final String kind,
+      required final String summary,
+      required final TaskStatus status,
+      required final TaskProgress progress}) = _$_Task;
+
+  factory _Task.fromJson(Map<String, dynamic> json) = _$_Task.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get kind;
+  @override
+  String get summary;
+  @override
+  TaskStatus get status;
+  @override
+  TaskProgress get progress;
+  @override
+  @JsonKey(ignore: true)
+  _$$_TaskCopyWith<_$_Task> get copyWith => throw _privateConstructorUsedError;
+}
+
+Change _$ChangeFromJson(Map<String, dynamic> json) {
+  return _Change.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Change {
+  String get id => throw _privateConstructorUsedError;
+  String get kind => throw _privateConstructorUsedError;
+  String get summary => throw _privateConstructorUsedError;
+  TaskStatus get status => throw _privateConstructorUsedError;
+  List<Task> get tasks => throw _privateConstructorUsedError;
+  bool get ready => throw _privateConstructorUsedError;
+  String? get err => throw _privateConstructorUsedError;
+  dynamic get data => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ChangeCopyWith<Change> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ChangeCopyWith<$Res> {
+  factory $ChangeCopyWith(Change value, $Res Function(Change) then) =
+      _$ChangeCopyWithImpl<$Res, Change>;
+  @useResult
+  $Res call(
+      {String id,
+      String kind,
+      String summary,
+      TaskStatus status,
+      List<Task> tasks,
+      bool ready,
+      String? err,
+      dynamic data});
+}
+
+/// @nodoc
+class _$ChangeCopyWithImpl<$Res, $Val extends Change>
+    implements $ChangeCopyWith<$Res> {
+  _$ChangeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? kind = null,
+    Object? summary = null,
+    Object? status = null,
+    Object? tasks = null,
+    Object? ready = null,
+    Object? err = freezed,
+    Object? data = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+      summary: null == summary
+          ? _value.summary
+          : summary // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TaskStatus,
+      tasks: null == tasks
+          ? _value.tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<Task>,
+      ready: null == ready
+          ? _value.ready
+          : ready // ignore: cast_nullable_to_non_nullable
+              as bool,
+      err: freezed == err
+          ? _value.err
+          : err // ignore: cast_nullable_to_non_nullable
+              as String?,
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ChangeCopyWith<$Res> implements $ChangeCopyWith<$Res> {
+  factory _$$_ChangeCopyWith(_$_Change value, $Res Function(_$_Change) then) =
+      __$$_ChangeCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String kind,
+      String summary,
+      TaskStatus status,
+      List<Task> tasks,
+      bool ready,
+      String? err,
+      dynamic data});
+}
+
+/// @nodoc
+class __$$_ChangeCopyWithImpl<$Res>
+    extends _$ChangeCopyWithImpl<$Res, _$_Change>
+    implements _$$_ChangeCopyWith<$Res> {
+  __$$_ChangeCopyWithImpl(_$_Change _value, $Res Function(_$_Change) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? kind = null,
+    Object? summary = null,
+    Object? status = null,
+    Object? tasks = null,
+    Object? ready = null,
+    Object? err = freezed,
+    Object? data = null,
+  }) {
+    return _then(_$_Change(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+      summary: null == summary
+          ? _value.summary
+          : summary // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TaskStatus,
+      tasks: null == tasks
+          ? _value._tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<Task>,
+      ready: null == ready
+          ? _value.ready
+          : ready // ignore: cast_nullable_to_non_nullable
+              as bool,
+      err: freezed == err
+          ? _value.err
+          : err // ignore: cast_nullable_to_non_nullable
+              as String?,
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Change implements _Change {
+  const _$_Change(
+      {required this.id,
+      required this.kind,
+      required this.summary,
+      required this.status,
+      required final List<Task> tasks,
+      required this.ready,
+      this.err,
+      this.data})
+      : _tasks = tasks;
+
+  factory _$_Change.fromJson(Map<String, dynamic> json) =>
+      _$$_ChangeFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String kind;
+  @override
+  final String summary;
+  @override
+  final TaskStatus status;
+  final List<Task> _tasks;
+  @override
+  List<Task> get tasks {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tasks);
+  }
+
+  @override
+  final bool ready;
+  @override
+  final String? err;
+  @override
+  final dynamic data;
+
+  @override
+  String toString() {
+    return 'Change(id: $id, kind: $kind, summary: $summary, status: $status, tasks: $tasks, ready: $ready, err: $err, data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Change &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.kind, kind) || other.kind == kind) &&
+            (identical(other.summary, summary) || other.summary == summary) &&
+            (identical(other.status, status) || other.status == status) &&
+            const DeepCollectionEquality().equals(other._tasks, _tasks) &&
+            (identical(other.ready, ready) || other.ready == ready) &&
+            (identical(other.err, err) || other.err == err) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      kind,
+      summary,
+      status,
+      const DeepCollectionEquality().hash(_tasks),
+      ready,
+      err,
+      const DeepCollectionEquality().hash(data));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ChangeCopyWith<_$_Change> get copyWith =>
+      __$$_ChangeCopyWithImpl<_$_Change>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ChangeToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Change implements Change {
+  const factory _Change(
+      {required final String id,
+      required final String kind,
+      required final String summary,
+      required final TaskStatus status,
+      required final List<Task> tasks,
+      required final bool ready,
+      final String? err,
+      final dynamic data}) = _$_Change;
+
+  factory _Change.fromJson(Map<String, dynamic> json) = _$_Change.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get kind;
+  @override
+  String get summary;
+  @override
+  TaskStatus get status;
+  @override
+  List<Task> get tasks;
+  @override
+  bool get ready;
+  @override
+  String? get err;
+  @override
+  dynamic get data;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ChangeCopyWith<_$_Change> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -457,6 +457,7 @@ _$_GuidedChoice _$$_GuidedChoiceFromJson(Map<String, dynamic> json) =>
       diskId: json['disk_id'] as String,
       useLvm: json['use_lvm'] as bool? ?? false,
       password: json['password'] as String?,
+      useTpm: json['use_tpm'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$$_GuidedChoiceToJson(_$_GuidedChoice instance) =>
@@ -464,7 +465,47 @@ Map<String, dynamic> _$$_GuidedChoiceToJson(_$_GuidedChoice instance) =>
       'disk_id': instance.diskId,
       'use_lvm': instance.useLvm,
       'password': instance.password,
+      'use_tpm': instance.useTpm,
     };
+
+_$_StorageEncryption _$$_StorageEncryptionFromJson(Map<String, dynamic> json) =>
+    _$_StorageEncryption(
+      support: $enumDecode(_$StorageEncryptionSupportEnumMap, json['support']),
+      storageSafety:
+          $enumDecode(_$StorageSafetyEnumMap, json['storage_safety']),
+      encryptionType:
+          $enumDecode(_$EncryptionTypeEnumMap, json['encryption_type']),
+      unavailableReason: json['unavailable_reason'] as String,
+    );
+
+Map<String, dynamic> _$$_StorageEncryptionToJson(
+        _$_StorageEncryption instance) =>
+    <String, dynamic>{
+      'support': _$StorageEncryptionSupportEnumMap[instance.support]!,
+      'storage_safety': _$StorageSafetyEnumMap[instance.storageSafety]!,
+      'encryption_type': _$EncryptionTypeEnumMap[instance.encryptionType]!,
+      'unavailable_reason': instance.unavailableReason,
+    };
+
+const _$StorageEncryptionSupportEnumMap = {
+  StorageEncryptionSupport.DISABLED: 'DISABLED',
+  StorageEncryptionSupport.AVAILABLE: 'AVAILABLE',
+  StorageEncryptionSupport.UNAVAILABLE: 'UNAVAILABLE',
+  StorageEncryptionSupport.DEFECTIVE: 'DEFECTIVE',
+};
+
+const _$StorageSafetyEnumMap = {
+  StorageSafety.UNSET: 'UNSET',
+  StorageSafety.ENCRYPTED: 'ENCRYPTED',
+  StorageSafety.PREFER_ENCRYPTED: 'PREFER_ENCRYPTED',
+  StorageSafety.PREFER_UNENCRYPTED: 'PREFER_UNENCRYPTED',
+};
+
+const _$EncryptionTypeEnumMap = {
+  EncryptionType.NONE: 'NONE',
+  EncryptionType.CRYPTSETUP: 'CRYPTSETUP',
+  EncryptionType.DEVICE_SETUP_HOOK: 'DEVICE_SETUP_HOOK',
+};
 
 _$_GuidedStorageResponse _$$_GuidedStorageResponseFromJson(
         Map<String, dynamic> json) =>
@@ -477,6 +518,11 @@ _$_GuidedStorageResponse _$$_GuidedStorageResponseFromJson(
       disks: (json['disks'] as List<dynamic>?)
           ?.map((e) => Disk.fromJson(e as Map<String, dynamic>))
           .toList(),
+      coreBootClassicError: json['core_boot_classic_error'] as String? ?? '',
+      storageEncryption: json['storage_encryption'] == null
+          ? null
+          : StorageEncryption.fromJson(
+              json['storage_encryption'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$$_GuidedStorageResponseToJson(
@@ -485,6 +531,8 @@ Map<String, dynamic> _$$_GuidedStorageResponseToJson(
       'status': _$ProbeStatusEnumMap[instance.status]!,
       'error_report': instance.errorReport?.toJson(),
       'disks': instance.disks?.map((e) => e.toJson()).toList(),
+      'core_boot_classic_error': instance.coreBootClassicError,
+      'storage_encryption': instance.storageEncryption?.toJson(),
     };
 
 const _$ProbeStatusEnumMap = {
@@ -804,6 +852,16 @@ Map<String, dynamic> _$$_DriversResponseToJson(_$_DriversResponse instance) =>
       'search_drivers': instance.searchDrivers,
     };
 
+_$_CodecsData _$$_CodecsDataFromJson(Map<String, dynamic> json) =>
+    _$_CodecsData(
+      install: json['install'] as bool,
+    );
+
+Map<String, dynamic> _$$_CodecsDataToJson(_$_CodecsData instance) =>
+    <String, dynamic>{
+      'install': instance.install,
+    };
+
 _$_DriversPayload _$$_DriversPayloadFromJson(Map<String, dynamic> json) =>
     _$_DriversPayload(
       install: json['install'] as bool,
@@ -1028,4 +1086,69 @@ Map<String, dynamic> _$$_WSLSetupOptionsToJson(_$_WSLSetupOptions instance) =>
     <String, dynamic>{
       'install_language_support_packages':
           instance.installLanguageSupportPackages,
+    };
+
+_$_TaskProgress _$$_TaskProgressFromJson(Map<String, dynamic> json) =>
+    _$_TaskProgress(
+      label: json['label'] as String? ?? '',
+      done: json['done'] as int? ?? 0,
+      total: json['total'] as int? ?? 0,
+    );
+
+Map<String, dynamic> _$$_TaskProgressToJson(_$_TaskProgress instance) =>
+    <String, dynamic>{
+      'label': instance.label,
+      'done': instance.done,
+      'total': instance.total,
+    };
+
+_$_Task _$$_TaskFromJson(Map<String, dynamic> json) => _$_Task(
+      id: json['id'] as String,
+      kind: json['kind'] as String,
+      summary: json['summary'] as String,
+      status: $enumDecode(_$TaskStatusEnumMap, json['status']),
+      progress: TaskProgress.fromJson(json['progress'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$_TaskToJson(_$_Task instance) => <String, dynamic>{
+      'id': instance.id,
+      'kind': instance.kind,
+      'summary': instance.summary,
+      'status': _$TaskStatusEnumMap[instance.status]!,
+      'progress': instance.progress.toJson(),
+    };
+
+const _$TaskStatusEnumMap = {
+  TaskStatus.DO: 'DO',
+  TaskStatus.DOING: 'DOING',
+  TaskStatus.DONE: 'DONE',
+  TaskStatus.ABORT: 'ABORT',
+  TaskStatus.UNDO: 'UNDO',
+  TaskStatus.UNDOING: 'UNDOING',
+  TaskStatus.HOLD: 'HOLD',
+  TaskStatus.ERROR: 'ERROR',
+};
+
+_$_Change _$$_ChangeFromJson(Map<String, dynamic> json) => _$_Change(
+      id: json['id'] as String,
+      kind: json['kind'] as String,
+      summary: json['summary'] as String,
+      status: $enumDecode(_$TaskStatusEnumMap, json['status']),
+      tasks: (json['tasks'] as List<dynamic>)
+          .map((e) => Task.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      ready: json['ready'] as bool,
+      err: json['err'] as String?,
+      data: json['data'],
+    );
+
+Map<String, dynamic> _$$_ChangeToJson(_$_Change instance) => <String, dynamic>{
+      'id': instance.id,
+      'kind': instance.kind,
+      'summary': instance.summary,
+      'status': _$TaskStatusEnumMap[instance.status]!,
+      'tasks': instance.tasks.map((e) => e.toJson()).toList(),
+      'ready': instance.ready,
+      'err': instance.err,
+      'data': instance.data,
     };

--- a/packages/subiquity_client/test/types_test.dart
+++ b/packages/subiquity_client/test/types_test.dart
@@ -243,11 +243,13 @@ void main() {
       diskId: '0',
       useLvm: true,
       password: '2',
+      useTpm: false,
     );
     const json = <String, dynamic>{
       'disk_id': '0',
       'use_lvm': true,
       'password': '2',
+      'use_tpm': false,
     };
     expect(choice.toJson(), equals(json));
     expect(GuidedChoice.fromJson(json), choice);

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -139,6 +139,7 @@ Future<void> runInstallerApp(
   // Use the default values for a number of endpoints
   // for which a UI page isn't implemented yet.
   return subiquityClient.markConfigured([
+    'codecs',
     'drivers',
     'mirror',
     'proxy',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
     plugin: python
     source-type: git
     source: https://git.launchpad.net/curtin
-    source-commit: 47c222681c81110a185497a64749f23596e29b16
+    source-commit: 1fc717df52ec15f616d26fff3c10bff181599b30
     build-packages:
       - shared-mime-info
       - zlib1g-dev


### PR DESCRIPTION
Generated (99.8%) changes:
- `types.dart` was [generated](https://github.com/canonical/ubuntu-desktop-installer/pull/965) from [`subiquity/common/types.py`](https://github.com/canonical/subiquity/blob/main/subiquity/common/types.py)
- `types.g.dart` and `types.freezed.dart` were generated by `build_runner`
- `snapcraft.yaml` was updated by the [`update_subiquity`](https://github.com/canonical/ubuntu-desktop-installer/blob/main/scripts/update-subiquity) script

Manual (0.2%) changes:
- added the new [`use_tpm`](https://github.com/canonical/subiquity/blob/main/subiquity/common/types.py#L323) field to guided storage choice unit tests
- marked the new [`codecs` endpoint](https://github.com/canonical/subiquity/pull/1473) configured until it gets implemented