### PR TITLE
Fix storage init on startup

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -86,8 +86,10 @@ Future<void> runInstallerApp(
     'Media': ProductInfoExtractor().getProductInfo().toString(),
   });
 
+  final storage = DiskStorageService(subiquityClient);
+
   registerService(() => ConfigService('/tmp/$baseName.conf'));
-  registerService(() => DiskStorageService(subiquityClient));
+  registerServiceInstance(storage);
   registerService(() => GeoService(sources: [geodata, geoname]));
   registerService(JournalService.new);
   registerService(() => NetworkService(subiquityClient));
@@ -140,13 +142,15 @@ Future<void> runInstallerApp(
 
   // Use the default values for a number of endpoints
   // for which a UI page isn't implemented yet.
-  return subiquityClient.markConfigured([
+  await subiquityClient.markConfigured([
     'mirror',
     'proxy',
     'ssh',
     'snaplist',
     'ubuntu_pro',
   ]);
+
+  await storage.init();
 }
 
 class UbuntuDesktopInstallerApp extends StatefulWidget {

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -10,9 +10,7 @@ final log = Logger('disk_storage');
 /// Provides means to read and modify the storage configuration.
 class DiskStorageService {
   /// Creates the service with the given [client].
-  DiskStorageService(this._client) {
-    _client.isOpen.then((_) => init());
-  }
+  DiskStorageService(this._client);
 
   final SubiquityClient _client;
 

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -18,7 +18,6 @@ void main() {
 
   setUp(() {
     client = MockSubiquityClient();
-    when(client.isOpen).thenAnswer((_) async => true);
     when(client.getGuidedStorageV2()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: testTargets));
     when(client.getStorageV2())
@@ -63,7 +62,7 @@ void main() {
   test('reset guided storage', () async {
     final service = DiskStorageService(client);
     expect(service.hasMultipleDisks, isFalse);
-    await untilCalled(client.getStorageV2());
+    await service.init();
 
     await service.getGuidedStorage();
     expect(service.hasMultipleDisks, isTrue);
@@ -82,7 +81,7 @@ void main() {
         (_) async => testStorageResponse(disks: testDisks.reversed.toList()));
 
     final service = DiskStorageService(client);
-    await untilCalled(client.getStorageV2());
+    await service.init();
     verify(client.getStorageV2()).called(1);
 
     expect(await service.getStorage(), equals(testDisks));
@@ -181,7 +180,7 @@ void main() {
     final service = DiskStorageService(client);
 
     when(client.hasRst()).thenAnswer((_) async => true);
-    await untilCalled(client.hasRst());
+    await service.init();
     verify(client.hasRst()).called(1);
     expect(service.hasRst, isTrue);
 
@@ -195,7 +194,7 @@ void main() {
     final service = DiskStorageService(client);
 
     when(client.hasBitLocker()).thenAnswer((_) async => true);
-    await untilCalled(client.hasBitLocker());
+    await service.init();
     expect(service.hasBitLocker, isTrue);
     verify(client.hasBitLocker()).called(1);
 
@@ -275,7 +274,7 @@ void main() {
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
 
     final service = DiskStorageService(client);
-    await untilCalled(client.getStorageV2());
+    await service.init();
 
     service.securityKey = 'foo123';
     expect(service.securityKey, equals('foo123'));


### PR DESCRIPTION
Post-pone `getStorage()` until after `setSource()` to let Subiquity know what kind of installation it's dealing with before asking for storage details including how much space the installation requires.

Also, even if mockito's `untilCalled()` made the easy to test, it's generally a better idea to trigger asynchronous initialization routines from the outside than from the service's own constructor because there's no way to get ahold of the future...

Fix: #1432