### PR TITLE
Add contact information

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,8 @@ description: |
 grade: stable
 confinement: classic
 base: core20
+issues: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
+contact: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
 
 apps:
   subiquity-server:


### PR DESCRIPTION
This will allow users to use ubuntu-bug ubuntu-desktop-installer from the "try ubuntu" environment and have bugs created at launchpad which fixes https://bugs.launchpad.net/ubuntu-desktop-installer/+bug/1979845.