### PR TITLE
ValidatedFormField: select all when gaining input focus

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -103,10 +103,21 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
     if (widget.focusNode == null) {
       _focusNode ??= FocusNode();
     }
+    focusNode.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() {
+    if (focusNode.hasPrimaryFocus && primaryFocus?.context != null) {
+      Actions.maybeInvoke<SelectAllTextIntent>(
+        primaryFocus!.context!,
+        const SelectAllTextIntent(SelectionChangedCause.keyboard),
+      );
+    }
   }
 
   @override
   void dispose() {
+    focusNode.removeListener(_onFocusChange);
     _controller.dispose();
     _focusNode?.dispose();
     super.dispose();

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -380,4 +380,29 @@ void main() {
     expect(find.text('is ubuntu'), findsNothing);
     expect(find.text('not ubuntu'), findsOneWidget);
   });
+
+  testWidgets('select all', (tester) async {
+    final controller = TextEditingController(text: 'Ubuntu');
+    final focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ValidatedFormField(
+            controller: controller,
+            focusNode: focusNode,
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.selection.isCollapsed, isTrue);
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    expect(controller.selection.isCollapsed, isFalse);
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, controller.text.length);
+  });
 }


### PR DESCRIPTION
> For example the hostname is pre-filled but it's unlikely the name you want to give to the machine. So you have to do CTRL+A or select with the mouse or delete the entire text to replace the content

[Screencast from 2023-02-09 12-06-58.webm](https://user-images.githubusercontent.com/140617/217797144-cf9ba165-eab4-4da6-a1bc-e074c9f450b4.webm)
