### PR TITLE
Connect to internet: show a spinner while connecting to wifi

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
@@ -165,6 +165,13 @@ class WifiListTile extends StatelessWidget {
       title: Text(device.model ?? device.interface),
       textColor: textColor,
       iconColor: textColor,
+      trailing: device.isConnecting
+          ? SizedBox(
+              width: iconSize,
+              height: iconSize,
+              child: const YaruCircularProgressIndicator(strokeWidth: 3),
+            )
+          : null,
       children: <Widget>[
         for (final accessPoint in device.accessPoints)
           ChangeNotifierProvider.value(

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_view_test.dart
@@ -77,6 +77,28 @@ void main() {
       ),
     );
 
+    // inactive device
+    final tile1 = find.widgetWithText(ListTile, 'model1');
+    expect(tile1, findsOneWidget);
+    expect(
+      find.descendant(
+        of: tile1,
+        matching: find.byType(YaruCircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+
+    // connecting device
+    final tile2 = find.widgetWithText(ListTile, 'model2');
+    expect(tile2, findsOneWidget);
+    expect(
+      find.descendant(
+        of: tile2,
+        matching: find.byType(YaruCircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+
     // select ap
     final ap1 = find.widgetWithText(ListTile, 'ap1').first;
     expect(ap1, findsOneWidget);


### PR DESCRIPTION
Give the user a visual clue when a wifi device is establishing a connection.

[Screencast from 2023-02-09 07-34-04.webm](https://user-images.githubusercontent.com/140617/217736572-e303ce16-4d62-4f57-93b8-21d8881ed936.webm)
