### PR TITLE
Remove old unused InstallationSlideModel.reboot()

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p;
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_wizard/utils.dart';
 
 import '../../services.dart';
 
@@ -25,12 +24,11 @@ class InstallationEvent {
 }
 
 /// View model for [InstallationSlidesPage].
-class InstallationSlidesModel extends SafeChangeNotifier with SystemShutdown {
+class InstallationSlidesModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
-  InstallationSlidesModel(this.client, this._journal);
+  InstallationSlidesModel(this._client, this._journal);
 
-  @override
-  final SubiquityClient client;
+  final SubiquityClient _client;
   final JournalService _journal;
 
   Stream<String>? _log;
@@ -98,7 +96,7 @@ class InstallationSlidesModel extends SafeChangeNotifier with SystemShutdown {
 
   /// Initializes and starts monitoring the status of the installation.
   Future<void> init() {
-    return client.status().then((status) {
+    return _client.status().then((status) {
       _log = _journal.start(status.logSyslogId);
       _updateStatus(status);
       _monitorStatus(status.eventSyslogId);
@@ -130,14 +128,8 @@ class InstallationSlidesModel extends SafeChangeNotifier with SystemShutdown {
     final events = _journal.start(syslogId, output: JournalOutput.cat);
     final subscription = events.listen(_processEvent);
     while (!isDone && !hasError) {
-      await client.status(current: state).then(_updateStatus);
+      await _client.status(current: state).then(_updateStatus);
     }
     subscription.cancel();
-  }
-
-  /// Requests an immediate system reboot.
-  @override
-  Future<void> reboot({bool immediate = true}) {
-    return super.reboot(immediate: immediate);
   }
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -125,22 +125,6 @@ void main() async {
     expect(model.hasError, isTrue);
   });
 
-  test('reboot', () async {
-    var windowClosed = false;
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
-
-    final client = MockSubiquityClient();
-    final journal = MockJournalService();
-    final model = InstallationSlidesModel(client, journal);
-
-    await model.reboot(immediate: true);
-    verify(client.reboot(immediate: true)).called(1);
-    expect(windowClosed, isTrue);
-  });
-
   test('log visibility', () async {
     final model = InstallationSlidesModel(
       MockSubiquityClient(),

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -3,15 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
-import 'dart:ui' as _i6;
+import 'dart:async' as _i3;
+import 'dart:ui' as _i5;
 
-import 'package:flutter/widgets.dart' as _i5;
+import 'package:flutter/widgets.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_desktop_installer/pages/installation_slides/installation_slides_model.dart'
-    as _i3;
-import 'package:ubuntu_desktop_installer/services.dart' as _i7;
+    as _i2;
+import 'package:ubuntu_desktop_installer/services.dart' as _i6;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,34 +23,15 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i7;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeSubiquityClient_0 extends _i1.SmartFake
-    implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
 /// A class which mocks [InstallationSlidesModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockInstallationSlidesModel extends _i1.Mock
-    implements _i3.InstallationSlidesModel {
+    implements _i2.InstallationSlidesModel {
   MockInstallationSlidesModel() {
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  _i2.SubiquityClient get client => (super.noSuchMethod(
-        Invocation.getter(#client),
-        returnValue: _FakeSubiquityClient_0(
-          this,
-          Invocation.getter(#client),
-        ),
-      ) as _i2.SubiquityClient);
   @override
   bool get isDone => (super.noSuchMethod(
         Invocation.getter(#isDone),
@@ -68,10 +48,10 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  _i4.Stream<String> get log => (super.noSuchMethod(
+  _i3.Stream<String> get log => (super.noSuchMethod(
         Invocation.getter(#log),
-        returnValue: _i4.Stream<String>.empty(),
-      ) as _i4.Stream<String>);
+        returnValue: _i3.Stream<String>.empty(),
+      ) as _i3.Stream<String>);
   @override
   bool get isLogVisible => (super.noSuchMethod(
         Invocation.getter(#isLogVisible),
@@ -96,36 +76,26 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  _i4.Future<void> init() => (super.noSuchMethod(
+  _i3.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i4.Future<void> precacheSlideImages(_i5.BuildContext? context) =>
+  _i3.Future<void> precacheSlideImages(_i4.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #precacheSlideImages,
           [context],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
-  _i4.Future<void> reboot({bool? immediate = true}) => (super.noSuchMethod(
-        Invocation.method(
-          #reboot,
-          [],
-          {#immediate: immediate},
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -133,7 +103,7 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -156,30 +126,20 @@ class MockInstallationSlidesModel extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
-  @override
-  _i4.Future<void> shutdown({required bool? immediate}) => (super.noSuchMethod(
-        Invocation.method(
-          #shutdown,
-          [],
-          {#immediate: immediate},
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [JournalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i7.JournalService {
+class MockJournalService extends _i1.Mock implements _i6.JournalService {
   MockJournalService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Stream<String> start(
+  _i3.Stream<String> start(
     String? id, {
-    _i7.JournalOutput? output = _i7.JournalOutput.short,
+    _i6.JournalOutput? output = _i6.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -187,6 +147,6 @@ class MockJournalService extends _i1.Mock implements _i7.JournalService {
           [id],
           {#output: output},
         ),
-        returnValue: _i4.Stream<String>.empty(),
-      ) as _i4.Stream<String>);
+        returnValue: _i3.Stream<String>.empty(),
+      ) as _i3.Stream<String>);
 }


### PR DESCRIPTION
We have a dedicated "installation complete" page and we haven't had the need to reboot straight from the installation slides for a very long time. This kills one use of the `SystemShutdown` mixin which is on the way out...