### PR TITLE
Allocate disk space: improve layout for smaller screens

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -83,7 +83,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
           Expanded(child: PartitionTable(controller: _scrollController)),
           const SizedBox(height: kContentSpacing / 2),
           const PartitionButtonRow(),
-          const SizedBox(height: kContentSpacing),
+          const SizedBox(height: kContentSpacing / 2),
           FractionallySizedBox(
             widthFactor: 0.5,
             alignment: Alignment.topLeft,

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -77,9 +77,9 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           const PartitionBar(),
-          const SizedBox(height: kContentSpacing / 2),
+          const SizedBox(height: kContentSpacing / 4),
           const PartitionLegend(),
-          const SizedBox(height: kContentSpacing / 2),
+          const SizedBox(height: kContentSpacing),
           Expanded(child: PartitionTable(controller: _scrollController)),
           const SizedBox(height: kContentSpacing / 2),
           const PartitionButtonRow(),

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -22,7 +22,7 @@ class PartitionBar extends StatelessWidget {
       borderRadius: BorderRadius.circular(kYaruButtonRadius),
       clipBehavior: Clip.antiAlias,
       child: CustomPaint(
-        size: const Size(double.infinity, 24),
+        size: const Size(double.infinity, 16),
         painter: _PartitionPainter(model),
       ),
     );
@@ -88,7 +88,6 @@ class PartitionLegend extends StatelessWidget {
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         children: objects
             .mapIndexed((index, object) => Padding(

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
@@ -1,5 +1,5 @@
 import 'package:filesize/filesize.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
@@ -31,8 +31,6 @@ class StorageSelector extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        if (title != null) Text(title!),
-        if (title != null) const SizedBox(height: 8),
         DropdownBuilder<int>(
           values: List.generate(storages.length, (index) => index),
           selected: selected,
@@ -43,6 +41,7 @@ class StorageSelector extends StatelessWidget {
               key: ValueKey(index),
             );
           },
+          decoration: InputDecoration(labelText: title),
         )
       ],
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -138,6 +138,7 @@ class StorageTable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruBorderContainer(
+      clipBehavior: Clip.antiAlias,
       child: LayoutBuilder(builder: (context, constraints) {
         final theme = Theme.of(context);
         return OverflowBox(
@@ -149,6 +150,8 @@ class StorageTable extends StatelessWidget {
               controller: controller,
               child: DataTable(
                 dataRowHeight: kMinInteractiveDimension +
+                    theme.visualDensity.baseSizeAdjustment.dy,
+                headingRowHeight: kMinInteractiveDimension +
                     theme.visualDensity.baseSizeAdjustment.dy,
                 showCheckboxColumn: false,
                 headingTextStyle: theme.textTheme.titleSmall,


### PR DESCRIPTION
- reduce partition bar height and partition legend spacing
- reduce table header height to match disk/partition rows
- move the bootloader selector label as part of the input decoration

On an 800x600 screen, these changes result in roughly two extra disk/partition rows.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/221769579-1ec9fe13-7a2e-400f-805a-88be4fc3ff02.png) | ![image](https://user-images.githubusercontent.com/140617/221817191-7ebb12ef-eddf-4aae-9511-f5cbbd390719.png) |

Fix: #1446