### PR TITLE
Installation slides: move AppBar outside SlideShow

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -34,6 +34,8 @@ class InstallationSlidesPage extends StatefulWidget {
 }
 
 class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
+  final _titleController = PageController();
+
   @override
   void initState() {
     super.initState();
@@ -52,6 +54,12 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
     });
   }
 
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
   String _formatEvent(InstallationEvent? event) {
     final lang = AppLocalizations.of(context);
     switch (event?.action) {
@@ -68,7 +76,26 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<InstallationSlidesModel>(context);
+    final slides = SlidesContext.of(context);
     return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        titleSpacing: 0,
+        title: SizedBox(
+          height: kYaruTitleBarHeight,
+          child: PageView.builder(
+            controller: _titleController,
+            itemCount: slides.length,
+            itemBuilder: (context, index) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: slides[index].title(context),
+              ),
+            ),
+          ),
+        ),
+      ),
       body: Column(
         children: <Widget>[
           Expanded(
@@ -76,9 +103,14 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
               children: [
                 SlideShow(
                   interval: const Duration(seconds: 50),
-                  slides: SlidesContext.of(context)
-                      .map((slide) => _SlidePage(slide: slide))
-                      .toList(),
+                  slides: slides.map((slide) => slide.body(context)).toList(),
+                  onSlide: (index) {
+                    _titleController.animateToPage(
+                      index,
+                      curve: kSlideCurve,
+                      duration: kSlideDuration,
+                    );
+                  },
                 ),
                 Positioned.fill(
                   top: Theme.of(context).appBarTheme.toolbarHeight,
@@ -135,26 +167,6 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _SlidePage extends StatelessWidget {
-  const _SlidePage({required this.slide});
-
-  final Slide slide;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        AppBar(
-          title: slide.title(context),
-          automaticallyImplyLeading: false,
-        ),
-        slide.body(context),
-      ],
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -48,11 +48,11 @@ void main() {
       child: SlidesContext(slides: [
         Slide(
           title: (context) => Text('title1'),
-          body: (context) => Text('body1'),
+          body: (context) => SizedBox.expand(child: Text('body1')),
         ),
         Slide(
           title: (context) => Text('title2'),
-          body: (context) => Text('body2'),
+          body: (context) => SizedBox.expand(child: Text('body2')),
         ),
       ], child: InstallationSlidesPage()),
     );


### PR DESCRIPTION
This PR does not introduce visual changes but only prepares `InstallationSlidePage` so that we can easily replace `AppBar` with `YaruWindowTitleBar`.

Previously, each slide was wrapped with a `Scaffold` bundled with an `AppBar` for the slide title. This made slide titles nicely animate together with the slides. This approach won't work with `YaruWindowTitleBar` because we don't want the window controls sliding around. :)

This PR creates a separate `AppBar` that can be easily replaced with a `YaruWindowTitleBar` when the time comes. It contains an embedded `PageView` for the slide titles and keeps it in sync with the slide show. The animations use the same curve and duration so it looks the same as before i.e. as if the app bar was inside the slide show.

[Screencast from 2023-01-17 16-14-15.webm](https://user-images.githubusercontent.com/140617/212938071-d72113c7-e483-43c2-bb18-8317719a5938.webm)

Ref: #670