### PR TITLE
Integration tests: simplify tapping buttons

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -415,7 +415,7 @@ Future<void> testInstallationTypePage(
     await tester.tapRadioButton<InstallationType>(type);
   }
   if (advancedFeature != null) {
-    await tester.tapButton(label: tester.lang.installationTypeAdvancedLabel);
+    await tester.tapButton(tester.lang.installationTypeAdvancedLabel);
     await tester.pumpAndSettle();
 
     await tester.tapRadioButton<AdvancedFeature>(advancedFeature);
@@ -428,7 +428,7 @@ Future<void> testInstallationTypePage(
       );
     }
 
-    await tester.tapButton(label: tester.lang.okButtonText);
+    await tester.tapButton(tester.lang.okButtonText);
   }
 
   await tester.pumpAndSettle();
@@ -464,7 +464,7 @@ Future<void> testAllocateDiskSpacePage(
   await expectPage(
       tester, AllocateDiskSpacePage, (lang) => lang.allocateDiskSpace);
 
-  await tester.tapButton(label: tester.lang.newPartitionTable);
+  await tester.tapButton(tester.lang.newPartitionTable);
   await tester.pumpAndSettle();
 
   for (final disk in storage ?? []) {
@@ -491,7 +491,7 @@ Future<void> testAllocateDiskSpacePage(
         await tester.pump();
       }
 
-      await tester.tapButton(label: tester.lang.okButtonText);
+      await tester.tapButton(tester.lang.okButtonText);
       await tester.pumpAndSettle();
     }
     await tester.pumpAndSettle();
@@ -522,14 +522,14 @@ Future<void> testInstallAlongsidePage(
     await tester.pumpAndSettle();
   }
 
-  await tester.tapButton(label: tester.lang.selectGuidedStorageInstallNow);
+  await tester.tapButton(tester.lang.selectGuidedStorageInstallNow);
 }
 
 Future<void> testWriteChangesToDiskPage(WidgetTester tester) async {
   await expectPage(
       tester, WriteChangesToDiskPage, (lang) => lang.writeChangesToDisk);
 
-  await tester.tapHighlightedButton(tester.lang.startInstallingButtonText);
+  await tester.tapButton(tester.lang.startInstallingButtonText);
 }
 
 Future<void> testTurnOffBitLockerPage(WidgetTester tester) async {
@@ -537,7 +537,7 @@ Future<void> testTurnOffBitLockerPage(WidgetTester tester) async {
       tester, TurnOffBitLockerPage, (lang) => lang.turnOffBitlockerTitle);
 
   final windowClosed = waitForWindowClosed();
-  await tester.tapHighlightedButton(tester.lang.restartIntoWindows);
+  await tester.tapButton(tester.lang.restartIntoWindows);
   await expectLater(windowClosed, completion(isTrue));
 }
 
@@ -643,7 +643,7 @@ Future<void> testInstallationCompletePage(WidgetTester tester) async {
       (lang) => lang.installationCompleteTitle);
 
   final windowClosed = waitForWindowClosed();
-  await tester.tapButton(label: tester.lang.continueTesting);
+  await tester.tapButton(tester.lang.continueTesting);
   await expectLater(windowClosed, completion(isTrue));
 }
 

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -138,24 +138,20 @@ Future<void> _testCloseWindow() async {
 /// Helpers for interacting with widgets.
 extension IntegrationTester on WidgetTester {
   /// Taps a "Go Back" button.
-  Future<void> tapBack() => tapButton(label: ulang.backAction);
+  Future<void> tapBack() => tapButton(ulang.backAction);
 
   /// Taps a "Continue" button.
-  Future<void> tapContinue() => tapButton(label: ulang.continueAction);
+  Future<void> tapContinue() => tapButton(ulang.continueAction);
 
-  /// Taps a button specified by its [label].
-  Future<void> tapButton({
-    required String label,
-    bool highlighted = false,
-  }) async {
-    await tap(find.widgetWithText(
-        highlighted ? ElevatedButton : OutlinedButton, label));
+  /// Taps a button specified by its [label]. The button can be any
+  /// [ButtonStyleButton] subclass, such as [OutlinedButton], [ElevatedButton],
+  /// or [FilledButton].
+  Future<void> tapButton(String label) async {
+    await tap(find.ancestor(
+      of: find.text(label),
+      matching: find.bySubtype<ButtonStyleButton>(),
+    ));
     await pump();
-  }
-
-  /// Taps a highlighted button specified by its [label].
-  Future<void> tapHighlightedButton(String label) {
-    return tapButton(label: label, highlighted: true);
   }
 
   /// Enters a text [value] into a form field specified by its [label], or does

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -116,7 +116,7 @@ Future<void> testAdvancedSetupPage(
   );
   await tester.pumpAndSettle();
 
-  await tester.tapButton(label: tester.lang.setupButton, highlighted: true);
+  await tester.tapButton(tester.lang.setupButton);
 }
 
 Future<void> testApplyingChangesPage(
@@ -157,7 +157,7 @@ Future<void> testConfigurationUIPage(
   );
   await tester.pumpAndSettle();
 
-  await tester.tapButton(label: tester.lang.saveButton, highlighted: true);
+  await tester.tapButton(tester.lang.saveButton);
 }
 
 void expectPage(


### PR DESCRIPTION
CommonFinders.widgetWithText() uses find.byType(T) which does not test subclass types but we can use find.bySubtype<T>() to be able to support any ButtonStyleButton because we don't really care about the exact type of button in the high level integration tests. All those small details are tested in widget tests.