### PR TITLE
Use padding & spacing constants from Yaru

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -11,6 +11,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_wizard/app.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru/yaru.dart';
@@ -226,7 +227,7 @@ class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
           Expanded(
             child: YaruBorderContainer(height: height),
           ),
-          const SizedBox(width: 20),
+          const SizedBox(width: kContentSpacing),
           Expanded(
             child: SvgPicture.asset(
               'assets/welcome/logo.svg',

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:ubuntu_wizard/constants.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class NetworkTile extends StatelessWidget {
   const NetworkTile(
@@ -12,10 +12,12 @@ class NetworkTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size =
+        kCheckradioActivableAreaPadding.inflateSize(kCheckradioTogglableSize);
     return Row(
       children: [
         SizedBox.fromSize(
-          size: kRadioSize,
+          size: size,
           child: Center(child: leading),
         ),
         const SizedBox(width: 8),
@@ -40,7 +42,7 @@ class NetworkTile extends StatelessWidget {
         ),
         const SizedBox(width: 8),
         SizedBox.fromSize(
-          size: kRadioSize,
+          size: size,
           child: Center(child: trailing),
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
@@ -55,7 +56,8 @@ class InstallationCompletePage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: kContentSpacing),
                   child: ElevatedButton(
                     onPressed: () async {
                       final model = context.read<InstallationCompleteModel>();

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -108,7 +109,7 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
                     ),
                   ),
                 ),
-                const SizedBox(width: 20),
+                const SizedBox(width: kContentSpacing),
                 Expanded(
                   child: YaruBorderContainer(
                     clipBehavior: Clip.antiAlias,

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
@@ -46,7 +47,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
           //     onSelected: () => model.selectOption(Option.repairUbuntu),
           //   ),
           // ),
-          // const SizedBox(width: 20),
+          // const SizedBox(width: kContentSpacing),
           const Spacer(),
           Expanded(
             flex: 2,
@@ -58,7 +59,7 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
               onSelected: () => model.selectOption(Option.tryUbuntu),
             ),
           ),
-          const SizedBox(width: 20),
+          const SizedBox(width: kContentSpacing * 2),
           Expanded(
             flex: 2,
             child: OptionCard(

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -88,7 +89,7 @@ class _WelcomePageState extends State<WelcomePage> {
                 ),
               ),
             ),
-            const SizedBox(width: 20),
+            const SizedBox(width: kContentSpacing),
             Expanded(
               child: SvgPicture.asset(
                 'assets/welcome/logo.svg',

--- a/packages/ubuntu_wizard/lib/constants.dart
+++ b/packages/ubuntu_wizard/lib/constants.dart
@@ -1,26 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 /// The spacing between Continue and Back buttons.
 const kButtonBarSpacing = 8.0;
 
 /// The spacing between header, content, and footer.
-const kContentSpacing = 20.0;
+const kContentSpacing = kYaruPagePadding;
 
 /// The padding around the content.
-const kContentPadding = EdgeInsets.symmetric(horizontal: 24);
+const kContentPadding = EdgeInsets.symmetric(horizontal: kContentSpacing);
 
 /// The padding around the header.
-const kHeaderPadding = EdgeInsets.fromLTRB(24, 24, 24, 0);
+const kHeaderPadding =
+    EdgeInsets.fromLTRB(kContentSpacing, kContentSpacing, kContentSpacing, 0);
 
 /// The padding around the footer.
-const kFooterPadding = EdgeInsets.fromLTRB(24, 0, 24, 24);
+const kFooterPadding =
+    EdgeInsets.fromLTRB(kContentSpacing, 0, kContentSpacing, kContentSpacing);
 
 /// The fraction of content width in relation to the page.
 const kContentWidthFraction = 0.7;
 
 /// The indentation to align with radio indicators etc.
 const kContentIndentation =
-    EdgeInsetsDirectional.only(start: kMinInteractiveDimension);
-
-/// The size of a radio indicator.
-const kRadioSize = Size.square(kMinInteractiveDimension - 8);
+    EdgeInsetsDirectional.only(start: kContentSpacing * 2);

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   window_manager: 0.2.8
   wizard_router: ^0.9.0
   yaru: ^0.4.6
+  yaru_widgets: ^2.0.0-0
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
The padding and spacing values were somewhat inconsistent. The values used were mostly 20px or 24px, sometimes using app-defined constants, and sometimes values hardcoded inline. Use Yaru's 20px padding constant to have consistent padding throughout the installer GUI and with other Flutter-based Ubuntu apps.

| Before (24px) | After (20px) |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/210767481-7d780954-ee61-4e15-bed9-02a216c60de4.png) | ![image](https://user-images.githubusercontent.com/140617/210767423-063c0c36-1ce2-4157-ab1e-c5b337425452.png) |