### PR TITLE
Manual partitioning table: add/edit on double click

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
@@ -468,10 +469,10 @@ Future<void> testAllocateDiskSpacePage(
   for (final disk in storage ?? []) {
     for (final partition in disk.partitions ?? const <Partition>[]) {
       // TODO: find the correct "free space" slot when there are multiple disks
-      await tester.tap(find.text(tester.lang.freeDiskSpace).last);
-      await tester.pump();
-
-      await tester.tap(find.byIcon(Icons.add));
+      final freeSpace = find.text(tester.lang.freeDiskSpace).last;
+      await tester.tap(freeSpace);
+      await tester.pump(kDoubleTapMinTime);
+      await tester.tap(freeSpace);
       await tester.pumpAndSettle();
 
       if (partition.size != null) {

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -170,12 +170,13 @@ class PartitionTable extends StatelessWidget {
     final model = Provider.of<AllocateDiskSpaceModel>(context);
     return StorageTable(
       columns: [
-        StorageDeviceColumn(),
-        StorageTypeColumn(),
-        StorageMountColumn(),
-        StorageSizeColumn(),
-        StorageSystemColumn(),
+        StorageDeviceColumn(size: ColumnSize.L),
+        StorageTypeColumn(size: ColumnSize.S),
+        StorageMountColumn(size: ColumnSize.M),
+        StorageSizeColumn(size: ColumnSize.S),
+        StorageSystemColumn(size: ColumnSize.M),
         StorageWipeColumn(
+          size: ColumnSize.S,
           onWipe: (disk, partition, wipe) {
             model.editPartition(disk, partition, wipe: wipe);
           },
@@ -186,6 +187,16 @@ class PartitionTable extends StatelessWidget {
       canSelect: model.canSelectStorage,
       isSelected: model.isStorageSelected,
       onSelected: model.selectStorage,
+      onDoubleTap: (disk, [object = -1]) {
+        model.selectStorage(disk, object);
+        if (model.canAddPartition) {
+          showCreatePartitionDialog(
+              context, model.selectedDisk!, model.selectedGap!);
+        } else if (model.canEditPartition) {
+          showEditPartitionDialog(context, model.selectedDisk!,
+              model.selectedPartition!, model.trailingGap);
+        }
+      },
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
@@ -1,3 +1,4 @@
+import 'package:data_table_2/data_table_2.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -6,6 +7,8 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../../l10n.dart';
 import 'storage_types.dart';
 
+export 'package:data_table_2/data_table_2.dart' show ColumnSize;
+
 typedef DiskBuilder = Widget Function(BuildContext context, Disk disk);
 typedef GapBuilder = Widget Function(BuildContext context, Disk disk, Gap gap);
 typedef PartitionBuilder = Widget Function(
@@ -13,12 +16,14 @@ typedef PartitionBuilder = Widget Function(
 
 class StorageColumn {
   const StorageColumn({
+    required this.size,
     required this.titleBuilder,
     required this.diskBuilder,
     required this.gapBuilder,
     required this.partitionBuilder,
   });
 
+  final ColumnSize size;
   final WidgetBuilder titleBuilder;
   final DiskBuilder diskBuilder;
   final GapBuilder gapBuilder;
@@ -26,7 +31,7 @@ class StorageColumn {
 }
 
 class StorageDeviceColumn extends StorageColumn {
-  StorageDeviceColumn()
+  StorageDeviceColumn({required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
@@ -34,28 +39,46 @@ class StorageDeviceColumn extends StorageColumn {
           },
           diskBuilder: (context, disk) {
             return Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(YaruIcons.drive_harddisk_filled),
                 const SizedBox(width: 16),
-                Text(disk.path ?? disk.id),
+                Expanded(
+                  child: Text(
+                    disk.path ?? disk.id,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
               ],
             );
           },
           gapBuilder: (context, disk, gap) {
             return Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(YaruIcons.drive_harddisk),
                 const SizedBox(width: 16),
-                Text(AppLocalizations.of(context).freeDiskSpace),
+                Expanded(
+                  child: Text(
+                    AppLocalizations.of(context).freeDiskSpace,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
               ],
             );
           },
           partitionBuilder: (context, disk, partition) {
             return Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(YaruIcons.drive_harddisk),
                 const SizedBox(width: 16),
-                Text('${disk.path}${partition.number}'),
+                Expanded(
+                  child: Text(
+                    '${disk.path}${partition.number}',
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
               ],
             );
           },
@@ -63,11 +86,11 @@ class StorageDeviceColumn extends StorageColumn {
 }
 
 class StorageTypeColumn extends StorageColumn {
-  StorageTypeColumn()
+  StorageTypeColumn({required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
-            return Text(lang.diskHeadersType);
+            return Text(lang.diskHeadersType, overflow: TextOverflow.ellipsis);
           },
           diskBuilder: (context, disk) {
             return const SizedBox.shrink();
@@ -76,17 +99,23 @@ class StorageTypeColumn extends StorageColumn {
             return const SizedBox.shrink();
           },
           partitionBuilder: (context, disk, partition) {
-            return Text(partition.format ?? '');
+            return Text(
+              partition.format ?? '',
+              overflow: TextOverflow.ellipsis,
+            );
           },
         );
 }
 
 class StorageMountColumn extends StorageColumn {
-  StorageMountColumn()
+  StorageMountColumn({required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
-            return Text(lang.diskHeadersMountPoint);
+            return Text(
+              lang.diskHeadersMountPoint,
+              overflow: TextOverflow.ellipsis,
+            );
           },
           diskBuilder: (context, disk) {
             return const SizedBox.shrink();
@@ -95,36 +124,42 @@ class StorageMountColumn extends StorageColumn {
             return const SizedBox.shrink();
           },
           partitionBuilder: (context, disk, partition) {
-            return Text(partition.mount ?? '');
+            return Text(partition.mount ?? '', overflow: TextOverflow.ellipsis);
           },
         );
 }
 
 class StorageSizeColumn extends StorageColumn {
-  StorageSizeColumn()
+  StorageSizeColumn({required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
-            return Text(lang.diskHeadersSize);
+            return Text(lang.diskHeadersSize, overflow: TextOverflow.ellipsis);
           },
           diskBuilder: (context, disk) {
-            return Text(filesize(disk.size));
+            return Text(filesize(disk.size), overflow: TextOverflow.ellipsis);
           },
           gapBuilder: (context, disk, gap) {
-            return Text(filesize(gap.size));
+            return Text(filesize(gap.size), overflow: TextOverflow.ellipsis);
           },
           partitionBuilder: (context, disk, partition) {
-            return Text(filesize(partition.size ?? 0));
+            return Text(
+              filesize(partition.size ?? 0),
+              overflow: TextOverflow.ellipsis,
+            );
           },
         );
 }
 
 class StorageSystemColumn extends StorageColumn {
-  StorageSystemColumn()
+  StorageSystemColumn({required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
-            return Text(lang.diskHeadersSystem);
+            return Text(
+              lang.diskHeadersSystem,
+              overflow: TextOverflow.ellipsis,
+            );
           },
           diskBuilder: (context, disk) {
             return const SizedBox.shrink();
@@ -133,17 +168,23 @@ class StorageSystemColumn extends StorageColumn {
             return const SizedBox.shrink();
           },
           partitionBuilder: (context, disk, partition) {
-            return Text(partition.os?.long ?? '');
+            return Text(
+              partition.os?.long ?? '',
+              overflow: TextOverflow.ellipsis,
+            );
           },
         );
 }
 
 class StorageWipeColumn extends StorageColumn {
-  StorageWipeColumn({required this.onWipe})
+  StorageWipeColumn({required this.onWipe, required super.size})
       : super(
           titleBuilder: (context) {
             final lang = AppLocalizations.of(context);
-            return Text(lang.diskHeadersFormat);
+            return Text(
+              lang.diskHeadersFormat,
+              overflow: TextOverflow.ellipsis,
+            );
           },
           diskBuilder: (context, disk) {
             return const SizedBox.shrink();

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   async: ^2.8.2
   collection: ^1.15.0
   dartx: ^1.0.0
+  data_table_2: ^2.3.10
   dbus: ^0.7.3
   diacritic: ^0.1.3
   dio: ^4.0.3

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:filesize/filesize.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -133,18 +134,18 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tap(find.text(testDisks.first.path!));
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
     verify(model.selectStorage(0)).called(1);
 
     await tester.tap(find.text(testDisks.last.path!));
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
     verify(model.selectStorage(1)).called(1);
 
     await tester.tap(find
         .text(testDisks.first.partitions.whereType<Partition>().last.mount!));
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
 
     verify(model.selectStorage(0, 1)).called(1);
   });
@@ -221,6 +222,7 @@ void main() {
     expect(checkbox, findsWidgets);
 
     await tester.tap(checkbox.first);
+    await tester.pumpAndSettle(kDoubleTapTimeout);
     verify(model.editPartition(disk, partition, wipe: true)).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/storage_table_test.dart
@@ -44,6 +44,7 @@ void main() {
   );
 
   final pathColumn = StorageColumn(
+    size: ColumnSize.L,
     titleBuilder: (_) => const Text('path'),
     diskBuilder: (_, disk) => Text(disk.path!),
     gapBuilder: (_, disk, gap) => SizedBox.shrink(),
@@ -53,6 +54,7 @@ void main() {
   );
 
   final sizeColumn = StorageColumn(
+    size: ColumnSize.S,
     titleBuilder: (_) => const Text('size'),
     diskBuilder: (_, disk) => Text('${disk.size}b'),
     gapBuilder: (_, disk, gap) => Text('${gap.size}b'),
@@ -78,7 +80,9 @@ void main() {
   }
 
   testWidgets('columns', (tester) async {
-    await tester.pumpWidget(buildTable([pathColumn, sizeColumn]));
+    await tester.pumpWidget(buildTable(
+      [pathColumn, sizeColumn],
+    ));
 
     expect(find.text('path'), findsOneWidget);
     // sda
@@ -204,7 +208,9 @@ void main() {
   });
 
   testWidgets('existing os', (tester) async {
-    await tester.pumpWidget(buildTable([StorageSystemColumn()]));
+    await tester.pumpWidget(buildTable(
+      [StorageSystemColumn(size: ColumnSize.M)],
+    ));
 
     expect(find.text('Ubuntu 18.04'), findsOneWidget);
   });


### PR DESCRIPTION
Let the user double-click partition entries to edit them, or "free space" entries to add new partitions, instead of forcing them to select entries first and then click the _Add_ or _Edit_ button below.

**NOTE**: Due to how gesture negotiation works in Flutter, handling double-click adds a 300ms delay for single clicks. This makes single-click selection and interaction with the Format checkboxes feel somehow a bit laggy.

Close: #1203