### PR TITLE
SubiquityStatusMonitor: force close when stopped

### DIFF
--- a/packages/subiquity_client/lib/src/status_monitor.dart
+++ b/packages/subiquity_client/lib/src/status_monitor.dart
@@ -36,7 +36,7 @@ class SubiquityStatusMonitor {
   /// Stops monitoring the status.
   Future<void> stop() {
     _status = null;
-    _client.close();
+    _client.close(force: true);
     return _cancel();
   }
 
@@ -88,8 +88,8 @@ class SubiquityStatusMonitor {
       }
       return data;
     } on HttpException catch (_) {
-      return null;
-    }
+    } on SocketException catch (_) {}
+    return null;
   }
 
   void _updateStatus(ApplicationStatus? status) {

--- a/packages/subiquity_client/test/status_monitor_test.dart
+++ b/packages/subiquity_client/test/status_monitor_test.dart
@@ -87,6 +87,7 @@ void main() {
 
     // no changes after stop
     await monitor.stop();
+    verify(client.close(force: true)).called(1);
     await expectLater(monitor.onStatusChanged, neverEmits(isDone));
     verifyNever(client.openUrl('GET', any));
   });


### PR DESCRIPTION
Force the HTTP client to close immediately to avoid keeping the potentially active connection alive until done, and catch socket exceptions in addition to HTTP exceptions to make it more resilient towards connection failures.