### PR TITLE
Connect to internet: disable superfluous radio button

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -7,6 +7,7 @@ import '../../l10n.dart';
 import '../../services.dart';
 import 'connect_model.dart';
 import 'connect_to_internet_model.dart';
+import 'connect_view.dart';
 import 'ethernet_model.dart';
 import 'ethernet_view.dart';
 import 'hidden_wifi_model.dart';
@@ -87,11 +88,8 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
           HiddenWifiView(
             expanded: model.connectMode == ConnectMode.hiddenWifi,
           ),
-          YaruRadioButton<ConnectMode>(
-            title: Text(lang.noInternet),
-            value: ConnectMode.none,
-            contentPadding: const EdgeInsets.only(top: 8),
-            groupValue: model.connectMode,
+          NoConnectView(
+            value: model.connectMode,
             onChanged: (_) => model.selectConnectMode(ConnectMode.none),
           ),
         ],

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_view.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n.dart';
+import 'connect_model.dart';
+import 'ethernet_model.dart';
+import 'wifi_model.dart';
+
+class NoConnectView extends StatelessWidget {
+  const NoConnectView({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final ConnectMode? value;
+  final ValueChanged<ConnectMode?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final lang = AppLocalizations.of(context);
+    final ethernet = context
+        .select((EthernetModel m) => m.isEnabled && m.devices.isNotEmpty);
+    final wifi =
+        context.select((WifiModel m) => m.isEnabled && m.devices.isNotEmpty);
+
+    return YaruRadioButton<ConnectMode>(
+      title: Text(lang.noInternet),
+      value: ConnectMode.none,
+      contentPadding: const EdgeInsets.only(top: 8),
+      groupValue: value,
+      onChanged: ethernet || wifi ? onChanged : null,
+    );
+  }
+}

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_view_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/pages/connect_to_internet/connect_model.dart';
+import 'package:ubuntu_desktop_installer/pages/connect_to_internet/connect_view.dart';
+import 'package:ubuntu_desktop_installer/pages/connect_to_internet/ethernet_model.dart';
+import 'package:ubuntu_desktop_installer/pages/connect_to_internet/wifi_model.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../test_utils.dart';
+import 'ethernet_view_test.mocks.dart';
+import 'wifi_view_test.mocks.dart';
+
+void main() {
+  setUpAll(() => UbuntuTester.context = NoConnectView);
+
+  testWidgets('disabled when no ethernet nor wifi', (tester) async {
+    final ethernet = MockEthernetModel();
+    when(ethernet.devices).thenReturn([]);
+    when(ethernet.isEnabled).thenReturn(false);
+
+    final wifi = MockWifiModel();
+    when(wifi.devices).thenReturn([]);
+    when(wifi.isEnabled).thenReturn(true);
+
+    await tester.pumpWidget(
+      tester.buildApp(
+        (_) => MultiProvider(
+          providers: [
+            ChangeNotifierProvider<EthernetModel>.value(value: ethernet),
+            ChangeNotifierProvider<WifiModel>.value(value: wifi),
+          ],
+          child: NoConnectView(value: ConnectMode.none, onChanged: (_) {}),
+        ),
+      ),
+    );
+
+    final radioButton = find.byType(YaruRadioButton<ConnectMode>);
+    expect(radioButton, findsOneWidget);
+    expect(tester.widget<YaruRadioButton>(radioButton).onChanged, isNull);
+  });
+}


### PR DESCRIPTION
If both ethernet and wifi are disabled or unavailable, disable the "I don't want to connect to the internet just now" radio button because there's nothing to select.

![Screenshot from 2023-02-17 14-20-34](https://user-images.githubusercontent.com/140617/219666410-3485e4d2-9015-4c31-a243-0fa9c77dfc12.png)

Fixes: #1402