### PR TITLE
WSL: fix integration test

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -123,11 +123,13 @@ Future<void> testApplyingChangesPage(
   WidgetTester tester, {
   bool expectClose = false,
 }) async {
+  final windowClosed = expectClose ? waitForWindowClosed() : null;
+
   await tester.pumpUntil(find.byType(ApplyingChangesPage));
   expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
 
-  if (expectClose) {
-    expect(await waitForWindowClosed(), isTrue);
+  if (windowClosed != null) {
+    expect(await windowClosed, isTrue);
   }
 }
 


### PR DESCRIPTION
`waitForWindowClosed()` installs a mock method handler on the "window_manager" channel. It handles window close requests and responds by pretending the window was closed. This prevents integration tests from closing the window for real and abruptly exiting the integration test process.

This PR changes the calling order to make sure the aforementioned mock method call handler is set up early enough by calling `waitForWindowClose()` before `pumpUntil(ApplyingChangedPage)` to avoid the window accidentally getting closed for real, while waiting for the page to appear.

Fixes: #1330