### PR TITLE
snap: add missing pyroute2 dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,6 +115,7 @@ parts:
       - libpython3.8-minimal
       - python3-apport
       - python3-requests-unixsocket
+      - python3-pyroute2
       - python3-pyudev
       - python3-systemd
       - python3-urwid


### PR DESCRIPTION
```
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]: Traceback (most recent call last):
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     return _run_code(code, main_globals, None,
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/usr/lib/python3.8/runpy.py", line 87, in _run_code
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     exec(code, run_globals)
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/cmd/server.py", line 180, in <module>
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     sys.exit(main())
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/cmd/server.py", line 121, in main
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     from subiquity.server.server import SubiquityServer
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/server/server.py", line 221, in <module>
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     class SubiquityServer(Application):
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/server/server.py", line 239, in SubiquityServer
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     from subiquity.server import controllers as controllers_mod
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/server/controllers/__init__.py", line 29, in <module>
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     from .network import NetworkController
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquity/server/controllers/network.py", line 30, in <module>
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     from subiquitycore.controllers.network import BaseNetworkController
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:   File "/snap/ubuntu-desktop-installer/x1/bin/subiquity/subiquitycore/controllers/network.py", line 24, in <module>
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]:     import pyroute2
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]: ModuleNotFoundError: No module named 'pyroute2'
Feb 28 07:20:54 ubuntu ubuntu-desktop-installer.subiquity-server[5426]: starting server
Feb 28 07:20:54 ubuntu systemd[1]: snap.ubuntu-desktop-installer.subiquity-server.service: Main process exited, code=exited, status=1/FAILURE
Feb 28 07:20:54 ubuntu systemd[1]: snap.ubuntu-desktop-installer.subiquity-server.service: Failed with result 'exit-code'.
Feb 28 07:20:54 ubuntu systemd[1]: snap.ubuntu-desktop-installer.subiquity-server.service: Scheduled restart job, restart counter is at 5.
Feb 28 07:20:54 ubuntu systemd[1]: Stopped Service for snap application ubuntu-desktop-installer.subiquity-server.
Feb 28 07:20:54 ubuntu systemd[1]: snap.ubuntu-desktop-installer.subiquity-server.service: Start request repeated too quickly.
Feb 28 07:20:54 ubuntu systemd[1]: snap.ubuntu-desktop-installer.subiquity-server.service: Failed with result 'exit-code'.
Feb 28 07:20:54 ubuntu systemd[1]: Failed to start Service for snap application ubuntu-desktop-installer.subiquity-server.
```