### PR TITLE
postinst: fix desktop schema overrides

### DIFF
--- a/snap/local/postinst.d/10_override_desktop_settings
+++ b/snap/local/postinst.d/10_override_desktop_settings
@@ -13,10 +13,10 @@ fi
 dconf_dump() {
     target_schema=$target_schemas/20_ubuntu-desktop-installer-$1.gschema.override
     sudo -u $user dconf dump /org/gnome/desktop/$1/ > $target_schema
-    # - [foo] -> [org.gnome.desktop.$1.foo]
-    sed -i -E "s/^\[([^/]*)\]/\[org.gnome.desktop.$1.\1\]/g" $target_schema
-    # - [/] -> [org.gnome.desktop.$1]
-    sed -i -E "s/^\[\/\]$/\[org.gnome.desktop.$1\]/g" $target_schema
+    # - [foo] -> [org.gnome.desktop.$1.foo:ubuntu]
+    sed -i -E "s/^\[([^/]*)\]/\[org.gnome.desktop.$1.\1:ubuntu\]/g" $target_schema
+    # - [/] -> [org.gnome.desktop.$1:ubuntu]
+    sed -i -E "s/^\[\/\]$/\[org.gnome.desktop.$1:ubuntu\]/g" $target_schema
     [ -s $target_schema ] || rm $target_schema
 }
 


### PR DESCRIPTION
The ":ubuntu" selector is necessary to override defaults with the same selector.

```ini
# /usr/share/glib-2.0/schemas/10_ubuntu-settings.gschema.override
[org.gnome.desktop.interface:ubuntu]
gtk-theme = "Yaru"
```
vs.

```ini
# /usr/share/glib-2.0/schemas/20_ubuntu-desktop-installer-interface.gschema.override
[org.gnome.desktop.interface] # <== missing ":ubuntu"
gtk-theme='Yaru-dark'
```

Fixes: #1243