### PR TITLE
Connect to internet: consider "need auth" a busy/connecting state

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/network_model.dart
@@ -151,6 +151,7 @@ class NetworkDevice extends PropertyStreamNotifier {
   bool get isActive => state == NetworkManagerDeviceState.activated;
   bool get isConnecting {
     switch (state) {
+      case NetworkManagerDeviceState.needAuth:
       case NetworkManagerDeviceState.config:
       case NetworkManagerDeviceState.ipCheck:
       case NetworkManagerDeviceState.ipConfig:

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/network_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/network_model_test.dart
@@ -63,6 +63,7 @@ void main() {
 
   test('state', () async {
     const connectingStates = {
+      NetworkManagerDeviceState.needAuth,
       NetworkManagerDeviceState.prepare,
       NetworkManagerDeviceState.config,
       NetworkManagerDeviceState.ipCheck,


### PR DESCRIPTION
When connecting to an access point that needs authentication, there can be a noticeable delay before a wifi device enters the "prepare" or "config" states.

Considering the "need auth" as a busy/connecting state helps to prevent accidentally clicking the _Connect_ button multiple times while the device is already in the process of establishing a connection...