### PR TITLE
Upgrade to Flutter 3.7

### DIFF
--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.3.x'
+        flutter-version: '3.7.x'
 
     - name: Build Windows Target
       working-directory: packages\ubuntu_wsl_setup\

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.3.x'
+        flutter-version: '3.7.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -68,7 +68,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.3.x'
+        flutter-version: '3.7.x'
 
     - name: Install Melos
       run: flutter pub global activate melos
@@ -93,7 +93,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '3.3.x'
+        flutter-version: '3.7.x'
 
     - name: Install Melos
       run: flutter pub global activate melos

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.3.x'
+          flutter-version: '3.7.x'
 
       - name: Flutter Doctor
         run: flutter doctor -v

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -151,8 +151,8 @@ class _PartitionLabel extends StatelessWidget {
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(title, style: Theme.of(context).textTheme.subtitle2),
-            Text(filesize(size), style: Theme.of(context).textTheme.caption),
+            Text(title, style: Theme.of(context).textTheme.titleSmall),
+            Text(filesize(size), style: Theme.of(context).textTheme.bodySmall),
           ],
         ),
       ],

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -151,8 +151,8 @@ class StorageTable extends StatelessWidget {
                 dataRowHeight: kMinInteractiveDimension +
                     theme.visualDensity.baseSizeAdjustment.dy,
                 showCheckboxColumn: false,
-                headingTextStyle: theme.textTheme.subtitle2,
-                dataTextStyle: theme.textTheme.bodyText2,
+                headingTextStyle: theme.textTheme.titleSmall,
+                dataTextStyle: theme.textTheme.bodyMedium,
                 columns: columns
                     .map((column) =>
                         DataColumn(label: column.titleBuilder(context)))

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -76,7 +76,7 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
                 widthFactor: kContentWidthFraction,
                 child: Html(
                   data: lang.chooseSecurityKeyWarning(
-                      Theme.of(context).errorColor.toHex()),
+                      Theme.of(context).colorScheme.error.toHex()),
                   style: {'body': Style(margin: EdgeInsets.zero)},
                 ),
               ),

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -97,7 +97,7 @@ class _ThemeOptionCard extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.all(8.0),
           child: Text(preferenceName,
-              style: Theme.of(context).textTheme.headline6),
+              style: Theme.of(context).textTheme.titleLarge),
         )
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
@@ -25,7 +25,7 @@ class EthernetRadioButton extends StatelessWidget {
     if (!model.isEnabled || model.devices.isEmpty) {
       return NetworkTile(
         leading:
-            Icon(YaruIcons.window_close, color: Theme.of(context).errorColor),
+            Icon(YaruIcons.window_close, color: Theme.of(context).colorScheme.error),
         title: model.devices.isEmpty
             ? Text(lang.noWiredConnection)
             : Text(lang.wiredDisabled),

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/ethernet_view.dart
@@ -24,8 +24,8 @@ class EthernetRadioButton extends StatelessWidget {
     final lang = AppLocalizations.of(context);
     if (!model.isEnabled || model.devices.isEmpty) {
       return NetworkTile(
-        leading:
-            Icon(YaruIcons.window_close, color: Theme.of(context).colorScheme.error),
+        leading: Icon(YaruIcons.window_close,
+            color: Theme.of(context).colorScheme.error),
         title: model.devices.isEmpty
             ? Text(lang.noWiredConnection)
             : Text(lang.wiredDisabled),

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
@@ -34,7 +34,7 @@ class WifiRadioButton extends StatelessWidget {
       child: !model.isEnabled || model.devices.isEmpty
           ? NetworkTile(
               leading: Icon(YaruIcons.window_close,
-                  color: Theme.of(context).errorColor),
+                  color: Theme.of(context).colorScheme.error),
               title: !model.isEnabled
                   ? Text(lang.wirelessNetworkingDisabled)
                   : Text(lang.noWifiDevicesDetected),
@@ -157,7 +157,7 @@ class WifiListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final device = Provider.of<WifiDevice>(context);
-    final textColor = Theme.of(context).textTheme.subtitle1!.color;
+    final textColor = Theme.of(context).textTheme.titleMedium!.color;
     final iconSize = IconTheme.of(context).size;
     return ExpansionTile(
       initiallyExpanded: true,

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
@@ -1,4 +1,4 @@
-import 'package:collection/collection.dart';
+import 'package:collection/collection.dart' hide ListExtensions;
 import 'package:dartx/dartx.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -83,7 +83,7 @@ class InstallAlongsideModel extends SafeChangeNotifier {
   Partition? getPartition(int index) {
     final number = getStorage(index)?.partitionNumber;
     if (number == null) return null;
-    return getAllPartitions(index)?.firstOrNullWhere((p) => p.number == number);
+    return getAllPartitions(index)?.firstWhereOrNull((p) => p.number == number);
   }
 
   /// Returns all partitions of the disk of the guided storage at the

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_button.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_button.dart
@@ -34,7 +34,7 @@ class StorageButton extends StatelessWidget {
           const SizedBox(height: kContentSpacing / 2),
           Text(
             name,
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
             overflow: TextOverflow.ellipsis,
             softWrap: false,
           ),
@@ -49,7 +49,7 @@ class StorageButton extends StatelessWidget {
           const SizedBox(height: kContentSpacing / 2),
           Text(
             filesize(size),
-            style: Theme.of(context).textTheme.headline5,
+            style: Theme.of(context).textTheme.headlineSmall,
             overflow: TextOverflow.clip,
             softWrap: false,
           ),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -120,7 +120,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                     duration: const Duration(milliseconds: 150),
                     offset: Offset(0, model.isLogVisible ? 0 : 1),
                     child: Container(
-                      color: Theme.of(context).backgroundColor,
+                      color: Theme.of(context).colorScheme.background,
                       padding: const EdgeInsets.only(
                         top: kContentSpacing,
                         left: kContentSpacing,
@@ -134,7 +134,7 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
             ),
           ),
           Container(
-            color: Theme.of(context).backgroundColor,
+            color: Theme.of(context).colorScheme.background,
             padding: const EdgeInsets.all(kContentSpacing),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -145,9 +145,9 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                       model.hasError
                           ? lang.installationFailed
                           : _formatEvent(model.event),
-                      style: Theme.of(context).textTheme.bodyText2!.copyWith(
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                           color: model.hasError
-                              ? Theme.of(context).errorColor
+                              ? Theme.of(context).colorScheme.error
                               : null),
                     ),
                     const Spacer(),
@@ -184,7 +184,7 @@ class _JournalView extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: kContentSpacing),
       style: TextStyle(
         inherit: false,
-        fontSize: Theme.of(context).textTheme.bodyText1!.fontSize,
+        fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
         fontFamily: 'Ubuntu Mono',
         textBaseline: TextBaseline.alphabetic,
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -121,7 +121,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
             title: Text(lang.installationTypeErase(flavor.name)),
             subtitle: Html(
               data: lang.installationTypeEraseWarning(
-                  Theme.of(context).errorColor.toHex()),
+                  Theme.of(context).colorScheme.error.toHex()),
               style: {'body': Style(margin: EdgeInsets.zero)},
             ),
             value: InstallationType.erase,

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_widgets.dart
@@ -21,7 +21,7 @@ class PressKeyView extends StatelessWidget {
         Text(lang.pressOneKey),
         const SizedBox(height: kContentSpacing),
         DefaultTextStyle(
-          style: Theme.of(context).textTheme.headline5!,
+          style: Theme.of(context).textTheme.headlineSmall!,
           child: Wrap(
             spacing: 24,
             alignment: WrapAlignment.spaceEvenly,
@@ -50,7 +50,7 @@ class KeyPresentView extends StatelessWidget {
         Text(lang.isKeyPresent),
         const SizedBox(height: kContentSpacing),
         DefaultTextStyle(
-          style: Theme.of(context).textTheme.headline5!,
+          style: Theme.of(context).textTheme.headlineSmall!,
           child: Align(
             alignment: Alignment.center,
             child: Text(_keyPresent),

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -104,14 +104,14 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
                   const SizedBox(height: kContentSpacing / 2),
                   Text(
                     flavor.name,
-                    style: Theme.of(context).textTheme.headline6,
+                    style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: kContentSpacing / 2),
                   Text(model.selectedDisk?.path ?? ''),
                   const SizedBox(height: kContentSpacing / 2),
                   Text(
                     filesize(model.selectedDisk?.size ?? 0),
-                    style: Theme.of(context).textTheme.headline5,
+                    style: Theme.of(context).textTheme.headlineSmall,
                   ),
                 ],
               ),

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -48,7 +48,7 @@ class TurnOffRSTPage extends StatelessWidget {
             const SizedBox(height: 60),
             SvgPicture.asset(
               'assets/turn_off_rst/qr-code.svg',
-              color: Theme.of(context).textTheme.bodyText1!.color,
+              color: Theme.of(context).textTheme.bodyLarge!.color,
             ),
           ],
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -99,7 +99,7 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
       ),
       footer: model.onBattery
           ? Html(
-              data: lang.onBatteryWarning(Theme.of(context).errorColor.toHex()),
+              data: lang.onBatteryWarning(Theme.of(context).colorScheme.error.toHex()),
             )
           : null,
       actions: <WizardAction>[

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -99,7 +99,8 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
       ),
       footer: model.onBattery
           ? Html(
-              data: lang.onBatteryWarning(Theme.of(context).colorScheme.error.toHex()),
+              data: lang.onBatteryWarning(
+                  Theme.of(context).colorScheme.error.toHex()),
             )
           : null,
       actions: <WizardAction>[

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
@@ -128,7 +128,7 @@ void main() {
     expect(warning, findsOneWidget);
     expect(
       tester.widget<Html>(warning).data,
-      equals(tester.lang.onBatteryWarning(theme.errorColor.toHex())),
+      equals(tester.lang.onBatteryWarning(theme.colorScheme.error.toHex())),
     );
   });
 

--- a/packages/ubuntu_wizard/lib/src/widgets/icons.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/icons.dart
@@ -24,6 +24,6 @@ class ErrorIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(Icons.error, color: Theme.of(context).errorColor);
+    return Icon(Icons.error, color: Theme.of(context).colorScheme.error);
   }
 }

--- a/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/option_card.dart
@@ -69,7 +69,7 @@ class OptionCard extends StatelessWidget {
           Align(
             alignment: Alignment.centerLeft,
             child: DefaultTextStyle(
-              style: theme.textTheme.bodyText2!.copyWith(
+              style: theme.textTheme.bodyMedium!.copyWith(
                 fontWeight: FontWeight.bold,
                 fontSize: 19,
               ),

--- a/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
@@ -22,7 +22,7 @@ class PasswordStrengthLabel extends StatelessWidget {
       case PasswordStrength.weak:
         return Text(
           lang.weakPassword,
-          style: TextStyle(color: Theme.of(context).errorColor),
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
         );
       case PasswordStrength.fair:
         return Text(lang.fairPassword);

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
       path: packages/ubuntu_widgets
   url_launcher: ^6.1.0
   window_manager: ^0.3.0
-  wizard_router: ^0.9.0
+  wizard_router: ^0.9.2
   yaru: ^0.4.6
   yaru_widgets: ^2.0.0-0
 

--- a/packages/ubuntu_wizard/test/option_card_test.dart
+++ b/packages/ubuntu_wizard/test/option_card_test.dart
@@ -45,7 +45,7 @@ void main() {
     expect(titleStyle, isNotNull);
 
     final theme = Theme.of(tester.element(title)).textTheme;
-    expect(titleStyle.color, equals(theme.bodyText2!.color));
-    expect(titleStyle.fontSize, greaterThan(theme.bodyText2!.fontSize!));
+    expect(titleStyle.color, equals(theme.bodyMedium!.color));
+    expect(titleStyle.fontSize, greaterThan(theme.bodyMedium!.fontSize!));
   });
 }

--- a/packages/ubuntu_wizard/test/password_strength_label_test.dart
+++ b/packages/ubuntu_wizard/test/password_strength_label_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     final widget = tester.widget<Text>(find.text(text));
     expect(widget.style?.color, isNotNull);
-    expect(widget.style!.color, equals(Theme.of(context).errorColor));
+    expect(widget.style!.color, equals(Theme.of(context).colorScheme.error));
   });
 
   testWidgets('fair password', (tester) async {

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/installation_slides_page.dart
@@ -152,9 +152,9 @@ class _SlidesPage extends StatelessWidget {
                     model.hasError
                         ? lang.installationSlidesErrorMsg
                         : lang.installationSlidesUnpacking,
-                    style: Theme.of(context).textTheme.bodyText2!.copyWith(
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                         color: model.hasError
-                            ? Theme.of(context).errorColor
+                            ? Theme.of(context).colorScheme.error
                             : null),
                   ),
                   const Spacer(),
@@ -202,7 +202,7 @@ class _JournalView extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: kContentSpacing),
       style: TextStyle(
         inherit: false,
-        fontSize: Theme.of(context).textTheme.bodyText1!.fontSize,
+        fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
         fontFamily: 'Ubuntu Mono',
         textBaseline: TextBaseline.alphabetic,
       ),
@@ -231,7 +231,7 @@ class _ErrorScreen extends StatelessWidget {
         subtitle: 'Oh, no!',
         span: [
           TextSpan(
-            style: Theme.of(context).textTheme.bodyText1,
+            style: Theme.of(context).textTheme.bodyLarge,
             text: lang.installationSlidesErrorText,
           ),
           const TextSpan(text: '\n'),
@@ -256,7 +256,7 @@ class _CodeLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = Theme.of(context).textTheme.bodyText1!.copyWith(
+    final style = Theme.of(context).textTheme.bodyLarge!.copyWith(
           fontFamily: 'Ubuntu Mono',
           backgroundColor: Theme.of(context).highlightColor,
         );

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
@@ -80,10 +80,13 @@ class Slide extends StatelessWidget {
                     children: [
                       Text(
                         subtitle,
-                        style: Theme.of(context).textTheme.headlineMedium!.copyWith(
-                            color: Colors.white70,
-                            fontSize: 32,
-                            fontWeight: FontWeight.normal),
+                        style: Theme.of(context)
+                            .textTheme
+                            .headlineMedium!
+                            .copyWith(
+                                color: Colors.white70,
+                                fontSize: 32,
+                                fontWeight: FontWeight.normal),
                       ),
                       if (span != null)
                         RichText(text: TextSpan(children: span)),

--- a/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/installation_slides/slides.dart
@@ -80,7 +80,7 @@ class Slide extends StatelessWidget {
                     children: [
                       Text(
                         subtitle,
-                        style: Theme.of(context).textTheme.headline4!.copyWith(
+                        style: Theme.of(context).textTheme.headlineMedium!.copyWith(
                             color: Colors.white70,
                             fontSize: 32,
                             fontWeight: FontWeight.normal),
@@ -177,7 +177,7 @@ List<Slide> theSlides(BuildContext context) {
 TextStyle _bodyTextStyle(BuildContext context) {
   return Theme.of(context)
       .textTheme
-      .headline6!
+      .titleLarge!
       .copyWith(color: Colors.white70, fontWeight: FontWeight.normal);
 }
 

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -48,7 +48,7 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
     final model = Provider.of<ProfileSetupModel>(context);
-    final textColor = Theme.of(context).textTheme.bodyText2!.color;
+    final textColor = Theme.of(context).textTheme.bodyMedium!.color;
     return WizardPage(
       contentPadding: EdgeInsets.zero,
       title: AppBar(

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.3.10
+    source-tag: 3.7.0
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
- CI bumped to 3.7.x
- Snap bumped to 3.7.0
- `deprecated_member_use` fixed by `dart fix`
- `ambiguous_extension_member_access` fixed by hand

P.S. There are minor formatting differences in the l10n files generated by 3.3 vs. 3.7. Those changes were intentionally left out because we can let the bot take care of it. :)