### PR TITLE
Installation type: prevent pressing "Continue" too early

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -74,6 +74,9 @@ class InstallationTypeModel extends SafeChangeNotifier {
   /// A list of existing OS installations or null if not detected.
   List<OsProber>? get existingOS => _diskService.existingOS;
 
+  /// Whether storage information has been queried and installation can proceed.
+  bool get hasStorage => _storages != null;
+
   /// Whether installation alongside an existing OS is possible.
   ///
   /// That is, whether a) an existing partition can be safely resized smaller to

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -154,6 +154,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
         WizardAction.back(context),
         WizardAction.next(
           context,
+          enabled: model.hasStorage,
           arguments: model.installationType,
           onNext: model.save,
           // If the user returns back to select another installation type, the

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
@@ -56,6 +56,7 @@ void main() {
     when(model.advancedFeature).thenReturn(AdvancedFeature.lvm);
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
+    when(model.hasStorage).thenReturn(true);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
@@ -87,6 +88,7 @@ void main() {
     when(model.advancedFeature).thenReturn(AdvancedFeature.lvm);
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
+    when(model.hasStorage).thenReturn(true);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -25,6 +25,7 @@ void main() {
     ProductInfo? productInfo,
     List<OsProber>? existingOS,
     bool? canInstallAlongside,
+    bool? hasStorage,
   }) {
     final model = MockInstallationTypeModel();
     when(model.installationType)
@@ -35,6 +36,7 @@ void main() {
     when(model.productInfo).thenReturn(productInfo ?? ProductInfo(name: ''));
     when(model.existingOS).thenReturn(existingOS);
     when(model.canInstallAlongside).thenReturn(canInstallAlongside ?? false);
+    when(model.hasStorage).thenReturn(hasStorage ?? true);
     return model;
   }
 
@@ -337,6 +339,35 @@ void main() {
       expect(find.text(tester.lang.installationTypeLVMEncryptionSelected),
           findsOneWidget);
     });
+  });
+
+  testWidgets('no storage', (tester) async {
+    final model = buildModel(hasStorage: false);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final continueButton = find.widgetWithText(
+      OutlinedButton,
+      tester.ulang.continueAction,
+    );
+    expect(continueButton, findsOneWidget);
+    expect(tester.widget<OutlinedButton>(continueButton).enabled, false);
+
+    await tester.tap(continueButton);
+    verifyNever(model.save());
+  });
+
+  testWidgets('continue', (tester) async {
+    final model = buildModel(hasStorage: true);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final continueButton = find.widgetWithText(
+      OutlinedButton,
+      tester.ulang.continueAction,
+    );
+    expect(continueButton, findsOneWidget);
+
+    await tester.tap(continueButton);
+    verify(model.save()).called(1);
   });
 
   testWidgets('creates a model', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -90,6 +90,11 @@ class MockInstallationTypeModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
+  bool get hasStorage => (super.noSuchMethod(
+        Invocation.getter(#hasStorage),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get canInstallAlongside => (super.noSuchMethod(
         Invocation.getter(#canInstallAlongside),
         returnValue: false,


### PR DESCRIPTION
Querying guided storage started taking slightly longer after the latest [Subiquity update](https://github.com/canonical/ubuntu-desktop-installer/pull/1221). There's now a chance that pressing _Continue_ too early takes the user incorrectly to the _Choose guided storage_ page which lists no disks at all until the guided storage query completes. Prevent this by disabling the _Continue_ button until the guided storage information has been received.