### PR TITLE
Hide unsupported/legacy/obsolete partition format options

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
@@ -457,6 +457,8 @@
   "@partitionFormatReiserFS": {},
   "partitionFormatZfsroot": "ZFS root file system",
   "@partitionFormatZfsroot": {},
+  "partitionFormatNone": "Leave unformatted",
+  "@partitionFormatNone": {},
   "partitionErase": "Format the partition",
   "@partitionErase": {},
   "partitionMountPointLabel": "Mount point:",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1214,6 +1214,12 @@ abstract class AppLocalizations {
   /// **'ZFS root file system'**
   String get partitionFormatZfsroot;
 
+  /// No description provided for @partitionFormatNone.
+  ///
+  /// In en, this message translates to:
+  /// **'Leave unformatted'**
+  String get partitionFormatNone;
+
   /// No description provided for @partitionErase.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -544,6 +544,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -544,6 +544,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -544,6 +544,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -544,6 +544,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -544,6 +544,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -544,6 +544,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -544,6 +544,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -544,6 +544,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formata la partició';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -544,6 +544,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get partitionFormatZfsroot => 'Kořenový souborový systém na ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Naformátovat oddíl';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -544,6 +544,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -544,6 +544,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -544,6 +544,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS-Root-Dateisystem';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Partition formatieren';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -544,6 +544,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get partitionFormatZfsroot => 'Radika dosiersistemo ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Reprepari la subdiskon';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get partitionFormatZfsroot => 'Sistema de archivos raíz ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formatear la partición';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -544,6 +544,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -544,6 +544,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -544,6 +544,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root -tiedostojärjestelmä';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Alusta osio';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -544,6 +544,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get partitionFormatZfsroot => 'Système de fichiers racine ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formatter la partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -544,6 +544,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -544,6 +544,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -544,6 +544,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -544,6 +544,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get partitionFormatZfsroot => 'מערכת קבצים לבסיס ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'פרמוט המחיצה';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -544,6 +544,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -544,6 +544,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -544,6 +544,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS gyökér fájlrendszer';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'A partíció formázása';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -544,6 +544,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get partitionFormatZfsroot => 'Sistem berkas root ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format partisi';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -544,6 +544,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -544,6 +544,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -544,6 +544,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS ルートファイルシステム';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'パーティションをフォーマット';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS 루트 파일 시스템';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => '파티션 포맷';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -544,6 +544,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -544,6 +544,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -544,6 +544,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -544,6 +544,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -544,6 +544,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -544,6 +544,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root ഫയൽ സിസ്റ്റം';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'പാർട്ടീഷൻ ഫോർമാറ്റ് ചെയ്യുക';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -544,6 +544,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -544,6 +544,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -544,6 +544,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS-rotfilsystem';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formater partisjonen';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -544,6 +544,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -544,6 +544,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -544,6 +544,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -544,6 +544,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get partitionFormatZfsroot => 'sistèma de fichièr ZFS';
 
   @override
+  String get partitionFormatNone => 'utilizar pas la particion';
+
+  @override
   String get partitionErase => 'Formatar la particion';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -544,6 +544,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -544,6 +544,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get partitionFormatZfsroot => 'System plików root ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Sformatuj partycję';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -544,6 +544,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get partitionFormatZfsroot => 'Sistema de ficheiros raiz ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formatar a partição';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -544,6 +544,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -544,6 +544,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get partitionFormatZfsroot => 'Корневая файловая система ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Форматировать раздел';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS මූල ගොනු පද්ධතිය';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -544,6 +544,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS rotfilsystem';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Formatera partitionen';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -544,6 +544,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root dosya sistemi';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Bölümü biçimlendir';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -544,6 +544,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -544,6 +544,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get partitionFormatZfsroot => 'Коренева файлова система ZFS';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Відформатувати розділ';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -544,6 +544,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS root file system';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => 'Format the partition';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -544,6 +544,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get partitionFormatZfsroot => 'ZFS 根文件系统';
 
   @override
+  String get partitionFormatNone => 'Leave unformatted';
+
+  @override
   String get partitionErase => '格式化分区';
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -53,7 +53,8 @@ Future<void> showCreatePartitionDialog(
     builder: (context) {
       final partitionUnit = ValueNotifier(DataUnit.megabytes);
       final partitionSize = ValueNotifier(gap.size);
-      final partitionFormat = ValueNotifier(PartitionFormat.defaultValue);
+      final partitionFormat =
+          ValueNotifier<PartitionFormat?>(PartitionFormat.defaultValue);
       final partitionMount = ValueNotifier<String?>(null);
 
       final lang = AppLocalizations.of(context);
@@ -93,7 +94,7 @@ Future<void> showCreatePartitionDialog(
               Text(lang.partitionFormatLabel, textAlign: TextAlign.end),
               _PartitionFormatSelector(
                 partitionFormat: partitionFormat,
-                partitionFormats: PartitionFormat.supported,
+                partitionFormats: [...PartitionFormat.supported, null],
               )
             ],
             <Widget>[
@@ -346,7 +347,7 @@ class _PartitionFormatSelector extends StatelessWidget {
   });
 
   final ValueNotifier<PartitionFormat?> partitionFormat;
-  final List<PartitionFormat> partitionFormats;
+  final List<PartitionFormat?> partitionFormats;
 
   @override
   Widget build(BuildContext context) {
@@ -354,13 +355,13 @@ class _PartitionFormatSelector extends StatelessWidget {
     return ValueListenableBuilder<PartitionFormat?>(
       valueListenable: partitionFormat,
       builder: (context, type, child) {
-        return DropdownBuilder<PartitionFormat>(
+        return DropdownBuilder<PartitionFormat?>(
           selected: type,
           values: partitionFormats,
           itemBuilder: (context, format, _) {
             return Text(
-              format.localize(lang),
-              key: ValueKey(format.type),
+              format?.localize(lang) ?? lang.partitionFormatNone,
+              key: ValueKey(format?.type),
             );
           },
           onSelected: (value) => partitionFormat.value = value,

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -93,6 +93,7 @@ Future<void> showCreatePartitionDialog(
               Text(lang.partitionFormatLabel, textAlign: TextAlign.end),
               _PartitionFormatSelector(
                 partitionFormat: partitionFormat,
+                partitionFormats: PartitionFormat.supported,
               )
             ],
             <Widget>[
@@ -221,7 +222,10 @@ Future<void> showEditPartitionDialog(
             ],
             <Widget>[
               Text(lang.partitionFormatLabel, textAlign: TextAlign.end),
-              _PartitionFormatSelector(partitionFormat: partitionFormat),
+              _PartitionFormatSelector(
+                partitionFormat: partitionFormat,
+                partitionFormats: PartitionFormat.values,
+              ),
             ],
             <Widget>[
               const SizedBox.shrink(),
@@ -338,9 +342,11 @@ class _PartitionWipeCheckbox extends StatelessWidget {
 class _PartitionFormatSelector extends StatelessWidget {
   const _PartitionFormatSelector({
     required this.partitionFormat,
+    required this.partitionFormats,
   });
 
   final ValueNotifier<PartitionFormat?> partitionFormat;
+  final List<PartitionFormat> partitionFormats;
 
   @override
   Widget build(BuildContext context) {
@@ -350,7 +356,7 @@ class _PartitionFormatSelector extends StatelessWidget {
       builder: (context, type, child) {
         return DropdownBuilder<PartitionFormat>(
           selected: type,
-          values: PartitionFormat.values,
+          values: partitionFormats,
           itemBuilder: (context, format, _) {
             return Text(
               format.localize(lang),

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -60,7 +60,7 @@ class PartitionFormat {
   static List<PartitionFormat> get values => _formats.values.toList();
 
   /// Partition formats supported for new partitions.
-  static List<PartitionFormat> get supported => [btrfs, ext4, swap, xfs];
+  static List<PartitionFormat> get supported => [ext4, xfs, btrfs, swap];
 
   static const _formats = <String, PartitionFormat>{
     'btrfs': btrfs,

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -56,8 +56,11 @@ class PartitionFormat {
   static PartitionFormat? fromPartition(Partition partition) =>
       _formats[partition.format];
 
-  /// Available partition formats.
+  /// All available partition formats.
   static List<PartitionFormat> get values => _formats.values.toList();
+
+  /// Partition formats supported for new partitions.
+  static List<PartitionFormat> get supported => [btrfs, ext4, swap, xfs];
 
   static const _formats = <String, PartitionFormat>{
     'btrfs': btrfs,

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -47,11 +47,11 @@ void main() {
     await tester.enterText(find.byType(SpinBox), '123');
     await tester.pump();
 
-    await tester.tap(find.byType(DropdownButton<PartitionFormat>));
+    await tester.tap(find.byType(DropdownButton<PartitionFormat?>));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byWidgetPredicate((widget) {
-      if (widget is! DropdownMenuItem<PartitionFormat>) return false;
+      if (widget is! DropdownMenuItem<PartitionFormat?>) return false;
       return widget.value == PartitionFormat.btrfs;
     }).last);
     await tester.pumpAndSettle();
@@ -115,11 +115,11 @@ void main() {
     await tester.enterText(find.byType(SpinBox), '123');
     await tester.pump();
 
-    await tester.tap(find.byType(DropdownButton<PartitionFormat>));
+    await tester.tap(find.byType(DropdownButton<PartitionFormat?>));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byWidgetPredicate((widget) {
-      if (widget is! DropdownMenuItem<PartitionFormat>) return false;
+      if (widget is! DropdownMenuItem<PartitionFormat?>) return false;
       return widget.value == PartitionFormat.btrfs;
     }).last);
     await tester.pumpAndSettle();


### PR DESCRIPTION
When creating new partitions:
- leave out unsupported/legacy/obsolete partition formats,
- offer a "Leave unformatted" option, and
- reorder the options to match Subiquity.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/219937096-72ca40df-9b7c-4333-ae4b-68a4adaca751.png) | ![image](https://user-images.githubusercontent.com/140617/219938016-cfa2baec-51e6-4d29-a5de-2634015230b2.png) |

<!--
![image](https://user-images.githubusercontent.com/140617/214318146-6463a470-a40d-4f6d-81c5-3756776df98a.png)
-->

Close: #1332