### PR TITLE
Control window closability from the widget tree

### DIFF
--- a/packages/ubuntu_desktop_installer/test/widget_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widget_test.dart
@@ -34,6 +34,11 @@ void main() {
     when(client.getStorageV2()).thenAnswer((_) async => testStorageResponse());
     when(client.isOpen).thenAnswer((_) async => true);
     registerMockService<SubiquityClient>(client);
+
+    final monitor = MockSubiquityStatusMonitor();
+    when(monitor.onStatusChanged).thenAnswer((_) => Stream.empty());
+    registerMockService<SubiquityStatusMonitor>(monitor);
+
     registerMockService<DiskStorageService>(DiskStorageService(client));
     registerMockService<TelemetryService>(TelemetryService());
 


### PR DESCRIPTION
Instead of subscribing to Subiquity status changes in runInstallerApp() (and leaking the subscription), do it from within the widget tree to be able to update the upcoming Flutter-based window title bar in #1329.