### PR TITLE
WSL Applying changes: use `yaru_window`

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_model.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_wizard/utils.dart';
 
 import '../../installing_state.dart';
 
@@ -10,31 +9,31 @@ import '../../installing_state.dart';
 ///
 /// See also:
 ///  * [ApplyingChangesPage]
-class ApplyingChangesModel extends SafeChangeNotifier with SystemShutdown {
+class ApplyingChangesModel extends SafeChangeNotifier {
   /// Creates a model for the 'applying changes' page.
-  ApplyingChangesModel(this.client, this._monitor);
+  ApplyingChangesModel(this._client, this._monitor);
 
   final SubiquityStatusMonitor _monitor;
 
-  @override
-  final SubiquityClient client;
+  final SubiquityClient _client;
   StreamSubscription<ApplicationStatus?>? _sub;
   bool _previousState = true;
 
-  void init() {
+  Future<void> init() async {
     if (null != _monitor.status && !_monitor.status!.state.isInstalling) {
       _previousState = false;
-      reboot(immediate: false);
-      return;
+      return _client.reboot(immediate: false);
     }
+    final completer = Completer();
     _sub = _monitor.onStatusChanged.listen((status) {
       if (status?.state.isInstalling == false && _previousState == true) {
         _previousState = false;
-        reboot(immediate: false);
+        _client.reboot(immediate: false).then((_) => completer.complete());
       } else {
         notifyListeners();
       }
     });
+    return completer.future;
   }
 
   @override

--- a/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/applying_changes/applying_changes_page.dart
@@ -4,6 +4,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import 'applying_changes_model.dart';
@@ -38,7 +39,10 @@ class _ApplyingChangesPageState extends State<ApplyingChangesPage> {
   void initState() {
     super.initState();
     final model = Provider.of<ApplyingChangesModel>(context, listen: false);
-    model.init();
+    model.init().then((_) {
+      if (!mounted) return;
+      YaruWindow.of(context).close();
+    });
   }
 
   @override

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.mocks.dart
@@ -3,13 +3,12 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i5;
+import 'dart:async' as _i3;
 import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i2;
 import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.dart'
-    as _i3;
+    as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -22,34 +21,15 @@ import 'package:ubuntu_wsl_setup/pages/applying_changes/applying_changes_model.d
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeSubiquityClient_0 extends _i1.SmartFake
-    implements _i2.SubiquityClient {
-  _FakeSubiquityClient_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
 /// A class which mocks [ApplyingChangesModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockApplyingChangesModel extends _i1.Mock
-    implements _i3.ApplyingChangesModel {
+    implements _i2.ApplyingChangesModel {
   MockApplyingChangesModel() {
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  _i2.SubiquityClient get client => (super.noSuchMethod(
-        Invocation.getter(#client),
-        returnValue: _FakeSubiquityClient_0(
-          this,
-          Invocation.getter(#client),
-        ),
-      ) as _i2.SubiquityClient);
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
@@ -61,13 +41,14 @@ class MockApplyingChangesModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  void init() => super.noSuchMethod(
+  _i3.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -100,24 +81,4 @@ class MockApplyingChangesModel extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
-  @override
-  _i5.Future<void> reboot({required bool? immediate}) => (super.noSuchMethod(
-        Invocation.method(
-          #reboot,
-          [],
-          {#immediate: immediate},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-  @override
-  _i5.Future<void> shutdown({required bool? immediate}) => (super.noSuchMethod(
-        Invocation.method(
-          #shutdown,
-          [],
-          {#immediate: immediate},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
 }


### PR DESCRIPTION
The end goal is to migrate all top-level window access from `window_manager` to `yaru_window` because the latter is a) compatible with `handy_window` and b) we have full control over it so we are able to quickly fix & publish whenever needed.

The main API difference is that `yaru_window` is not a singleton but accessed from the widget tree instead using the context as a reference, following the direction of the ongoing top-level window work in Flutter. This makes the old `SystemShutdown` helper mixin useless, though, because we can't/shouldn't access the window directly from models anymore which was a bit questionable choice anyway, by yours truly. :grin: 

Ref: #1371