### PR TITLE
Use YaruBanner + YaruSelectableContainer for option cards

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -78,8 +78,17 @@ class _ThemeOptionCard extends StatelessWidget {
           width: width,
           child: YaruSelectableContainer(
             selected: selected,
+            padding: EdgeInsets.zero,
             onTap: onTap,
-            child: Image.asset(assetName),
+            child: IntrinsicHeight(
+              child: YaruBanner(
+                padding: EdgeInsets.zero,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.asset(assetName),
+                ),
+              ),
+            ),
           ),
         ),
         Padding(

--- a/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 /// A card widget that presents a toggleable option.
 ///
@@ -23,7 +24,7 @@ import 'package:flutter/material.dart';
 ///   ],
 /// )
 /// ```
-class OptionCard extends StatefulWidget {
+class OptionCard extends StatelessWidget {
   /// Creates an option card with the given properties.
   const OptionCard({
     super.key,
@@ -50,65 +51,36 @@ class OptionCard extends StatefulWidget {
   final VoidCallback onSelected;
 
   @override
-  OptionCardState createState() => OptionCardState();
-}
-
-@visibleForTesting
-// ignore: public_member_api_docs
-class OptionCardState extends State<OptionCard> {
-  bool _hovered = false;
-  bool get hovered => _hovered; // ignore: public_member_api_docs
-
-  void _setHovered(bool hovered) {
-    if (_hovered == hovered) return;
-    setState(() => _hovered = hovered);
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Card(
-      color: Theme.of(context).cardColor,
-      shape: RoundedRectangleBorder(
-          side: BorderSide(
-              color: widget.selected
-                  ? Theme.of(context).primaryColor.withOpacity(0.5)
-                  : Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withAlpha(hovered ? 60 : 20),
-              width: 2),
-          borderRadius: BorderRadius.circular(6)),
-      elevation: 0,
-      child: InkWell(
-        hoverColor: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(6),
-        onHover: _setHovered,
-        onTap: widget.onSelected,
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(children: <Widget>[
-            const SizedBox(height: 20),
-            Expanded(
-              flex: 2,
-              child: widget.image ?? const SizedBox.shrink(),
-            ),
-            const SizedBox(height: 40),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: DefaultTextStyle(
-                style: Theme.of(context).textTheme.bodyText2!.copyWith(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 19,
-                    ),
-                child: widget.title ?? const SizedBox.shrink(),
+    final theme = Theme.of(context);
+    return YaruSelectableContainer(
+      selected: selected,
+      padding: EdgeInsets.zero,
+      child: YaruBanner(
+        onTap: onSelected,
+        padding: const EdgeInsets.all(20),
+        child: Column(children: <Widget>[
+          const SizedBox(height: 20),
+          Expanded(
+            flex: 2,
+            child: image ?? const SizedBox.shrink(),
+          ),
+          const SizedBox(height: 40),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: DefaultTextStyle(
+              style: theme.textTheme.bodyText2!.copyWith(
+                fontWeight: FontWeight.bold,
+                fontSize: 19,
               ),
+              child: title ?? const SizedBox.shrink(),
             ),
-            const SizedBox(height: 10),
-            Expanded(
-              child: widget.body ?? const SizedBox.shrink(),
-            ),
-          ]),
-        ),
+          ),
+          const SizedBox(height: 10),
+          Expanded(
+            child: body ?? const SizedBox.shrink(),
+          ),
+        ]),
       ),
     );
   }

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   window_manager: 0.2.8
   wizard_router: ^0.9.0
   yaru: ^0.4.6
+  yaru_widgets: ^2.0.0-0
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/packages/ubuntu_wizard/test/option_card_test.dart
+++ b/packages/ubuntu_wizard/test/option_card_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,9 +12,11 @@ void main() {
     var wasSelected = false;
     await tester.pumpWidget(
       MaterialApp(
-        home: OptionCard(
-          selected: false,
-          onSelected: () => wasSelected = true,
+        home: Material(
+          child: OptionCard(
+            selected: false,
+            onSelected: () => wasSelected = true,
+          ),
         ),
       ),
     );
@@ -24,33 +25,15 @@ void main() {
     expect(wasSelected, isTrue);
   });
 
-  testWidgets('reacts to hover', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OptionCard(selected: false, onSelected: () {}),
-      ),
-    );
-
-    final state = tester.state<OptionCardState>(find.byType(OptionCard));
-    expect(state.hovered, isFalse);
-
-    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer();
-    addTearDown(gesture.removePointer);
-    await tester.pump();
-    await gesture.moveTo(tester.getCenter(find.byType(OptionCard)));
-    await tester.pumpAndSettle();
-
-    expect(state.hovered, isTrue);
-  });
-
   testWidgets('title text style', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: OptionCard(
-          title: Text('title'),
-          selected: false,
-          onSelected: () {},
+        home: Material(
+          child: OptionCard(
+            title: Text('title'),
+            selected: false,
+            onSelected: () {},
+          ),
         ),
       ),
     );


### PR DESCRIPTION
- subtle background color
- slightly wider selection border
- press effect along the border only, not across the whole card

### Before

[Screencast from 2023-01-04 17-36-29.webm](https://user-images.githubusercontent.com/140617/210604410-441a1ee5-8829-4e03-99e0-c754d4b99968.webm)

### After

[Screencast from 2023-01-04 17-37-06.webm](https://user-images.githubusercontent.com/140617/210604436-c5dfe6c3-9839-427c-af2a-5327cbf17f85.webm)

/cc @Feichtmeier 