### PR TITLE
NetworkTile: use YaruTile

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_tile.dart
@@ -12,40 +12,12 @@ class NetworkTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final size =
-        kCheckradioActivableAreaPadding.inflateSize(kCheckradioTogglableSize);
-    return Row(
-      children: [
-        SizedBox.fromSize(
-          size: size,
-          child: Center(child: leading),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (title != null)
-                DefaultTextStyle(
-                  style: Theme.of(context).textTheme.subtitle1!,
-                  child: title!,
-                ),
-              if (title != null && subtitle != null) const SizedBox(height: 2),
-              if (subtitle != null)
-                DefaultTextStyle(
-                  style: Theme.of(context).textTheme.bodyText2!,
-                  child: subtitle!,
-                ),
-            ],
-          ),
-        ),
-        const SizedBox(width: 8),
-        SizedBox.fromSize(
-          size: size,
-          child: Center(child: trailing),
-        ),
-      ],
+    return YaruTile(
+      padding: EdgeInsets.zero,
+      leading: SizedBox(width: 32, child: leading),
+      title: title ?? const SizedBox.shrink(),
+      subtitle: subtitle,
+      trailing: trailing,
     );
   }
 }


### PR DESCRIPTION
Replace the home-made tile layout with `YaruTile` that offers a convenient way to achieve the common leading-title-subtitle-trailing "tile" layout.

The `kYaruCheckradio*` constants were considered internal implementation details and moved out of the public API to avoid people using them in creative ways, like myself here...
- https://github.com/ubuntu/yaru_widgets.dart/pull/495

No visual difference:

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/212639203-dc321026-b571-41eb-8950-0caac849ceb1.png) | ![image](https://user-images.githubusercontent.com/140617/212638542-565610ad-da33-43a6-a3b9-d0149ed77789.png) |