### PR TITLE
Drop repetitive and long FS descriptions in favor of short names

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -136,49 +136,6 @@ Future<void> showCreatePartitionDialog(
   );
 }
 
-extension _PartitionFormatLang on PartitionFormat {
-  String localize(AppLocalizations lang) {
-    switch (this) {
-      case PartitionFormat.none:
-        return lang.partitionFormatNone;
-      case PartitionFormat.btrfs:
-        return lang.partitionFormatBtrfs;
-      case PartitionFormat.ext2:
-        return lang.partitionFormatExt2;
-      case PartitionFormat.ext3:
-        return lang.partitionFormatExt3;
-      case PartitionFormat.ext4:
-        return lang.partitionFormatExt4;
-      case PartitionFormat.fat:
-        return lang.partitionFormatFat;
-      case PartitionFormat.fat12:
-        return lang.partitionFormatFat12;
-      case PartitionFormat.fat16:
-        return lang.partitionFormatFat16;
-      case PartitionFormat.fat32:
-        return lang.partitionFormatFat32;
-      case PartitionFormat.iso9660:
-        return lang.partitionFormatIso9660;
-      case PartitionFormat.vfat:
-        return lang.partitionFormatVfat;
-      case PartitionFormat.jfs:
-        return lang.partitionFormatJfs;
-      case PartitionFormat.ntfs:
-        return lang.partitionFormatNtfs;
-      case PartitionFormat.reiserfs:
-        return lang.partitionFormatReiserFS;
-      case PartitionFormat.swap:
-        return lang.partitionFormatSwap;
-      case PartitionFormat.xfs:
-        return lang.partitionFormatXfs;
-      case PartitionFormat.zfsroot:
-        return lang.partitionFormatZfsroot;
-      default:
-        throw UnimplementedError(toString());
-    }
-  }
-}
-
 /// Shows a dialog for editing an existing partition on the given [disk].
 Future<void> showEditPartitionDialog(
     BuildContext context, Disk disk, Partition partition, Gap? gap) {
@@ -372,7 +329,7 @@ class _PartitionFormatSelector extends StatelessWidget {
             values: partitionFormats,
             itemBuilder: (context, format, _) {
               return Text(
-                format?.localize(lang) ?? lang.partitionFormatNone,
+                format?.name ?? lang.partitionFormatNone,
                 key: ValueKey(format?.type),
               );
             },

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -21,10 +21,13 @@ extension PartitionExtension on Partition {
 
 /// Available partition formats.
 class PartitionFormat {
-  const PartitionFormat._(this.type);
+  const PartitionFormat._(this.type, this.name);
 
   /// The type of the partition format (e.g. 'ext4').
   final String type;
+
+  /// The display name of the partition format (e.g. 'Ext4').
+  final String? name;
 
   /// Whether a partition with this format can be wiped.
   bool get canWipe => type != 'swap';
@@ -32,23 +35,23 @@ class PartitionFormat {
   @override
   String toString() => type;
 
-  static const none = PartitionFormat._('');
-  static const btrfs = PartitionFormat._('btrfs');
-  static const ext2 = PartitionFormat._('ext2');
-  static const ext3 = PartitionFormat._('ext3');
-  static const ext4 = PartitionFormat._('ext4');
-  static const fat = PartitionFormat._('fat');
-  static const fat12 = PartitionFormat._('fat12');
-  static const fat16 = PartitionFormat._('fat16');
-  static const fat32 = PartitionFormat._('fat32');
-  static const iso9660 = PartitionFormat._('iso9660');
-  static const vfat = PartitionFormat._('vfat');
-  static const jfs = PartitionFormat._('jfs');
-  static const ntfs = PartitionFormat._('ntfs');
-  static const reiserfs = PartitionFormat._('reiserfs');
-  static const swap = PartitionFormat._('swap');
-  static const xfs = PartitionFormat._('xfs');
-  static const zfsroot = PartitionFormat._('zfsroot');
+  static const none = PartitionFormat._('', null);
+  static const btrfs = PartitionFormat._('btrfs', 'Btrfs');
+  static const ext2 = PartitionFormat._('ext2', 'Ext2');
+  static const ext3 = PartitionFormat._('ext3', 'Ext3');
+  static const ext4 = PartitionFormat._('ext4', 'Ext4');
+  static const fat = PartitionFormat._('fat', 'FAT');
+  static const fat12 = PartitionFormat._('fat12', 'FAT12');
+  static const fat16 = PartitionFormat._('fat16', 'FAT16');
+  static const fat32 = PartitionFormat._('fat32', 'FAT32');
+  static const iso9660 = PartitionFormat._('iso9660', 'ISO9660');
+  static const vfat = PartitionFormat._('vfat', 'VFAT');
+  static const jfs = PartitionFormat._('jfs', 'JFS');
+  static const ntfs = PartitionFormat._('ntfs', 'NTFS');
+  static const reiserfs = PartitionFormat._('reiserfs', 'ReiserFS');
+  static const swap = PartitionFormat._('swap', 'Swap');
+  static const xfs = PartitionFormat._('xfs', 'XFS');
+  static const zfsroot = PartitionFormat._('zfsroot', 'ZFS root');
 
   /// The default partition format.
   static PartitionFormat get defaultValue => _formats['ext4']!;

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -51,8 +51,8 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<PartitionFormat?>));
     await tester.pumpAndSettle();
 
-    await tester.tap(
-        find.widgetWithText(MenuItemButton, tester.lang.partitionFormatBtrfs));
+    await tester
+        .tap(find.widgetWithText(MenuItemButton, PartitionFormat.btrfs.name!));
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(YaruAutocomplete<String>), '/tst');
@@ -117,8 +117,8 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<PartitionFormat?>));
     await tester.pumpAndSettle();
 
-    await tester.tap(
-        find.widgetWithText(MenuItemButton, tester.lang.partitionFormatBtrfs));
+    await tester
+        .tap(find.widgetWithText(MenuItemButton, PartitionFormat.btrfs.name!));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byType(YaruCheckbox));


### PR DESCRIPTION
Just updating the English translation which is used as a template for all others. The bot will automatically regenerate the untranslated entries and open a PR. For already translated entries, Weblate will show a warning that they are out of date.

```
$ apt show btrfs-progs 2>/dev/null | grep Desc
Description: Checksumming Copy on Write Filesystem utilities
```

![Screenshot from 2023-03-01 18-41-44](https://user-images.githubusercontent.com/140617/222220832-510a70a6-cc0b-441f-8ce0-0560c755f3ae.png)

Close: #1294