### PR TITLE
Pin window_manager at 0.2.8

### DIFF
--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
   url_launcher: ^6.1.0
-  window_manager: ^0.2.5
+  window_manager: 0.2.8
   wizard_router: ^0.9.0
   yaru: ^0.4.6
 


### PR DESCRIPTION
The desktop installer integration test crashes in the CI. Presumably, due to https://github.com/leanflutter/window_manager/pull/268.