### PR TITLE
Fix advanced features dialog alignment

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
@@ -30,6 +30,7 @@ Future<void> showAdvancedFeaturesDialog(
           animation: Listenable.merge([advancedFeature, encryption]),
           builder: (context, child) {
             return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 YaruRadioButton<AdvancedFeature>(
                   title: Text(lang.installationTypeNone),

--- a/packages/ubuntu_desktop_installer/lib/routes.dart
+++ b/packages/ubuntu_desktop_installer/lib/routes.dart
@@ -1,5 +1,5 @@
 abstract class Routes {
-  static const initial = installationType;
+  static const initial = welcome;
   static const welcome = '/welcome';
   static const tryOrInstall = '/try-or-install';
   static const turnOffRST = '/turn-off-rst';

--- a/packages/ubuntu_desktop_installer/lib/routes.dart
+++ b/packages/ubuntu_desktop_installer/lib/routes.dart
@@ -1,5 +1,5 @@
 abstract class Routes {
-  static const initial = welcome;
+  static const initial = installationType;
   static const welcome = '/welcome';
   static const tryOrInstall = '/try-or-install';
   static const turnOffRST = '/turn-off-rst';


### PR DESCRIPTION
Yaru check and radio buttons were [fixed to not stretch](https://github.com/ubuntu/yaru_widgets.dart/pull/415), which screwed up the alignment here because columns are center-aligned by default.

| Before | After |
|---|---|
| ![Screenshot from 2023-01-13 10-17-48](https://user-images.githubusercontent.com/140617/212283943-a9d849d2-2bc7-4442-baa9-e8f48767aac3.png) | ![Screenshot from 2023-01-13 10-17-37](https://user-images.githubusercontent.com/140617/212283968-7c6af1a4-2a5e-4f5f-a295-65bea5049c42.png) |

Fixes: #1309