### PR TITLE
Snap: set `GDK_RENDERING=image` to avoid graphical glitches on X11

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -23,6 +23,12 @@ fi
 export XDG_CACHE_HOME="$SNAP_USER_COMMON/.cache"
 [ -d "$XDG_CACHE_HOME" ] ||  mkdir -p "$XDG_CACHE_HOME"
 
+# Workaround for flickering corners and other graphical glitches with GTK's
+# OpenGL backend for X11. See:
+# - https://github.com/canonical/ubuntu-desktop-installer/issues/1397
+# - https://gitlab.gnome.org/GNOME/gtk/-/issues/5600
+export GDK_RENDERING=image
+
 export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
 export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
 if [ "$needs_update" = true ] || [ ! -f "$GDK_PIXBUF_MODULE_FILE" ]; then


### PR DESCRIPTION
See:
- #1397
- https://gitlab.gnome.org/GNOME/gtk/-/issues/5600
- https://gitlab.gnome.org/GNOME/gtk/-/issues/4704#note_1676890