### PR TITLE
Fix "Resize partition" -dialog's button spacing

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
@@ -72,6 +72,7 @@ class StorageSizeDialog extends StatelessWidget {
     final canAccept = size >= minimumSize && size <= maximumSize;
     return AlertDialog(
       title: Text(title),
+      buttonPadding: EdgeInsets.zero,
       content: CallbackShortcuts(
         bindings: {
           if (canAccept)


### PR DESCRIPTION
It was spotted in #1323 that the spacing between the ok and cancel buttons is different than in all other dialogs. I wish this was themable in Flutter...

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/213440357-5743de3b-d450-4556-b9c3-965c0098264f.png) | ![image](https://user-images.githubusercontent.com/140617/213440290-3646f3fe-eae1-4a28-88a0-cd21e1860b85.png) |