### PR TITLE
Move AppBar outside of WizardPage

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -220,7 +220,7 @@ class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
     final height = MediaQuery.of(context).size.height;
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(AppLocalizations.of(context).welcome),
+      title: AppBar(title: Text(AppLocalizations.of(context).welcome)),
       header: Text(lang.welcomeHeader),
       content: Row(
         children: [

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -69,7 +69,10 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
     final lang = AppLocalizations.of(context);
 
     return WizardPage(
-      title: Text(lang.allocateDiskSpace),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.allocateDiskSpace),
+      ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -52,7 +52,10 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(
-      title: Text(lang.chooseSecurityKeyTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.chooseSecurityKeyTitle),
+      ),
       header: FractionallySizedBox(
         widthFactor: kContentWidthFraction,
         child: Text(lang.chooseSecurityKeyHeader(flavor.name)),

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -21,7 +21,10 @@ class ChooseYourLookPage extends StatelessWidget {
         WizardAction.back(context),
         WizardAction.next(context),
       ],
-      title: Text(lang.chooseYourLookPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.chooseYourLookPageTitle),
+      ),
       content: Center(
         child: Row(
             mainAxisSize: MainAxisSize.min,

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
@@ -31,7 +31,10 @@ class _ConfigureSecureBootPageState extends State<ConfigureSecureBootPage> {
     final model = context.watch<ConfigureSecureBootModel>();
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.configureSecureBootTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.configureSecureBootTitle),
+      ),
       header: Text(lang.configureSecureBootDescription),
       content: LayoutBuilder(
         builder: (context, constraints) {

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -56,7 +56,10 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
     final model = Provider.of<ConnectToInternetModel>(context);
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.connectToInternetPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.connectToInternetPageTitle),
+      ),
       header: Text(lang.connectToInternetDescription),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
@@ -70,7 +70,10 @@ class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
     final model = Provider.of<InstallAlongsideModel>(context);
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(_formatTitle(context)),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(_formatTitle(context)),
+      ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -27,7 +27,10 @@ class InstallationCompletePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.installationCompleteTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.installationCompleteTitle),
+      ),
       content: Column(
         children: [
           Padding(

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -83,7 +83,10 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(
-      title: Text(lang.installationTypeTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.installationTypeTitle),
+      ),
       header: Text(_formatHeader(context, model.existingOS ?? [])),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -88,7 +88,10 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
     final model = Provider.of<KeyboardLayoutModel>(context);
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.keyboardLayoutPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.keyboardLayoutPageTitle),
+      ),
       header: Text(lang.chooseYourKeyboardLayout),
       content: Column(
         children: <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -26,7 +26,10 @@ class NotEnoughDiskSpacePage extends StatelessWidget {
     final flavor = Flavor.of(context);
     return Scaffold(
       body: WizardPage(
-        title: Text(lang.notEnoughDiskSpaceTitle),
+        title: AppBar(
+          automaticallyImplyLeading: false,
+          title: Text(lang.notEnoughDiskSpaceTitle),
+        ),
         header: Text(lang.notEnoughDiskSpaceHeader(
             filesize(model.installMinimumSize), flavor.name)),
         content: Text(model.hasMultipleDisks

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -60,7 +60,10 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(
-      title: Text(lang.selectGuidedStoragePageTitle(flavor.name)),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.selectGuidedStoragePageTitle(flavor.name)),
+      ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -34,7 +34,10 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(
-      title: Text(lang.tryOrInstallPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.tryOrInstallPageTitle),
+      ),
       contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 100),
       content: Row(
         children: [

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -27,7 +27,10 @@ class TurnOffBitLockerPage extends StatelessWidget {
     final model = Provider.of<TurnOffBitLockerModel>(context);
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.turnOffBitlockerTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.turnOffBitlockerTitle),
+      ),
       header: Text(lang.turnOffBitlockerDescription),
       content: Column(
         children: [

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -29,7 +29,10 @@ class TurnOffRSTPage extends StatelessWidget {
     final lang = AppLocalizations.of(context);
     return Scaffold(
       body: WizardPage(
-        title: Text(lang.turnOffRST),
+        title: AppBar(
+          automaticallyImplyLeading: false,
+          title: Text(lang.turnOffRST),
+        ),
         header: Text(lang.turnOffRSTDescription),
         content: Column(
           children: <Widget>[

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -46,7 +46,10 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
     final model = context.watch<UpdateOtherSoftwareModel>();
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.updatesOtherSoftwarePageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.updatesOtherSoftwarePageTitle),
+      ),
       headerPadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
       content: Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -75,7 +75,10 @@ class _WelcomePageState extends State<WelcomePage> {
     final lang = AppLocalizations.of(context);
     final height = MediaQuery.of(context).size.height;
     return WizardPage(
-      title: Text(lang.welcome),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.welcome),
+      ),
       header: Text(lang.welcomeHeader),
       content: FractionallySizedBox(
         child: Row(

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -69,7 +69,10 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
     final lang = AppLocalizations.of(context);
 
     return WizardPage(
-      title: Text(lang.whereAreYouPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.whereAreYouPageTitle),
+      ),
       headerPadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
       content: Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -51,7 +51,10 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
 
     return WizardPage(
       contentPadding: EdgeInsets.zero,
-      title: Text(lang.whoAreYouPageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.whoAreYouPageTitle),
+      ),
       content: LayoutBuilder(builder: (context, constraints) {
         final fieldPadding = EdgeInsets.symmetric(
             horizontal: kContentPadding.left, vertical: 10);

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -53,7 +53,10 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<WriteChangesToDiskModel>(context);
     return WizardPage(
-      title: Text(lang.writeChangesToDisk),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.writeChangesToDisk),
+      ),
       header: Text(lang.writeChangesDescription),
       content: ListView(children: <Widget>[
         Align(

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -25,8 +25,8 @@ class WizardPage extends StatefulWidget {
     this.actions = const <WizardAction>[],
   });
 
-  /// The title widget in the app bar.
-  final Widget? title;
+  /// The title widget.
+  final PreferredSizeWidget? title;
 
   /// A header widget below the title.
   final Widget? header;
@@ -68,7 +68,7 @@ class _WizardPageState extends State<WizardPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: widget.title, automaticallyImplyLeading: false),
+      appBar: widget.title,
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -30,7 +30,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          title: const Text('title'),
+          title: AppBar(title: const Text('title')),
           header: const Text('header'),
           content: const Text('content'),
           footer: const Text('footer'),

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -50,7 +50,10 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
     final lang = AppLocalizations.of(context);
     return WizardPage(
       contentPadding: EdgeInsets.zero,
-      title: Text(lang.advancedSetupTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.advancedSetupTitle),
+      ),
       header: Text(lang.advancedSetupHeader),
       content: LayoutBuilder(builder: (context, constraints) {
         final fieldWidth = constraints.maxWidth * kContentWidthFraction;

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -45,7 +45,10 @@ class _ApplyingChangesPageState extends State<ApplyingChangesPage> {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     return WizardPage(
-      title: Text(lang.setupCompleteTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.setupCompleteTitle),
+      ),
       content: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -44,7 +44,10 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<ConfigurationUIModel>(context);
     return WizardPage(
-      title: Text(lang.configurationUITitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.configurationUITitle),
+      ),
       headerPadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
       content: ListView(

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -51,7 +51,10 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
     final textColor = Theme.of(context).textTheme.bodyText2!.color;
     return WizardPage(
       contentPadding: EdgeInsets.zero,
-      title: Text(lang.profileSetupTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.profileSetupTitle),
+      ),
       header: AbsorbPointer(
         child: Html(
           data: lang.profileSetupHeader,

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -59,7 +59,10 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<SelectLanguageModel>(context);
     return WizardPage(
-      title: Text(lang.selectLanguageTitle),
+      title: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(lang.selectLanguageTitle),
+      ),
       content: Column(
         children: [
           Flexible(


### PR DESCRIPTION
This PR does not introduce visual changes but only prepares `WizardPage` to allow passing any `PreferredSizeWidget` to make it possible to replace it with `YaruWindowTitleBar` in the desktop installer. The WSL setup may choose to continue using `AppBar`.

Ref: #670