### PR TITLE
[WSL] Allows conditionally skipping the SelectLanguagePage

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
@@ -15,9 +15,6 @@ void main() {
     await testInstallationSlidesPage(tester);
     await tester.pumpAndSettle();
 
-    await testSelectYourLanguagePage(tester, language: 'Français');
-    await tester.pumpAndSettle();
-
     await testProfileSetupPage(
       tester,
       password: 'password123',

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   // Select language and setup profile
   testWidgets('basic setup', (tester) async {
-    await app.main(<String>[]);
+    await app.main(<String>['--initial-route', Routes.selectLanguage]);
     await tester.pumpAndSettle();
 
     await testSelectYourLanguagePage(tester, language: 'Français');

--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wsl_setup/app_model.dart';
 import 'package:ubuntu_wsl_setup/splash_screen.dart';
@@ -12,13 +13,11 @@ import 'routes.dart';
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({
     super.key,
-    required this.model,
   });
-
-  final AppModel model;
 
   @override
   Widget build(BuildContext context) {
+    final model = context.watch<AppModel>();
     return InheritedLocale(
       child: Builder(builder: (context) {
         return MaterialApp(
@@ -34,17 +33,17 @@ class UbuntuWslSetupApp extends StatelessWidget {
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
           home: model.showSplashScreen == false
-              ? buildWizard(context)
+              ? buildWizard(context, model)
               : SplashScreen(
                   animationDuration: const Duration(seconds: 6),
-                  builder: buildWizard,
+                  builder: (context) => buildWizard(context, model),
                 ),
         );
       }),
     );
   }
 
-  Widget? buildWizard(BuildContext context) {
+  Widget? buildWizard(BuildContext context, AppModel model) {
     if (model.variant == null &&
         model.initialRoute != Routes.installationSlides) {
       return model.showSplashScreen ? null : const SizedBox.shrink();

--- a/packages/ubuntu_wsl_setup/lib/is_locale_set.dart
+++ b/packages/ubuntu_wsl_setup/lib/is_locale_set.dart
@@ -1,0 +1,7 @@
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/utils.dart';
+
+Future<bool> isLocaleSet(SubiquityClient client) async {
+  final loc = await client.locale().then(parseLocale);
+  return loc.languageCode != 'C';
+}

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -38,9 +39,9 @@ Future<void> main(List<String> args) async {
   registerService(UrlLauncher.new);
   registerService(LanguageFallbackService.linux);
   await runWizardApp(
-    ValueListenableBuilder<AppModel>(
-      valueListenable: appModel,
-      builder: (context, model, child) => UbuntuWslSetupApp(model: model),
+    ValueListenableProvider<AppModel>.value(
+      value: appModel,
+      child: const UbuntuWslSetupApp(),
     ),
     options: options,
     subiquityClient: subiquityClient,

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -11,6 +11,7 @@ import 'app.dart';
 import 'app_model.dart';
 import 'args_common.dart';
 import 'installing_state.dart';
+import 'is_locale_set.dart';
 import 'services/language_fallback.dart';
 
 Future<void> main(List<String> args) async {
@@ -51,11 +52,16 @@ Future<void> main(List<String> args) async {
     },
   );
   await subiquityClient.variant().then((value) {
-    appModel.value = appModel.value.copyWith(variant: value);
     if (value == Variant.WSL_SETUP) {
+      isLocaleSet(subiquityClient).then(
+        (isSet) => appModel.value =
+            appModel.value.copyWith(variant: value, languageAlreadySet: isSet),
+      );
       subiquityMonitor.onStatusChanged.listen((status) {
         setWindowClosable(status?.state.isInstalling != true);
       });
+    } else {
+      appModel.value = appModel.value.copyWith(variant: value);
     }
   });
 }

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -89,11 +90,9 @@ Future<void> main(List<String> args) async {
   );
 
   await runWizardApp(
-    ValueListenableBuilder<AppModel>(
-      valueListenable: appModel,
-      builder: (context, model, child) {
-        return UbuntuWslSetupApp(model: model);
-      },
+    ValueListenableProvider<AppModel>.value(
+      value: appModel,
+      child: const UbuntuWslSetupApp(),
     ),
     options: options,
     subiquityClient: subiquityClient,

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -13,6 +13,7 @@ import 'app.dart';
 import 'app_model.dart';
 import 'args_common.dart';
 import 'installing_state.dart';
+import 'is_locale_set.dart';
 import 'routes.dart';
 import 'services/journal.dart';
 import 'services/named_event.dart';
@@ -104,11 +105,16 @@ Future<void> main(List<String> args) async {
     },
   );
   await subiquityClient.variant().then((value) {
-    appModel.value = appModel.value.copyWith(variant: value);
     if (value == Variant.WSL_SETUP) {
+      isLocaleSet(subiquityClient).then(
+        (isSet) => appModel.value =
+            appModel.value.copyWith(variant: value, languageAlreadySet: isSet),
+      );
       subiquityMonitor.onStatusChanged.listen((status) {
         setWindowClosable(status?.state.isInstalling != true);
       });
+    } else {
+      appModel.value = appModel.value.copyWith(variant: value);
     }
   });
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -41,13 +41,9 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     model.loadLanguages().then((_) {
       final locale = InheritedLocale.of(context);
       model.selectLocale(locale);
-      model.getServerLocale().then((loc) {
-        model.selectLocale(loc);
-        InheritedLocale.apply(context, loc);
-        _languageListScrollController.scrollToIndex(model.selectedLanguageIndex,
-            preferPosition: AutoScrollPosition.middle,
-            duration: const Duration(milliseconds: 1));
-      });
+      _languageListScrollController.scrollToIndex(model.selectedLanguageIndex,
+          preferPosition: AutoScrollPosition.middle,
+          duration: const Duration(milliseconds: 1));
     });
     model.getInstallLanguagePacks();
   }

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -17,8 +17,14 @@ class UbuntuWslSetupWizard extends StatelessWidget {
     return Wizard(
       initialRoute: initialRoute,
       routes: <String, WizardRoute>{
-        Routes.installationSlides: const WizardRoute(
+        Routes.installationSlides: WizardRoute(
           builder: InstallationSlidesPage.create,
+          onReplace: (settings) {
+            if ((settings.arguments as bool) == true) {
+              return Routes.profileSetup;
+            }
+            return Routes.selectLanguage;
+          },
         ),
         Routes.selectLanguage: const WizardRoute(
           builder: SelectLanguagePage.create,

--- a/packages/ubuntu_wsl_setup/test/app_test.dart
+++ b/packages/ubuntu_wsl_setup/test/app_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -19,9 +20,9 @@ void main() {
     registerService(LanguageFallbackService.linux);
 
     await tester.pumpWidget(
-      const UbuntuWslSetupApp(
-        model: AppModel(variant: Variant.WSL_SETUP),
-      ),
+      Provider<AppModel>(
+          create: (_) => const AppModel(variant: Variant.WSL_SETUP),
+          child: const UbuntuWslSetupApp()),
     );
 
     expect(find.byType(Wizard), findsOneWidget);

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
@@ -10,6 +10,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:ubuntu_wsl_setup/app_model.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/installation_slides/installation_slides_model.dart';
 import 'package:ubuntu_wsl_setup/pages/installation_slides/installation_slides_page.dart';
@@ -65,20 +66,23 @@ void main() {
   }
 
   Widget buildApp(Widget Function(BuildContext) builder) {
-    return MaterialApp(
-      localizationsDelegates: localizationsDelegates,
-      home: Wizard(routes: {
-        '/': WizardRoute(
-          builder: builder,
-          onNext: (settings) => '/end',
-        ),
-        '/end': WizardRoute(
-          builder: (_) => Center(
-            child: const Text(theEnd),
+    return Provider<AppModel>(
+      create: (_) => AppModel(),
+      child: MaterialApp(
+        localizationsDelegates: localizationsDelegates,
+        home: Wizard(routes: {
+          '/': WizardRoute(
+            builder: builder,
+            onNext: (settings) => '/end',
           ),
-          onNext: (settings) => '/end',
-        ),
-      }),
+          '/end': WizardRoute(
+            builder: (_) => Center(
+              child: const Text(theEnd),
+            ),
+            onNext: (settings) => '/end',
+          ),
+        }),
+      ),
     );
   }
 

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
@@ -71,6 +71,11 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
+  bool get skipLanguageSelection => (super.noSuchMethod(
+        Invocation.getter(#skipLanguageSelection),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get hasError => (super.noSuchMethod(
         Invocation.getter(#hasError),
         returnValue: false,
@@ -101,11 +106,18 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  void init({required void Function()? onServerUp}) => super.noSuchMethod(
+  void init({
+    _i5.AppModel? current,
+    required void Function()? onServerUp,
+  }) =>
+      super.noSuchMethod(
         Invocation.method(
           #init,
           [],
-          {#onServerUp: onServerUp},
+          {
+            #current: current,
+            #onServerUp: onServerUp,
+          },
         ),
         returnValueForMissingStub: null,
       );

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
-import 'dart:ui' as _i5;
+import 'dart:ui' as _i6;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/subiquity_client.dart' as _i2;
+import 'package:ubuntu_wsl_setup/app_model.dart' as _i5;
 import 'package:ubuntu_wsl_setup/pages/installation_slides/installation_slides_model.dart'
     as _i3;
-import 'package:ubuntu_wsl_setup/services/journal.dart' as _i6;
+import 'package:ubuntu_wsl_setup/services/journal.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -61,6 +62,14 @@ class MockInstallationSlidesModel extends _i1.Mock
         Invocation.getter(#journal),
         returnValue: _i4.Stream<String>.empty(),
       ) as _i4.Stream<String>);
+  @override
+  set appModel(_i5.AppModel? details) => super.noSuchMethod(
+        Invocation.setter(
+          #appModel,
+          details,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   bool get hasError => (super.noSuchMethod(
         Invocation.getter(#hasError),
@@ -117,7 +126,7 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -125,7 +134,7 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -145,7 +154,7 @@ class MockInstallationSlidesModel extends _i1.Mock
 /// A class which mocks [JournalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i6.JournalService {
+class MockJournalService extends _i1.Mock implements _i7.JournalService {
   MockJournalService() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/ubuntu_wsl_setup/test/is_locale_set_test.dart
+++ b/packages/ubuntu_wsl_setup/test/is_locale_set_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:ubuntu_wsl_setup/is_locale_set.dart';
+import 'package:ubuntu_test/mocks.dart';
+
+void main() {
+  test('default is not set', () async {
+    final client = MockSubiquityClient();
+    when(client.locale()).thenAnswer((_) async => 'C.UTF-8');
+    expect(await isLocaleSet(client), isFalse);
+  });
+  test('any other is set', () async {
+    final client = MockSubiquityClient();
+    when(client.locale()).thenAnswer((_) async => 'en_US.UTF-8');
+    expect(await isLocaleSet(client), isTrue);
+  });
+}

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -85,7 +85,7 @@ void main() {
     await tester.pumpWidget(buildApp(tester, model, Locale('fr_FR')));
 
     verify(model.loadLanguages()).called(1);
-    verify(model.getServerLocale()).called(1);
+    verifyNever(model.getServerLocale());
     verify(model.selectLocale(Locale('fr_FR'))).called(1);
 
     final continueButton =


### PR DESCRIPTION
Setting up WSL results in an Ubuntu environment with locale set to `C.UTF-8` by default. So, if a `GET` request returns anything different from that value it means the server acknowledged some configuration data for the language, such as when the prefill information file is passed via command line. In such scenarios Subiquity configures the locale controller, so clients can skip the language selection page.

This PR leverages that to skip the `SelectLanguagePage` conditionally. Two consequences unfold:
1. We can no longer assume the `selectLanguage` to be the default initial route and
2. We no longer need to request the server for the language in the SelectLanguagePage because that's only shown if the server is set to C.UTF-8, for which the `parseLocale` sets the UI in English.

Those consequences are reflected in the changes herein submitted to the test code.

Skipping that page on the Windows entry point, where it has to pass through the `InstallationSlidesPage` was a bit more evolving, because the decision of whether the `SelectLanguagePage` could be skipped or not could only be taken close to the moment when the slides page kicks itself out of the stage. `InstallationSlidesModel` now requires knowing about the `AppModel`. Thus the AppModel is now passed via a `ValueListenableProvider`, which carefully exposes the current value, without exposing the listenable object itself. That combined with the `ChangeNotifierProxyProvider` allows the view model to be in sync with the `AppModel` without being able to trigger the listenable object by accident.