### PR TITLE
Write changes to disk: fix storage API calling order

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -34,10 +34,11 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
     if (_service.guidedTarget != null) {
       await _service.setGuidedStorage();
     }
+    await _service.getStorage().then(_updateDisks);
     _originals = await _service.getOriginalStorage().then((disks) =>
         Map.fromEntries(disks.map((d) => MapEntry(
             d.sysname, d.partitions.whereType<Partition>().toList()))));
-    return _service.getStorage().then(_updateDisks);
+    notifyListeners();
   }
 
   /// Starts the installation process.

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -58,8 +58,10 @@ void main() {
 
     final model = WriteChangesToDiskModel(client, service);
     await model.init();
-    verify(service.getStorage()).called(1);
-    verify(service.getOriginalStorage()).called(1);
+    verifyInOrder([
+      service.getStorage(),
+      service.getOriginalStorage(),
+    ]);
     verifyNever(service.setGuidedStorage());
 
     expect(model.disks, equals(nonPreservedDisks));


### PR DESCRIPTION
Split off from #1412 and coupled with a unit test.

Make sure to call `GET /storage/v2?wait=true` before calling `GET /storage/v2/orig_config`. The former blocks until Subiquity is done probing the hardware, whereas the latter throws if Subiquity is not done probing the hardware.

The correct order is important in autoinstall mode because the GUI jumps straight to the confirmation screen if Subiquity reports `NEEDS_CONFIRMATION` after establishing the connection. At that point, Subiquity might be still probing the hardware in the background.