### PR TITLE
Don't mark 'drivers' and 'codecs' configured on startup

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -139,8 +139,6 @@ Future<void> runInstallerApp(
   // Use the default values for a number of endpoints
   // for which a UI page isn't implemented yet.
   return subiquityClient.markConfigured([
-    'codecs',
-    'drivers',
     'mirror',
     'proxy',
     'ssh',


### PR DESCRIPTION
Drivers & codecs have been implemented in #733 and #1237, respectively, and both endpoints are now configured from the _Updates and other software_ screen.