### PR TITLE
Remove unused dio dependency

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   dartx: ^1.0.0
   dbus: ^0.7.3
   diacritic: ^0.1.3
-  dio: ^4.0.3
   file: ^6.1.0
   filesize: ^2.0.0
   flutter:


### PR DESCRIPTION
I noticed Renovate trying to offer an update but we're not even using dio in the installer.

- https://github.com/canonical/ubuntu-desktop-installer/pull/1398