### PR TITLE
Melos: add generic pub command

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -47,7 +47,7 @@ jobs:
     # test all packages
 
     - name: Bootstrap workspace
-      run: melos bootstrap
+      run: melos pub get
     
     - name: Run tests
       run: melos run coverage
@@ -74,7 +74,7 @@ jobs:
       run: flutter pub global activate melos
 
     - name: Bootstrap workspace
-      run: melos bootstrap
+      run: melos pub get
 
     - name: Check for any formatting issues
       run: melos run format
@@ -99,7 +99,7 @@ jobs:
       run: flutter pub global activate melos
 
     - name: Bootstrap workspace
-      run: melos bootstrap
+      run: melos pub get
 
     - name: Generate source code
       run: melos run generate

--- a/melos.yaml
+++ b/melos.yaml
@@ -46,12 +46,10 @@ scripts:
     melos exec -c 1 --fail-fast --dir-exists=integration_test -- \
       flutter test integration_test
 
+  # runs "flutter pub <arg(s)>" in all packages
+  pub: melos exec -c 1 -- flutter pub "$@"
+
   # run tests in all packages
   test: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \
       flutter test
-
-  # runs pub upgrade in all packages
-  upgrade: >
-    melos exec -c 1 -- \
-      flutter pub upgrade


### PR DESCRIPTION
[Melos bootstrap](https://melos.invertase.dev/commands/bootstrap) does some magic under the hood to connect local packages with each other by modifying the package config generated by the Dart tool. This functionality helps with development in mono-repos managing multiple published packages depending on each other, such as flutterfire and plus_plugins. In our case, however, the complicated bootstrapping process is not only unnecessary but also creates issues that we're working around by sometimes manually running "pub get" instead.

This commit adds a new generic "melos pub" command that accepts the rest as arguments so that it can be used to run pub get, upgrade, or any other pub subcommand in all packages. We've had "melos pub-get", "melos upgrade" and similar commands in various projects because I didn't know it was possible to forward melos script arguments... It turns out "$@" only works if the whole script is on a single line. :slightly_smiling_face: 