### PR TITLE
SubiquityMonitor to stop itself on status DONE or EXITED.

### DIFF
--- a/packages/subiquity_client/lib/src/status_monitor.dart
+++ b/packages/subiquity_client/lib/src/status_monitor.dart
@@ -99,5 +99,9 @@ class SubiquityStatusMonitor {
     if (_statusController?.isClosed == false) {
       _statusController!.add(status);
     }
+    if (_status?.state == ApplicationState.DONE ||
+        _status?.state == ApplicationState.EXITED) {
+      stop();
+    }
   }
 }


### PR DESCRIPTION
This helps preventing socket exceptions being thrown due server down.
DONE should be enough, but there are cases in which the transition goes too fast and we may only get notified of the EXITED status.