### PR TITLE
Fix wizard button padding

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -121,7 +121,7 @@ class _WizardPageState extends State<WizardPage> {
             padding: widget.footerPadding,
             child: Row(
               children: [
-                _buildAction(context, leading) ?? const SizedBox.shrink(),
+                _buildAction(context, leading),
                 const Spacer(),
                 if (currentStep != null && totalSteps != null)
                   YaruPageIndicator(
@@ -132,9 +132,10 @@ class _WizardPageState extends State<WizardPage> {
                   ),
                 const Spacer(),
                 for (final action in trailing)
-                  Padding(
+                  _buildAction(
+                    context,
+                    action,
                     padding: const EdgeInsets.only(left: kButtonBarSpacing),
-                    child: _buildAction(context, action),
                   ),
               ],
             ),
@@ -144,9 +145,13 @@ class _WizardPageState extends State<WizardPage> {
     );
   }
 
-  Widget? _buildAction(BuildContext context, WizardAction? action) {
+  Widget _buildAction(
+    BuildContext context,
+    WizardAction? action, {
+    EdgeInsetsGeometry? padding,
+  }) {
     if (action == null || action.visible == false) {
-      return null;
+      return const SizedBox.shrink();
     }
 
     final maybeActivate = action.enabled ?? true
@@ -156,12 +161,16 @@ class _WizardPageState extends State<WizardPage> {
           }
         : null;
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minWidth: 136),
-      child: action.highlighted == true
-          ? ElevatedButton(onPressed: maybeActivate, child: Text(action.label!))
-          : OutlinedButton(
-              onPressed: maybeActivate, child: Text(action.label!)),
+    return Padding(
+      padding: padding ?? EdgeInsets.zero,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 136),
+        child: action.highlighted == true
+            ? ElevatedButton(
+                onPressed: maybeActivate, child: Text(action.label!))
+            : OutlinedButton(
+                onPressed: maybeActivate, child: Text(action.label!)),
+      ),
     );
   }
 }


### PR DESCRIPTION
Remove bogus padding around hidden actions.

## Before

[Screencast from 2023-03-01 17-53-01.webm](https://user-images.githubusercontent.com/140617/222207844-0295a15c-bd9f-4fa4-829c-cd2b190eece8.webm)

## After

[Screencast from 2023-03-01 17-52-07.webm](https://user-images.githubusercontent.com/140617/222207651-975d4d75-ccd9-4146-bbfe-1ab04166c383.webm)
