### PR TITLE
[WSL] named_event.h: add missing <string> include

### DIFF
--- a/packages/ubuntu_wsl_setup/windows/runner/named_event.h
+++ b/packages/ubuntu_wsl_setup/windows/runner/named_event.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 
 #include <functional>
+#include <string>
 
 // A wrapper around the OpenEvent/RegisterWait Win32 API's setup for triggering
 // only once which waits on another thread and executes the supplied [callback]


### PR DESCRIPTION
Fixes a build issue that has suddenly appeared in the CI:
```
named_event.h(13,19): error C2039: 'string': is not a member of 'std'
```