### PR TITLE
Installation slides: use YaruIconButton

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -4,6 +4,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';
@@ -117,12 +118,9 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                               : null),
                     ),
                     const Spacer(),
-                    IconButton(
+                    YaruIconButton(
+                      isSelected: model.isLogVisible,
                       icon: const Icon(Icons.terminal),
-                      color: model.isLogVisible
-                          ? Theme.of(context).primaryColor
-                          : null,
-                      splashRadius: 24,
                       onPressed: model.toggleLogVisibility,
                     ),
                   ],

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
@@ -24,6 +24,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../services/journal.dart';
@@ -146,12 +147,9 @@ class _SlidesPage extends StatelessWidget {
                             : null),
                   ),
                   const Spacer(),
-                  IconButton(
+                  YaruIconButton(
                     icon: const Icon(Icons.terminal),
-                    color: model.isLogVisible
-                        ? Theme.of(context).primaryColor
-                        : null,
-                    splashRadius: 24,
+                    isSelected: model.isLogVisible,
                     onPressed: model.toggleLogVisibility,
                   ),
                 ],


### PR DESCRIPTION
The Yaru icon button has a bit nicer highlight and stays circular, unlike the M3 icon button.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/210770007-72d7e19f-3a6b-4553-bb3f-4e4e0287eac8.png) | ![image](https://user-images.githubusercontent.com/140617/210770221-caad8c13-d88e-4c65-89b7-e52883f2719c.png) |
| ![image](https://user-images.githubusercontent.com/140617/210770083-ce9f09ed-9ff3-4dcf-bd28-b05c5f460801.png) | ![image](https://user-images.githubusercontent.com/140617/210770266-328e7688-18c9-48f6-ab22-c6c37e8644f5.png) |