### PR TITLE
Downgrade freezed

### DIFF
--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
 part of 'types.dart';
 
@@ -869,8 +869,6 @@ class _$_LiveSessionSSHInfo implements _LiveSessionSSHInfo {
   final List<KeyFingerprint> _authorizedKeyFingerprints;
   @override
   List<KeyFingerprint> get authorizedKeyFingerprints {
-    if (_authorizedKeyFingerprints is EqualUnmodifiableListView)
-      return _authorizedKeyFingerprints;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_authorizedKeyFingerprints);
   }
@@ -878,7 +876,6 @@ class _$_LiveSessionSSHInfo implements _LiveSessionSSHInfo {
   final List<String> _ips;
   @override
   List<String> get ips {
-    if (_ips is EqualUnmodifiableListView) return _ips;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_ips);
   }
@@ -886,8 +883,6 @@ class _$_LiveSessionSSHInfo implements _LiveSessionSSHInfo {
   final List<KeyFingerprint> _hostKeyFingerprints;
   @override
   List<KeyFingerprint> get hostKeyFingerprints {
-    if (_hostKeyFingerprints is EqualUnmodifiableListView)
-      return _hostKeyFingerprints;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_hostKeyFingerprints);
   }
@@ -1297,7 +1292,6 @@ class _$StepPressKey implements StepPressKey {
   final List<String> _symbols;
   @override
   List<String> get symbols {
-    if (_symbols is EqualUnmodifiableListView) return _symbols;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_symbols);
   }
@@ -1305,7 +1299,6 @@ class _$StepPressKey implements StepPressKey {
   final Map<int, String> _keycodes;
   @override
   Map<int, String> get keycodes {
-    if (_keycodes is EqualUnmodifiableMapView) return _keycodes;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableMapView(_keycodes);
   }
@@ -2242,7 +2235,6 @@ class _$_KeyboardLayout implements _KeyboardLayout {
   final List<KeyboardVariant> _variants;
   @override
   List<KeyboardVariant> get variants {
-    if (_variants is EqualUnmodifiableListView) return _variants;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_variants);
   }
@@ -2421,7 +2413,6 @@ class _$_KeyboardSetup implements _KeyboardSetup {
   final List<KeyboardLayout> _layouts;
   @override
   List<KeyboardLayout> get layouts {
-    if (_layouts is EqualUnmodifiableListView) return _layouts;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_layouts);
   }
@@ -2848,7 +2839,6 @@ class _$_SourceSelectionAndSetting implements _SourceSelectionAndSetting {
   final List<SourceSelection> _sources;
   @override
   List<SourceSelection> get sources {
-    if (_sources is EqualUnmodifiableListView) return _sources;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_sources);
   }
@@ -3304,7 +3294,6 @@ class _$_NetworkStatus implements _NetworkStatus {
   final List<NetDevInfo> _devices;
   @override
   List<NetDevInfo> get devices {
-    if (_devices is EqualUnmodifiableListView) return _devices;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_devices);
   }
@@ -3599,8 +3588,6 @@ PartitionOrGap _$PartitionOrGapFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PartitionOrGap {
-  int? get size => throw _privateConstructorUsedError;
-  int? get offset => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
@@ -3685,9 +3672,6 @@ mixin _$PartitionOrGap {
   }) =>
       throw _privateConstructorUsedError;
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $PartitionOrGapCopyWith<PartitionOrGap> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -3695,8 +3679,6 @@ abstract class $PartitionOrGapCopyWith<$Res> {
   factory $PartitionOrGapCopyWith(
           PartitionOrGap value, $Res Function(PartitionOrGap) then) =
       _$PartitionOrGapCopyWithImpl<$Res, PartitionOrGap>;
-  @useResult
-  $Res call({int? size, int? offset});
 }
 
 /// @nodoc
@@ -3708,33 +3690,13 @@ class _$PartitionOrGapCopyWithImpl<$Res, $Val extends PartitionOrGap>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? size = freezed,
-    Object? offset = freezed,
-  }) {
-    return _then(_value.copyWith(
-      size: freezed == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int?,
-      offset: freezed == offset
-          ? _value.offset
-          : offset // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
-  }
 }
 
 /// @nodoc
-abstract class _$$PartitionCopyWith<$Res>
-    implements $PartitionOrGapCopyWith<$Res> {
+abstract class _$$PartitionCopyWith<$Res> {
   factory _$$PartitionCopyWith(
           _$Partition value, $Res Function(_$Partition) then) =
       __$$PartitionCopyWithImpl<$Res>;
-  @override
   @useResult
   $Res call(
       {int? size,
@@ -3891,7 +3853,6 @@ class _$Partition implements Partition {
   @override
   @JsonKey()
   List<String> get annotations {
-    if (_annotations is EqualUnmodifiableListView) return _annotations;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_annotations);
   }
@@ -4111,7 +4072,6 @@ abstract class Partition implements PartitionOrGap {
 
   factory Partition.fromJson(Map<String, dynamic> json) = _$Partition.fromJson;
 
-  @override
   int? get size;
   int? get number;
   bool? get preserve;
@@ -4122,22 +4082,19 @@ abstract class Partition implements PartitionOrGap {
   bool? get grubDevice;
   bool? get boot;
   OsProber? get os;
-  @override
   int? get offset;
   int? get estimatedMinSize;
   bool? get resize;
   String? get path;
-  @override
   @JsonKey(ignore: true)
   _$$PartitionCopyWith<_$Partition> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$GapCopyWith<$Res> implements $PartitionOrGapCopyWith<$Res> {
+abstract class _$$GapCopyWith<$Res> {
   factory _$$GapCopyWith(_$Gap value, $Res Function(_$Gap) then) =
       __$$GapCopyWithImpl<$Res>;
-  @override
   @useResult
   $Res call({int offset, int size, GapUsable usable});
 }
@@ -4343,12 +4300,9 @@ abstract class Gap implements PartitionOrGap {
 
   factory Gap.fromJson(Map<String, dynamic> json) = _$Gap.fromJson;
 
-  @override
   int get offset;
-  @override
   int get size;
   GapUsable get usable;
-  @override
   @JsonKey(ignore: true)
   _$$GapCopyWith<_$Gap> get copyWith => throw _privateConstructorUsedError;
 }
@@ -4618,7 +4572,6 @@ class _$_Disk implements _Disk {
   final List<String> _usageLabels;
   @override
   List<String> get usageLabels {
-    if (_usageLabels is EqualUnmodifiableListView) return _usageLabels;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_usageLabels);
   }
@@ -4626,7 +4579,6 @@ class _$_Disk implements _Disk {
   final List<PartitionOrGap> _partitions;
   @override
   List<PartitionOrGap> get partitions {
-    if (_partitions is EqualUnmodifiableListView) return _partitions;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_partitions);
   }
@@ -5350,7 +5302,6 @@ class _$_GuidedStorageResponse implements _GuidedStorageResponse {
   List<Disk>? get disks {
     final value = _disks;
     if (value == null) return null;
-    if (_disks is EqualUnmodifiableListView) return _disks;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -5654,7 +5605,6 @@ class _$_StorageResponse implements _StorageResponse {
   List<dynamic>? get origConfig {
     final value = _origConfig;
     if (value == null) return null;
-    if (_origConfig is EqualUnmodifiableListView) return _origConfig;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -5664,7 +5614,6 @@ class _$_StorageResponse implements _StorageResponse {
   List<dynamic>? get config {
     final value = _config;
     if (value == null) return null;
-    if (_config is EqualUnmodifiableListView) return _config;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -5674,7 +5623,6 @@ class _$_StorageResponse implements _StorageResponse {
   Map<String, dynamic>? get blockdev {
     final value = _blockdev;
     if (value == null) return null;
-    if (_blockdev is EqualUnmodifiableMapView) return _blockdev;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableMapView(value);
   }
@@ -5684,7 +5632,6 @@ class _$_StorageResponse implements _StorageResponse {
   Map<String, dynamic>? get dasd {
     final value = _dasd;
     if (value == null) return null;
-    if (_dasd is EqualUnmodifiableMapView) return _dasd;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableMapView(value);
   }
@@ -5967,7 +5914,6 @@ class _$_StorageResponseV2 implements _StorageResponseV2 {
   @override
   @JsonKey()
   List<Disk> get disks {
-    if (_disks is EqualUnmodifiableListView) return _disks;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_disks);
   }
@@ -6796,14 +6742,14 @@ class __$$GuidedStorageTargetUseGapCopyWithImpl<$Res>
   @override
   $Res call({
     Object? diskId = null,
-    Object? gap = freezed,
+    Object? gap = null,
   }) {
     return _then(_$GuidedStorageTargetUseGap(
       diskId: null == diskId
           ? _value.diskId
           : diskId // ignore: cast_nullable_to_non_nullable
               as String,
-      gap: freezed == gap
+      gap: null == gap
           ? _value.gap
           : gap // ignore: cast_nullable_to_non_nullable
               as Gap,
@@ -7320,7 +7266,6 @@ class _$_GuidedStorageResponseV2 implements _GuidedStorageResponseV2 {
   @override
   @JsonKey()
   List<GuidedStorageTarget> get possible {
-    if (_possible is EqualUnmodifiableListView) return _possible;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_possible);
   }
@@ -7427,19 +7372,19 @@ class _$AddPartitionV2CopyWithImpl<$Res, $Val extends AddPartitionV2>
   @override
   $Res call({
     Object? diskId = null,
-    Object? partition = freezed,
-    Object? gap = freezed,
+    Object? partition = null,
+    Object? gap = null,
   }) {
     return _then(_value.copyWith(
       diskId: null == diskId
           ? _value.diskId
           : diskId // ignore: cast_nullable_to_non_nullable
               as String,
-      partition: freezed == partition
+      partition: null == partition
           ? _value.partition
           : partition // ignore: cast_nullable_to_non_nullable
               as Partition,
-      gap: freezed == gap
+      gap: null == gap
           ? _value.gap
           : gap // ignore: cast_nullable_to_non_nullable
               as Gap,
@@ -7470,19 +7415,19 @@ class __$$_AddPartitionV2CopyWithImpl<$Res>
   @override
   $Res call({
     Object? diskId = null,
-    Object? partition = freezed,
-    Object? gap = freezed,
+    Object? partition = null,
+    Object? gap = null,
   }) {
     return _then(_$_AddPartitionV2(
       diskId: null == diskId
           ? _value.diskId
           : diskId // ignore: cast_nullable_to_non_nullable
               as String,
-      partition: freezed == partition
+      partition: null == partition
           ? _value.partition
           : partition // ignore: cast_nullable_to_non_nullable
               as Partition,
-      gap: freezed == gap
+      gap: null == gap
           ? _value.gap
           : gap // ignore: cast_nullable_to_non_nullable
               as Gap,
@@ -7602,14 +7547,14 @@ class _$ModifyPartitionV2CopyWithImpl<$Res, $Val extends ModifyPartitionV2>
   @override
   $Res call({
     Object? diskId = null,
-    Object? partition = freezed,
+    Object? partition = null,
   }) {
     return _then(_value.copyWith(
       diskId: null == diskId
           ? _value.diskId
           : diskId // ignore: cast_nullable_to_non_nullable
               as String,
-      partition: freezed == partition
+      partition: null == partition
           ? _value.partition
           : partition // ignore: cast_nullable_to_non_nullable
               as Partition,
@@ -7640,14 +7585,14 @@ class __$$_ModifyPartitionV2CopyWithImpl<$Res>
   @override
   $Res call({
     Object? diskId = null,
-    Object? partition = freezed,
+    Object? partition = null,
   }) {
     return _then(_$_ModifyPartitionV2(
       diskId: null == diskId
           ? _value.diskId
           : diskId // ignore: cast_nullable_to_non_nullable
               as String,
-      partition: freezed == partition
+      partition: null == partition
           ? _value.partition
           : partition // ignore: cast_nullable_to_non_nullable
               as Partition,
@@ -8200,7 +8145,6 @@ class _$_SSHData implements _SSHData {
   @override
   @JsonKey()
   List<String> get authorizedKeys {
-    if (_authorizedKeys is EqualUnmodifiableListView) return _authorizedKeys;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_authorizedKeys);
   }
@@ -8581,7 +8525,6 @@ class _$_SSHFetchIdResponse implements _SSHFetchIdResponse {
   List<SSHIdentity>? get identities {
     final value = _identities;
     if (value == null) return null;
-    if (_identities is EqualUnmodifiableListView) return _identities;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -9120,7 +9063,6 @@ class _$_SnapInfo implements _SnapInfo {
   @override
   @JsonKey()
   List<ChannelSnapInfo> get channels {
-    if (_channels is EqualUnmodifiableListView) return _channels;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_channels);
   }
@@ -9357,7 +9299,6 @@ class _$_DriversResponse implements _DriversResponse {
   List<String>? get drivers {
     final value = _drivers;
     if (value == null) return null;
-    if (_drivers is EqualUnmodifiableListView) return _drivers;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -10001,7 +9942,6 @@ class _$_SnapListResponse implements _SnapListResponse {
   @override
   @JsonKey()
   List<SnapInfo> get snaps {
-    if (_snaps is EqualUnmodifiableListView) return _snaps;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_snaps);
   }
@@ -10010,7 +9950,6 @@ class _$_SnapListResponse implements _SnapListResponse {
   @override
   @JsonKey()
   List<SnapSelection> get selections {
-    if (_selections is EqualUnmodifiableListView) return _selections;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_selections);
   }
@@ -11159,7 +11098,6 @@ class _$_UbuntuProSubscription implements _UbuntuProSubscription {
   final List<UbuntuProService> _services;
   @override
   List<UbuntuProService> get services {
-    if (_services is EqualUnmodifiableListView) return _services;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_services);
   }
@@ -12459,7 +12397,7 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
     Object? tasks = null,
     Object? ready = null,
     Object? err = freezed,
-    Object? data = freezed,
+    Object? data = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -12490,7 +12428,7 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
           ? _value.err
           : err // ignore: cast_nullable_to_non_nullable
               as String?,
-      data: freezed == data
+      data: null == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as dynamic,
@@ -12532,7 +12470,7 @@ class __$$_ChangeCopyWithImpl<$Res>
     Object? tasks = null,
     Object? ready = null,
     Object? err = freezed,
-    Object? data = freezed,
+    Object? data = null,
   }) {
     return _then(_$_Change(
       id: null == id
@@ -12563,7 +12501,7 @@ class __$$_ChangeCopyWithImpl<$Res>
           ? _value.err
           : err // ignore: cast_nullable_to_non_nullable
               as String?,
-      data: freezed == data
+      data: null == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as dynamic,
@@ -12599,7 +12537,6 @@ class _$_Change implements _Change {
   final List<Task> _tasks;
   @override
   List<Task> get tasks {
-    if (_tasks is EqualUnmodifiableListView) return _tasks;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_tasks);
   }

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   flutter_lints: ^2.0.0
-  freezed: ^2.1.0
+  freezed: 2.2.1
   json_serializable: ^6.3.1
   mockito: 5.3.2
   test: ^1.17.0


### PR DESCRIPTION
We have issues with version [2.3.0](https://pub.dev/packages/freezed/changelog#230) that added support for covariant unions:
```
lib/src/types.freezed.dart:4142:18: Error: The parameter 'offset' of the method '_$$GapCopyWith.call' has type 'int', which does not match the corresponding type, 'int?', in the overridden method, '$PartitionOrGapCopyWith.call'.
```