### PR TITLE
subiquity_client: add codecs & drivers

### DIFF
--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -537,4 +537,32 @@ class SubiquityClient {
     final json = await _receiveJson('getKeyboardStep($step)', response);
     return AnyStep.fromJson(json);
   }
+
+  Future<DriversResponse> getDrivers() async {
+    final request = await _openUrl('GET', url('drivers'));
+    final response = await request.close();
+    final json = await _receiveJson('getDrivers()', response);
+    return DriversResponse.fromJson(json);
+  }
+
+  Future<void> setDrivers({required bool install}) async {
+    final request = await _openUrl('POST', url('drivers'));
+    request.write(jsonEncode(<String, dynamic>{'install': install}));
+    final response = await request.close();
+    await _receive('setDrivers($install)', response);
+  }
+
+  Future<CodecsData> getCodecs() async {
+    final request = await _openUrl('GET', url('codecs'));
+    final response = await request.close();
+    final json = await _receiveJson('getCodecs()', response);
+    return CodecsData.fromJson(json);
+  }
+
+  Future<void> setCodecs({required bool install}) async {
+    final request = await _openUrl('POST', url('codecs'));
+    request.write(jsonEncode(<String, dynamic>{'install': install}));
+    final response = await request.close();
+    await _receive('setCodecs($install)', response);
+  }
 }

--- a/packages/subiquity_client/test/subiquity_client_test.dart
+++ b/packages/subiquity_client/test/subiquity_client_test.dart
@@ -490,6 +490,26 @@ void main() {
       await client.setFreeOnly(false);
       expect(await client.freeOnly(), false);
     });
+
+    test('drivers', () async {
+      await client.setDrivers(install: true);
+      final response1 = await client.getDrivers();
+      expect(response1.install, isTrue);
+
+      await client.setDrivers(install: false);
+      final response2 = await client.getDrivers();
+      expect(response2.install, isFalse);
+    });
+
+    test('codecs', () async {
+      await client.setCodecs(install: true);
+      final response1 = await client.getCodecs();
+      expect(response1.install, isTrue);
+
+      await client.setCodecs(install: false);
+      final response2 = await client.getCodecs();
+      expect(response2.install, isFalse);
+    });
   });
 
   group('wsl', () {

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -172,8 +172,29 @@ class _FakeAnyStep_13 extends _i1.SmartFake implements _i3.AnyStep {
         );
 }
 
-class _FakeEndpoint_14 extends _i1.SmartFake implements _i4.Endpoint {
-  _FakeEndpoint_14(
+class _FakeDriversResponse_14 extends _i1.SmartFake
+    implements _i3.DriversResponse {
+  _FakeDriversResponse_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCodecsData_15 extends _i1.SmartFake implements _i3.CodecsData {
+  _FakeCodecsData_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEndpoint_16 extends _i1.SmartFake implements _i4.Endpoint {
+  _FakeEndpoint_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,6 +964,55 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
           ),
         )),
       ) as _i6.Future<_i3.AnyStep>);
+  @override
+  _i6.Future<_i3.DriversResponse> getDrivers() => (super.noSuchMethod(
+        Invocation.method(
+          #getDrivers,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i3.DriversResponse>.value(_FakeDriversResponse_14(
+          this,
+          Invocation.method(
+            #getDrivers,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.DriversResponse>);
+  @override
+  _i6.Future<void> setDrivers({required bool? install}) => (super.noSuchMethod(
+        Invocation.method(
+          #setDrivers,
+          [],
+          {#install: install},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<_i3.CodecsData> getCodecs() => (super.noSuchMethod(
+        Invocation.method(
+          #getCodecs,
+          [],
+        ),
+        returnValue: _i6.Future<_i3.CodecsData>.value(_FakeCodecsData_15(
+          this,
+          Invocation.method(
+            #getCodecs,
+            [],
+          ),
+        )),
+      ) as _i6.Future<_i3.CodecsData>);
+  @override
+  _i6.Future<void> setCodecs({required bool? install}) => (super.noSuchMethod(
+        Invocation.method(
+          #setCodecs,
+          [],
+          {#install: install},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
 }
 
 /// A class which mocks [SubiquityServer].
@@ -964,7 +1034,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
   @override
   _i4.Endpoint get endpoint => (super.noSuchMethod(
         Invocation.getter(#endpoint),
-        returnValue: _FakeEndpoint_14(
+        returnValue: _FakeEndpoint_16(
           this,
           Invocation.getter(#endpoint),
         ),
@@ -983,7 +1053,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
             #environment: environment,
           },
         ),
-        returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_14(
+        returnValue: _i6.Future<_i4.Endpoint>.value(_FakeEndpoint_16(
           this,
           Invocation.method(
             #start,


### PR DESCRIPTION
This PR adds Dart API for the following two Subiquity endpoints:
- `codecs`: https://github.com/canonical/subiquity/pull/1473
- `drivers`: https://github.com/canonical/subiquity/pull/1179

The endpoints are needed for implementing the _Other options_ on the _Updates and other software_ page:

![image](https://user-images.githubusercontent.com/140617/202412194-bc1a68fe-02a0-44aa-b883-b643674a446f.png)

Design: https://people.canonical.com/~platform/desktop/installer/6.%20Updates%20and%20Other%20Software/