### PR TITLE
Refactor: AppModel for the WSL app

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:ubuntu_wsl_setup/app_model.dart';
 import 'package:ubuntu_wsl_setup/splash_screen.dart';
 import 'package:yaru/yaru.dart';
 
@@ -12,14 +12,10 @@ import 'routes.dart';
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({
     super.key,
-    this.variant,
-    this.initialRoute,
-    this.showSplashScreen = false,
+    required this.model,
   });
 
-  final Variant? variant;
-  final String? initialRoute;
-  final bool showSplashScreen;
+  final AppModel model;
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +33,7 @@ class UbuntuWslSetupApp extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
-          home: showSplashScreen == false
+          home: model.showSplashScreen == false
               ? buildWizard(context)
               : SplashScreen(
                   animationDuration: const Duration(seconds: 6),
@@ -49,23 +45,13 @@ class UbuntuWslSetupApp extends StatelessWidget {
   }
 
   Widget? buildWizard(BuildContext context) {
-    if (variant == null && initialRoute != Routes.installationSlides) {
-      return showSplashScreen ? null : const SizedBox.shrink();
+    if (model.variant == null &&
+        model.initialRoute != Routes.installationSlides) {
+      return model.showSplashScreen ? null : const SizedBox.shrink();
     }
 
     return UbuntuWslSetupWizard(
-      initialRoute: initialRoute ?? routeForVariant(variant!),
+      initialRoute: model.initialRoute,
     );
-  }
-
-  String routeForVariant(Variant value) {
-    switch (value) {
-      case Variant.WSL_SETUP:
-        return Routes.selectLanguage;
-      case Variant.WSL_CONFIGURATION:
-        return Routes.advancedReconfig;
-      default:
-        throw UnsupportedError('Unsupported WSL variant: $variant');
-    }
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/app_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/app_model.dart
@@ -1,0 +1,45 @@
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wsl_setup/routes.dart';
+
+class AppModel {
+  final Variant? variant;
+  final bool languageAlreadySet;
+  final bool showSplashScreen;
+  final String? routeFromOptions;
+
+  AppModel copyWith({
+    Variant? variant,
+    bool? languageAlreadySet,
+    bool? showSplashScreen,
+    String? routeFromOptions,
+  }) {
+    return AppModel(
+      variant: variant ?? this.variant,
+      languageAlreadySet: languageAlreadySet ?? this.languageAlreadySet,
+      showSplashScreen: showSplashScreen ?? this.showSplashScreen,
+      routeFromOptions: routeFromOptions ?? this.routeFromOptions,
+    );
+  }
+
+  const AppModel({
+    this.variant,
+    this.languageAlreadySet = false,
+    this.showSplashScreen = false,
+    this.routeFromOptions,
+  });
+
+  String get initialRoute {
+    if (routeFromOptions != null) {
+      return routeFromOptions!;
+    }
+    switch (variant) {
+      case null:
+      case Variant.WSL_SETUP:
+        return languageAlreadySet ? Routes.profileSetup : Routes.selectLanguage;
+      case Variant.WSL_CONFIGURATION:
+        return Routes.advancedReconfig;
+      default:
+        throw UnsupportedError('Unsupported WSL variant: $variant');
+    }
+  }
+}

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -7,15 +7,15 @@ import 'routes.dart';
 class UbuntuWslSetupWizard extends StatelessWidget {
   const UbuntuWslSetupWizard({
     super.key,
-    this.initialRoute,
+    required this.initialRoute,
   });
 
-  final String? initialRoute;
+  final String initialRoute;
 
   @override
   Widget build(BuildContext context) {
     return Wizard(
-      initialRoute: initialRoute ?? Routes.selectLanguage,
+      initialRoute: initialRoute,
       routes: <String, WizardRoute>{
         Routes.installationSlides: const WizardRoute(
           builder: InstallationSlidesPage.create,

--- a/packages/ubuntu_wsl_setup/test/app_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_model_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wsl_setup/app_model.dart';
+import 'package:ubuntu_wsl_setup/routes.dart';
+
+void main() {
+  test('defaults', () {
+    const model = AppModel();
+    expect(model.variant, isNull);
+    expect(model.routeFromOptions, isNull);
+    expect(model.languageAlreadySet, isFalse);
+    expect(model.showSplashScreen, isFalse);
+    expect(model.initialRoute, Routes.selectLanguage);
+  });
+
+  test('copy with', () {
+    const model1 = AppModel();
+    final model2 = model1.copyWith(showSplashScreen: true);
+    expect(model1.showSplashScreen, isFalse);
+    expect(model2.showSplashScreen, isTrue);
+  });
+  test('inital route', () {
+    var model = const AppModel();
+    expect(model.initialRoute, Routes.selectLanguage);
+    model = const AppModel(routeFromOptions: Routes.advancedSetup);
+    expect(model.initialRoute, Routes.advancedSetup);
+    model = const AppModel(languageAlreadySet: true);
+    expect(model.initialRoute, Routes.profileSetup);
+    model = const AppModel(variant: Variant.WSL_CONFIGURATION);
+    expect(model.initialRoute, Routes.advancedReconfig);
+    // this doesn't affect the Routes, but the optional screen shown before the wizard.
+    model = const AppModel(showSplashScreen: true);
+    expect(model.initialRoute, Routes.selectLanguage);
+  });
+}

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -5,6 +5,7 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/app.dart';
+import 'package:ubuntu_wsl_setup/app_model.dart';
 import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
 void main() {
@@ -18,7 +19,9 @@ void main() {
     registerService(LanguageFallbackService.linux);
 
     await tester.pumpWidget(
-      const UbuntuWslSetupApp(variant: Variant.WSL_SETUP),
+      const UbuntuWslSetupApp(
+        model: AppModel(variant: Variant.WSL_SETUP),
+      ),
     );
 
     expect(find.byType(Wizard), findsOneWidget);


### PR DESCRIPTION
To simplify the decision of the default route. That decision was being taken quite scattered between the `main` functions and the `UbuntuWslSetupApp` class. When playing with conditionally skipping the `SelectLanguagePage` it became evident that the complexity of that decision was going too far.
So this refactor implements an POD `AppModel` class to encapsulate that decision, accepting the parameters that affect it. It's intended to be used behind a `ValueListentable<AppModel>` so the app can react to the server response to calls such as `GET /meta/variant' and `GET /locale`.
The following changes should not yet affect any behavior, but allow for simple changes to make that happen.