### PR TITLE
Write changes to disk: add missing partition format check

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -135,7 +135,7 @@ class _PartitionLabel extends StatelessWidget {
         partition.format ?? '',
         partition.mount ?? '',
       );
-    } else if (partition.wipe != null) {
+    } else if (partition.wipe != null && partition.format?.isNotEmpty == true) {
       return lang.writeChangesPartitionFormatted(
         sysname,
         partition.number ?? 0,

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -70,6 +70,7 @@ final testDisks = <Disk>[
       Partition(
         number: 7,
         preserve: false,
+        wipe: 'superblock',
       ),
     ],
   ),


### PR DESCRIPTION
Don't assume that a wiped partition has a format because it's not always the case.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/217779780-cc36390f-d371-4da2-9664-a336fb9ddd7f.png) | ![Screenshot from 2023-02-09 10-49-04](https://user-images.githubusercontent.com/140617/217779224-b5d2ba1f-33ed-44a7-a64d-99277a767110.png) |

Fixes: #1372