### PR TITLE
Installation complete: use relative spacing

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -33,7 +33,7 @@ class InstallationCompletePage extends StatelessWidget {
       ),
       content: Row(
         children: [
-          const SizedBox(width: 120),
+          const Spacer(flex: 2),
           Container(
             decoration: BoxDecoration(
               shape: BoxShape.circle,
@@ -49,8 +49,9 @@ class InstallationCompletePage extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: 60),
+          const Spacer(),
           Expanded(
+            flex: 8,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -94,7 +95,7 @@ class InstallationCompletePage extends StatelessWidget {
               ],
             ),
           ),
-          const SizedBox(width: 120),
+          const Spacer(flex: 2),
         ],
       ),
     );


### PR DESCRIPTION
Use less spacing when the window is small to avoid the content getting squeezed and button labels wrapping.

| | Before | After |
|---|---|---|
| 800x600 | ![image](https://user-images.githubusercontent.com/140617/221234006-6709b952-8659-4633-bc6b-23e6ae6e28c4.png) | ![image](https://user-images.githubusercontent.com/140617/221233931-1ca991f8-f82a-4a02-9c1b-71736b2be442.png) |
| 960x680 | ![image](https://user-images.githubusercontent.com/140617/221234132-afdffc66-40b9-4e74-aff5-965a954f386c.png) | ![image](https://user-images.githubusercontent.com/140617/221234223-211e30a9-f711-40b8-8db8-8d420b2f3c19.png) |

Fixes: #1448