### PR TITLE
Try or install: move the release note label out of the way

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -38,48 +38,58 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
       title: YaruWindowTitleBar(
         title: Text(lang.tryOrInstallPageTitle),
       ),
-      contentPadding: const EdgeInsets.fromLTRB(20, 50, 20, 100),
-      content: Row(
+      content: Column(
         children: [
-          // Expanded(
-          //   child: OptionCard(
-          //     selected: model.option == Option.repairUbuntu,
-          //     image: Image.asset('assets/try_or_install/repair-wrench.png'),
-          //     title: Text(lang.repairInstallation),
-          //     body: Text(lang.repairInstallationDescription),
-          //     onSelected: () => model.selectOption(Option.repairUbuntu),
-          //   ),
-          // ),
-          // const SizedBox(width: kContentSpacing),
           const Spacer(),
           Expanded(
-            flex: 2,
-            child: OptionCard(
-              selected: model.option == Option.tryUbuntu,
-              image: Image.asset('assets/try_or_install/steering-wheel.png'),
-              title: Text(lang.tryUbuntu(flavor.name)),
-              body: Text(lang.tryUbuntuDescription(flavor.name)),
-              onSelected: () => model.selectOption(Option.tryUbuntu),
-            ),
-          ),
-          const SizedBox(width: kContentSpacing * 2),
-          Expanded(
-            flex: 2,
-            child: OptionCard(
-              selected: model.option == Option.installUbuntu,
-              image: Image.asset('assets/try_or_install/hard-drive.png'),
-              title: Text(lang.installUbuntu(flavor.name)),
-              body: Text(lang.installUbuntuDescription(flavor.name)),
-              onSelected: () => model.selectOption(Option.installUbuntu),
+            flex: 6,
+            child: Row(
+              children: [
+                // Expanded(
+                //   child: OptionCard(
+                //     selected: model.option == Option.repairUbuntu,
+                //     image: Image.asset('assets/try_or_install/repair-wrench.png'),
+                //     title: Text(lang.repairInstallation),
+                //     body: Text(lang.repairInstallationDescription),
+                //     onSelected: () => model.selectOption(Option.repairUbuntu),
+                //   ),
+                // ),
+                // const SizedBox(width: kContentSpacing),
+                const Spacer(),
+                Expanded(
+                  flex: 2,
+                  child: OptionCard(
+                    selected: model.option == Option.tryUbuntu,
+                    image:
+                        Image.asset('assets/try_or_install/steering-wheel.png'),
+                    title: Text(lang.tryUbuntu(flavor.name)),
+                    body: Text(lang.tryUbuntuDescription(flavor.name)),
+                    onSelected: () => model.selectOption(Option.tryUbuntu),
+                  ),
+                ),
+                const SizedBox(width: kContentSpacing * 2),
+                Expanded(
+                  flex: 2,
+                  child: OptionCard(
+                    selected: model.option == Option.installUbuntu,
+                    image: Image.asset('assets/try_or_install/hard-drive.png'),
+                    title: Text(lang.installUbuntu(flavor.name)),
+                    body: Text(lang.installUbuntuDescription(flavor.name)),
+                    onSelected: () => model.selectOption(Option.installUbuntu),
+                  ),
+                ),
+                const Spacer(),
+              ],
             ),
           ),
           const Spacer(),
+          Html(
+            data: lang.releaseNotesLabel(
+                model.releaseNotesURL(Settings.of(context).locale)),
+            style: {'body': Style(margin: Margins.zero)},
+            onLinkTap: (url, _, __, ___) => launchUrl(url!),
+          ),
         ],
-      ),
-      footer: Html(
-        data: lang.releaseNotesLabel(
-            model.releaseNotesURL(Settings.of(context).locale)),
-        onLinkTap: (url, _, __, ___) => launchUrl(url!),
       ),
       actions: <WizardAction>[
         WizardAction.back(context),


### PR DESCRIPTION
The whole page will be redesigned soon but this PR will only move the label out of the way so we can move the back button to the left. See e.g. https://github.com/canonical/ubuntu-desktop-installer/issues/1467#issuecomment-1447934037

| Before | After |
|---|---|
| ![Screenshot from 2023-02-28 11-58-12](https://user-images.githubusercontent.com/140617/221834916-f3d19a8a-17b4-45c9-b788-31805b973f57.png) | ![Screenshot from 2023-02-28 11-58-02](https://user-images.githubusercontent.com/140617/221834926-6e3b69f2-0ac3-49d2-ad33-ad9c06974b7c.png) |
