### PR TITLE
WizardPage: keep the bottom bar in place during page transitions

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -115,26 +115,29 @@ class _WizardPageState extends State<WizardPage> {
             SizedBox(height: widget.contentSpacing),
           ],
         ),
-        bottomNavigationBar: Padding(
-          padding: widget.footerPadding,
-          child: Row(
-            children: [
-              _buildAction(context, leading) ?? const SizedBox.shrink(),
-              const Spacer(),
-              if (currentStep != null && totalSteps != null)
-                YaruPageIndicator(
-                  page: currentStep,
-                  length: totalSteps,
-                  dotSize: 12,
-                  dotSpacing: 8,
-                ),
-              const Spacer(),
-              for (final action in trailing)
-                Padding(
-                  padding: const EdgeInsets.only(left: kButtonBarSpacing),
-                  child: _buildAction(context, action),
-                ),
-            ],
+        bottomNavigationBar: Hero(
+          tag: 'wizard-bottom-bar', // keep in place during page transitions
+          child: Padding(
+            padding: widget.footerPadding,
+            child: Row(
+              children: [
+                _buildAction(context, leading) ?? const SizedBox.shrink(),
+                const Spacer(),
+                if (currentStep != null && totalSteps != null)
+                  YaruPageIndicator(
+                    page: currentStep,
+                    length: totalSteps,
+                    dotSize: 12,
+                    dotSpacing: 8,
+                  ),
+                const Spacer(),
+                for (final action in trailing)
+                  Padding(
+                    padding: const EdgeInsets.only(left: kButtonBarSpacing),
+                    child: _buildAction(context, action),
+                  ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
We're in the process of making sure buttons have consistent sizes between pages (#1487) so we don't need to (ab)use animations to hide the difference anymore.

Keeping the bottom bar in place during page transitions requires a lot fewer changes than implementing different animations for the buttons so I'd suggest we start with this. It looks and feels nice and natural, especially with all the button changes that are halfway through.

## Before

[Screencast from 2023-03-01 06-39-42.webm](https://user-images.githubusercontent.com/140617/222054587-8a9362e6-6d9f-42b6-97a2-ddd3b5bfe2d4.webm)

## After

[Screencast from 2023-03-01 06-38-17.webm](https://user-images.githubusercontent.com/140617/222054416-a2969043-cb55-42d1-93af-ac4c7a1d0d66.webm)


Ref: #1466