### PR TITLE
Use YaruDialogTitleBar

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -21,7 +21,8 @@ Future<bool> showConfirmationDialog(
     context: context,
     builder: (context) {
       return AlertDialog(
-        title: Text(title),
+        title: YaruDialogTitleBar(title: Text(title)),
+        titlePadding: EdgeInsets.zero,
         content: Text(message),
         actions: <Widget>[
           OutlinedButton(
@@ -57,8 +58,10 @@ Future<void> showCreatePartitionDialog(
 
       final lang = AppLocalizations.of(context);
       return AlertDialog(
-        title: Text(lang.partitionCreateTitle),
-        titlePadding: kHeaderPadding,
+        title: YaruDialogTitleBar(
+          title: Text(lang.partitionCreateTitle),
+        ),
+        titlePadding: EdgeInsets.zero,
         contentPadding: kContentPadding.copyWith(
             top: kContentSpacing, bottom: kContentSpacing),
         actionsPadding: kFooterPadding,
@@ -184,8 +187,10 @@ Future<void> showEditPartitionDialog(
 
       final lang = AppLocalizations.of(context);
       return AlertDialog(
-        title: Text(lang.partitionEditTitle),
-        titlePadding: kHeaderPadding,
+        title: YaruDialogTitleBar(
+          title: Text(lang.partitionEditTitle),
+        ),
+        titlePadding: EdgeInsets.zero,
         contentPadding: kContentPadding.copyWith(
             top: kContentSpacing, bottom: kContentSpacing),
         actionsPadding: kFooterPadding,

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../widgets.dart';
@@ -71,7 +72,10 @@ class StorageSizeDialog extends StatelessWidget {
     final lang = AppLocalizations.of(context);
     final canAccept = size >= minimumSize && size <= maximumSize;
     return AlertDialog(
-      title: Text(title),
+      title: YaruDialogTitleBar(
+        title: Text(title),
+      ),
+      titlePadding: EdgeInsets.zero,
       buttonPadding: EdgeInsets.zero,
       content: CallbackShortcuts(
         bindings: {

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
@@ -19,8 +19,10 @@ Future<void> showAdvancedFeaturesDialog(
       final flavor = Flavor.of(context);
 
       return AlertDialog(
-        title: Text(lang.installationTypeAdvancedTitle),
-        titlePadding: kHeaderPadding,
+        title: YaruDialogTitleBar(
+          title: Text(lang.installationTypeAdvancedTitle),
+        ),
+        titlePadding: EdgeInsets.zero,
         contentPadding: kContentPadding.copyWith(
             top: kContentSpacing, bottom: kContentSpacing),
         actionsPadding: kFooterPadding,

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';
@@ -29,8 +30,10 @@ Future<StepResult?> showDetectKeyboardLayoutDialog(BuildContext context) async {
         builder: (context, step, _) {
           final size = MediaQuery.of(context).size;
           return AlertDialog(
-            title: Text(lang.detectLayout),
-            titlePadding: kHeaderPadding,
+            title: YaruDialogTitleBar(
+              title: Text(lang.detectLayout),
+            ),
+            titlePadding: EdgeInsets.zero,
             contentPadding: kContentPadding.copyWith(
                 top: kContentSpacing, bottom: kContentSpacing),
             actionsPadding: kFooterPadding,


### PR DESCRIPTION
This not only makes the dialogs look nicer but also adds such behavior that could be considered a pre-requisite for replacing the native `HdyHeaderBar` with `YaruWindowTitleBar` (outside vs. inside the Flutter view, respectively).

When a modal dialog is open, the entire Flutter view is covered by a modal barrier. This means that `YaruWindowTitleBar` is not accessible underneath whenever a modal dialog is open. `YaruDialogTitleBar` solves this by offering the usual top-level window actions (move by drag, right-click menu) via the dialog title bar. It feels a lot like a modal top-level dialog attached to and blocking its parent window.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/213433450-4ce288fc-2624-4a9b-91cb-095d253eeb6d.png) | ![image](https://user-images.githubusercontent.com/140617/213432515-638d6e89-4601-4aa9-9171-11847652e497.png) |
| ![image](https://user-images.githubusercontent.com/140617/213433581-e69cd010-c9d6-4a4b-962b-235ffdf41805.png) | ![image](https://user-images.githubusercontent.com/140617/213433649-46f0e851-f7d9-4356-8bcc-08a8491d8817.png) |
| ![image](https://user-images.githubusercontent.com/140617/213436464-463dc2f0-086d-474d-89dc-97b06210dfd4.png) | ![image](https://user-images.githubusercontent.com/140617/213436355-687ac73b-4e80-4665-82a6-4013610d6802.png) |
| ![image](https://user-images.githubusercontent.com/140617/213436555-a0fee65a-ef55-4db6-8b4d-4d2fe1c6cde5.png) | ![image](https://user-images.githubusercontent.com/140617/213436861-f1cbcb6c-0bf9-4833-b83c-a4b8c7ff4f9d.png) |
| ![image](https://user-images.githubusercontent.com/140617/213437377-4ac98c7e-28ce-413b-9890-405a21c59d67.png) | ![image](https://user-images.githubusercontent.com/140617/213437331-5fdd1e25-6d09-463c-9d31-31a1ff1638bb.png) |

Ref: #670