### PR TITLE
Installation slides: remove log view background & border

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -191,6 +191,9 @@ class _JournalView extends StatelessWidget {
       ),
       decoration: const InputDecoration(
         border: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        fillColor: Colors.transparent,
         contentPadding: EdgeInsets.symmetric(vertical: kContentSpacing / 2),
       ),
       background: BoxDecoration(color: Theme.of(context).shadowColor),


### PR DESCRIPTION
yaru.dart 0.5.0 added fill color and a default border in different states that we don't want in the log view.

| Before Yaru update | After Yaru update | After this PR |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/140617/215453595-23246708-d458-4077-b40c-618ed3348831.png) | ![image](https://user-images.githubusercontent.com/140617/215453188-e3475e16-de9e-4dce-9bb9-b677f7b5357a.png) | ![image](https://user-images.githubusercontent.com/140617/215453937-aaa447f0-8380-4ed7-9ad6-cb33975ce1de.png) |