### PR TITLE
Pin Flutter version at 3.3

### DIFF
--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.3.x'
 
     - name: Build Windows Target
       working-directory: packages\ubuntu_wsl_setup\

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.3.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -67,6 +68,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.3.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -91,6 +93,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.3.x'
 
     - name: Install Melos
       run: flutter pub global activate melos

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.x'
 
       - name: Flutter Doctor
         run: flutter doctor -v

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-branch: stable
+    source-tag: 3.3.10
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
Flutter 3.7 was released yesterday: https://medium.com/flutter/whats-new-in-flutter-3-7-38cbea71133c

There are a few things to fix before we're ready to upgrade. Pinning the version at 3.3 helps to keep the CI green meanwhile.