### PR TITLE
Use YaruBorderContainer in favor of RoundedContainer & RoundedListView

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -10,11 +10,11 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:timezone_map/timezone_map.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru/yaru.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'l10n.dart';
 import 'pages.dart';
@@ -224,7 +224,7 @@ class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
       content: Row(
         children: [
           Expanded(
-            child: RoundedContainer(height: height),
+            child: YaruBorderContainer(height: height),
           ),
           const SizedBox(width: 20),
           Expanded(

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import 'allocate_disk_space_dialogs.dart';
@@ -18,7 +18,9 @@ class PartitionBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<AllocateDiskSpaceModel>(context);
-    return RoundedContainer(
+    return YaruBorderContainer(
+      borderRadius: BorderRadius.circular(kYaruButtonRadius),
+      clipBehavior: Clip.antiAlias,
       child: CustomPaint(
         size: const Size(double.infinity, 24),
         painter: _PartitionPainter(model),
@@ -198,7 +200,9 @@ class PartitionButtonRow extends StatelessWidget {
 
     return Row(
       children: <Widget>[
-        RoundedContainer(
+        YaruBorderContainer(
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+          clipBehavior: Clip.antiAlias,
           child: IntrinsicHeight(
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'storage_columns.dart';
 import 'storage_types.dart';
@@ -137,7 +137,7 @@ class StorageTable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RoundedContainer(
+    return YaruBorderContainer(
       child: LayoutBuilder(builder: (context, constraints) {
         final theme = Theme.of(context);
         return OverflowBox(

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -122,22 +121,25 @@ class WifiListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<WifiModel>(context);
-    return RoundedListView.builder(
-      shrinkWrap: true,
-      itemCount: model.devices.length,
-      itemBuilder: (context, index) {
-        return ChangeNotifierProvider.value(
-          value: model.devices[index],
-          child: WifiListTile(
-            key: ValueKey(index),
-            selected: model.isSelectedDevice(model.devices[index]),
-            onSelected: (device, accessPoint) {
-              model.selectDevice(device);
-              onSelected(device, accessPoint);
-            },
-          ),
-        );
-      },
+    return YaruBorderContainer(
+      clipBehavior: Clip.antiAlias,
+      child: ListView.builder(
+        shrinkWrap: true,
+        itemCount: model.devices.length,
+        itemBuilder: (context, index) {
+          return ChangeNotifierProvider.value(
+            value: model.devices[index],
+            child: WifiListTile(
+              key: ValueKey(index),
+              selected: model.isSelectedDevice(model.devices[index]),
+              onSelected: (device, accessPoint) {
+                model.selectDevice(device);
+                onSelected(device, accessPoint);
+              },
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';
@@ -87,41 +87,47 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
                 Expanded(
                   child: FocusTraversalGroup(
                     policy: WidgetOrderTraversalPolicy(),
-                    child: RoundedListView.builder(
-                      controller: _layoutListScrollController,
-                      itemCount: model.layoutCount,
-                      itemBuilder: (context, index) {
-                        return AutoScrollTag(
-                          index: index,
-                          key: ValueKey(index),
-                          controller: _layoutListScrollController,
-                          child: ListTile(
-                            title: Text(model.layoutName(index)),
-                            selected: index == model.selectedLayoutIndex,
-                            onTap: () => model.selectLayout(index),
-                          ),
-                        );
-                      },
+                    child: YaruBorderContainer(
+                      clipBehavior: Clip.antiAlias,
+                      child: ListView.builder(
+                        controller: _layoutListScrollController,
+                        itemCount: model.layoutCount,
+                        itemBuilder: (context, index) {
+                          return AutoScrollTag(
+                            index: index,
+                            key: ValueKey(index),
+                            controller: _layoutListScrollController,
+                            child: ListTile(
+                              title: Text(model.layoutName(index)),
+                              selected: index == model.selectedLayoutIndex,
+                              onTap: () => model.selectLayout(index),
+                            ),
+                          );
+                        },
+                      ),
                     ),
                   ),
                 ),
                 const SizedBox(width: 20),
                 Expanded(
-                  child: RoundedListView.builder(
-                    controller: _keyboardVariantListScrollController,
-                    itemCount: model.variantCount,
-                    itemBuilder: (context, index) {
-                      return AutoScrollTag(
-                        index: index,
-                        key: ValueKey(index),
-                        controller: _keyboardVariantListScrollController,
-                        child: ListTile(
-                          title: Text(model.variantName(index)),
-                          selected: index == model.selectedVariantIndex,
-                          onTap: () => model.selectVariant(index),
-                        ),
-                      );
-                    },
+                  child: YaruBorderContainer(
+                    clipBehavior: Clip.antiAlias,
+                    child: ListView.builder(
+                      controller: _keyboardVariantListScrollController,
+                      itemCount: model.variantCount,
+                      itemBuilder: (context, index) {
+                        return AutoScrollTag(
+                          index: index,
+                          key: ValueKey(index),
+                          controller: _keyboardVariantListScrollController,
+                          child: ListTile(
+                            title: Text(model.variantName(index)),
+                            selected: index == model.selectedVariantIndex,
+                            onTap: () => model.selectVariant(index),
+                          ),
+                        );
+                      },
+                    ),
                   ),
                 ),
               ],

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';
@@ -64,25 +64,28 @@ class _WelcomePageState extends State<WelcomePage> {
         child: Row(
           children: [
             Expanded(
-              child: RoundedListView.builder(
-                controller: _languageListScrollController,
-                itemCount: model.languageCount,
-                itemBuilder: (context, index) {
-                  return AutoScrollTag(
-                    index: index,
-                    key: ValueKey(index),
-                    controller: _languageListScrollController,
-                    child: ListTile(
-                      title: Text(model.language(index)),
-                      selected: index == model.selectedLanguageIndex,
-                      onTap: () {
-                        model.selectedLanguageIndex = index;
-                        final settings = Settings.of(context, listen: false);
-                        settings.applyLocale(model.locale(index));
-                      },
-                    ),
-                  );
-                },
+              child: YaruBorderContainer(
+                clipBehavior: Clip.antiAlias,
+                child: ListView.builder(
+                  controller: _languageListScrollController,
+                  itemCount: model.languageCount,
+                  itemBuilder: (context, index) {
+                    return AutoScrollTag(
+                      index: index,
+                      key: ValueKey(index),
+                      controller: _languageListScrollController,
+                      child: ListTile(
+                        title: Text(model.language(index)),
+                        selected: index == model.selectedLanguageIndex,
+                        onTap: () {
+                          model.selectedLanguageIndex = index;
+                          final settings = Settings.of(context, listen: false);
+                          settings.applyLocale(model.locale(index));
+                        },
+                      ),
+                    );
+                  },
+                ),
               ),
             ),
             const SizedBox(width: 20),

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
@@ -70,24 +69,27 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
           Flexible(
             child: FractionallySizedBox(
               widthFactor: 0.5,
-              child: RoundedListView.builder(
-                controller: _languageListScrollController,
-                itemCount: model.languageCount,
-                itemBuilder: (context, index) {
-                  return AutoScrollTag(
-                    index: index,
-                    key: ValueKey(index),
-                    controller: _languageListScrollController,
-                    child: ListTile(
-                      title: Text(model.language(index)),
-                      selected: index == model.selectedLanguageIndex,
-                      onTap: () {
-                        model.selectedLanguageIndex = index;
-                        InheritedLocale.apply(context, model.uiLocale(index));
-                      },
-                    ),
-                  );
-                },
+              child: YaruBorderContainer(
+                clipBehavior: Clip.antiAlias,
+                child: ListView.builder(
+                  controller: _languageListScrollController,
+                  itemCount: model.languageCount,
+                  itemBuilder: (context, index) {
+                    return AutoScrollTag(
+                      index: index,
+                      key: ValueKey(index),
+                      controller: _languageListScrollController,
+                      child: ListTile(
+                        title: Text(model.language(index)),
+                        selected: index == model.selectedLanguageIndex,
+                        onTap: () {
+                          model.selectedLanguageIndex = index;
+                          InheritedLocale.apply(context, model.uiLocale(index));
+                        },
+                      ),
+                    );
+                  },
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
`YaruBorderContainer` is very similar to our homemade `RoundedContainer` but with a tiny bit larger border-radius. Let Yaru define the default border-radius for consistency with other Flutter-based Ubuntu apps.

| Before | After |
|---|---|
| ![Screenshot from 2022-12-13 20-09-28](https://user-images.githubusercontent.com/140617/207423567-4a9be13b-c89a-4f57-97eb-2172908d5fca.png) | ![image](https://user-images.githubusercontent.com/140617/207423545-76058483-b09d-4806-a5ef-f8c80d7e16bf.png) |
| ![image](https://user-images.githubusercontent.com/140617/207537859-eb06b4e4-829f-46b2-94bb-681e7adb831b.png) | ![image](https://user-images.githubusercontent.com/140617/207538509-ab35d031-1b72-420c-9512-56bd6ed837ce.png) |

NOTE: For reusability and performance reasons, the generic `YaruBorderContainer` doesn't force clipping by default. Any container that can have scrollable content, a press/ripple effect, or anything else that needs to clip along the rounded border should therefore explicitly request clipping.