### PR TITLE
README.md: update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ git submodule update --init --recursive
 
 Install Subiquity dependencies:
 ```sh
-cd packages/subiquity_client/subiquity
-sudo ./scripts/installdeps.sh
+make -C packages/subiquity_client/subiquity install_deps
 ```
 
 ### Run the installer
@@ -52,6 +51,7 @@ sudo ./scripts/installdeps.sh
 Run the installer either from within your IDE or by running the following command:
 
 ```sh
+cd packages/ubuntu_desktop_installer
 flutter run
 ```
 


### PR DESCRIPTION
Running `make install_deps` as non-root is better as it depends on `gitdeps` which builds the local curtin & probert as the local user and `aptdeps` that uses sudo to install the relevant dependencies. The `installdeps.sh` script is somewhat intrusive because it runs dist-upgrade etc. and is supposedly primarily meant for the CI.