### PR TITLE
CI: use `make install_deps` for subiquity deps

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Get subiquity dependencies
       working-directory: ./packages/subiquity_client/subiquity
-      run: sudo ./scripts/installdeps.sh
+      run: make install_deps
 
     - name: Check subiquity integration
       run: ./scripts/subiquity_integration


### PR DESCRIPTION
Same as #1407 but this time for the CI workflow. Integration tests run on 22.04 whereas these run on 20.04 which may explain why the two started to fail at different times...

```
Setting up grub-efi-amd64-signed (1.187.3~20.04.1+2.06-2ubuntu14.1) ...
mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-14d5346542020202076e4e0de6b21a348aa1740149647cee7-part15 does not exist.
dpkg: error processing package grub-efi-amd64-signed (--configure):
 installed grub-efi-amd64-signed package post-installation script subprocess returned error exit status 32
[...]
Errors were encountered while processing:
 grub-efi-amd64-signed
E: Sub-process /usr/bin/dpkg returned an error code (1)
Error: Process completed with exit code 100.
```
https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4194769934/jobs/7273374343