### PR TITLE
Allows unfinished stdout/err on integration tests.

### DIFF
--- a/packages/subiquity_client/lib/src/server/process.dart
+++ b/packages/subiquity_client/lib/src/server/process.dart
@@ -204,8 +204,8 @@ class SubiquityProcess {
       workingDirectory: workingDirectory,
       environment: {...?environment, ...?additionalEnv},
     ).then((process) {
-      stdout.addStream(process.stdout);
-      stderr.addStream(process.stderr);
+      process.stdout.listen(stdout.add);
+      process.stderr.listen(stderr.add);
       return process;
     });
     log.info(


### PR DESCRIPTION
When playing with removing screens from WSL setup I observed that it was possible during integration tests to have a new Subiquity process started without the standard streams of the previous one having finished, thus causing the `addStream` calls to throw exceptions.