### PR TITLE
Not enough disk space: use `yaru_window`

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_model.dart
@@ -1,7 +1,6 @@
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
-import 'package:ubuntu_wizard/utils.dart';
 
 /// @internal
 final log = Logger('not_enough_disk_space');
@@ -17,7 +16,4 @@ class NotEnoughDiskSpaceModel extends SafeChangeNotifier {
   int get largestDiskSize => _service.largestDiskSize;
   bool get hasMultipleDisks => _service.hasMultipleDisks;
   int get installMinimumSize => _service.installMinimumSize;
-
-  // TODO: tell subiquity to quit?
-  void quit() => closeWindow();
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -40,7 +40,10 @@ class NotEnoughDiskSpacePage extends StatelessWidget {
           WizardAction.done(
             context,
             label: lang.quitButtonText,
-            onDone: () => model.quit(),
+            onDone: () {
+              // TODO: tell subiquity to quit?
+              YaruWindow.of(context).close();
+            },
           ),
         ],
       ),

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -21,22 +20,5 @@ void main() async {
     expect(model.hasMultipleDisks, isTrue);
     expect(model.installMinimumSize, 123);
     expect(model.largestDiskSize, 456);
-  });
-
-  test('quit', () {
-    final service = MockDiskStorageService();
-    when(service.installMinimumSize).thenReturn(123);
-    when(service.largestDiskSize).thenReturn(456);
-
-    var windowClosed = false;
-    const methodChannel = MethodChannel('window_manager');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
-
-    final model = NotEnoughDiskSpaceModel(service);
-    model.quit();
-    expect(windowClosed, isTrue);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -68,8 +69,16 @@ void main() {
         find.widgetWithText(OutlinedButton, tester.lang.quitButtonText);
     expect(button, findsOneWidget);
 
+    var windowClosed = false;
+    const methodChannel = MethodChannel('yaru_window');
+    methodChannel.setMockMethodCallHandler((call) async {
+      expect(call.method, equals('close'));
+      windowClosed = true;
+    });
+
     await tester.tap(button);
-    verify(model.quit()).called(1);
+
+    expect(windowClosed, isTrue);
   });
 
   testWidgets('creates a model', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.mocks.dart
@@ -55,14 +55,6 @@ class MockNotEnoughDiskSpaceModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  void quit() => super.noSuchMethod(
-        Invocation.method(
-          #quit,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
   void addListener(_i3.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,


### PR DESCRIPTION
Same story as with the [others](https://github.com/canonical/ubuntu-desktop-installer/pulls?q=is%3Apr+is%3Aclosed+yaru_window), migrating to `yaru_window` helps to fix showing the window in fullscreen mode when the fixed size window doesn't fit the desktop.

![image](https://user-images.githubusercontent.com/140617/220032925-390bfde4-8bf1-4bd3-8e33-cac40dc1e1e6.png)

Ref: #1371 