### PR TITLE
Removes Advanced Setup Route

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
@@ -24,9 +24,6 @@ void main() {
       password: 'password123',
       confirmedPassword: 'password123',
     );
-    await tester.pumpAndSettle();
-
-    await testAdvancedSetupPage(tester);
     await testApplyingChangesPage(tester, expectClose: true);
     await tester.pumpAndSettle();
   });

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
@@ -20,9 +20,6 @@ void main() {
       password: 'password123',
       confirmedPassword: 'password123',
     );
-    await tester.pumpAndSettle();
-
-    await testAdvancedSetupPage(tester);
     await testApplyingChangesPage(tester, expectClose: true);
     await tester.pumpAndSettle();
   });

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -28,9 +28,7 @@ void main() {
       password: 'password123',
       confirmedPassword: 'password123',
     );
-    await tester.pumpAndSettle();
 
-    await testAdvancedSetupPage(tester);
     await testApplyingChangesPage(tester, expectClose: true);
 
     await verifyStateFile('basic-setup/WSLLocale');
@@ -38,15 +36,7 @@ void main() {
 
   // enter all WSLConfigurationBase values
   testWidgets('advanced setup', (tester) async {
-    await app.main(<String>['--initial-route', Routes.profileSetup]);
-    await tester.pumpAndSettle();
-
-    await testProfileSetupPage(
-      tester,
-      profile: const IdentityData(realname: 'WSL User', username: 'wsl-user'),
-      password: 'password123',
-      confirmedPassword: 'password123',
-    );
+    await app.main(<String>['--reconfigure']);
     await tester.pumpAndSettle();
 
     // NOTE: opposites of the default values to force writing the config
@@ -59,6 +49,9 @@ void main() {
         networkGenerateresolvconf: false,
       ),
     );
+
+    await tester.pumpAndSettle();
+    await testConfigurationUIPage(tester);
     await testApplyingChangesPage(tester, expectClose: true);
 
     await verifyConfigFile('advanced-setup/wsl.conf');

--- a/packages/ubuntu_wsl_setup/lib/wizard.dart
+++ b/packages/ubuntu_wsl_setup/lib/wizard.dart
@@ -31,12 +31,8 @@ class UbuntuWslSetupWizard extends StatelessWidget {
         ),
         Routes.profileSetup: WizardRoute(
           builder: ProfileSetupPage.create,
-          onNext: (settings) {
-            if ((settings.arguments as bool?) == true) {
-              return Routes.advancedSetup;
-            }
-            return Routes.applyingChanges;
-          },
+          // Unconditionally skip the AdvancedSetupPage due MS feedback.
+          onNext: (settings) => Routes.applyingChanges,
         ),
         Routes.advancedSetup: const WizardRoute(
           builder: AdvancedSetupPage.create,


### PR DESCRIPTION
Addressing feedbacks we receive that the options exposed via this route are not relevant for most users during setup we put together this PR to remove that, while still preserving that page for the reconfiguration workflow.

Latest subqiuity (since https://github.com/canonical/subiquity/pull/1522 ) is required.

Apparently updating subiquity in a separate PR broke the integration tests (ref.: #1296 ), so I had to put them all together.