### PR TITLE
Reduce the window size to match the design

### DIFF
--- a/packages/ubuntu_desktop_installer/linux/my_application.cc
+++ b/packages/ubuntu_desktop_installer/linux/my_application.cc
@@ -53,7 +53,7 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
   gtk_window_set_type_hint(window, GDK_WINDOW_TYPE_HINT_DIALOG);  // no min/max
-  gtk_window_set_default_size(window, 960, 680 + 48);             // header bar
+  gtk_window_set_default_size(window, 960, 680);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(


### PR DESCRIPTION
We should not reserve the extra 48px for a window title bar anymore because we merged the app bar and the window header bar in #1329. Without the extra 48px we still have effectively the same content area as it was before the title bar changes.

Thanks to the app & title bar merger, we ended up having too much empty space on some pages making them look a bit unbalanced.

| Before | After |
|---|---|
| ![Screenshot from 2023-02-06 14-09-41](https://user-images.githubusercontent.com/140617/216981007-3f722423-324e-4879-a82b-05178ecbbc3d.png) | ![Screenshot from 2023-02-06 14-08-44](https://user-images.githubusercontent.com/140617/216981043-72336952-2cda-42ac-8935-3748306d9d60.png) |