### PR TITLE
Change "Go back" in buttons to "Back"

### DIFF
--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
@@ -297,7 +297,7 @@ void main() {
 
     final backButton = find.widgetWithText(
       OutlinedButton,
-      tester.ulang.backAction,
+      tester.ulang.backLabel,
     );
     expect(backButton, findsOneWidget);
     expect(tester.widget<OutlinedButton>(backButton).enabled, isFalse);

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -138,7 +138,7 @@ Future<void> _testCloseWindow() async {
 /// Helpers for interacting with widgets.
 extension IntegrationTester on WidgetTester {
   /// Taps a "Go Back" button.
-  Future<void> tapBack() => tapButton(ulang.backAction);
+  Future<void> tapBack() => tapButton(ulang.backLabel);
 
   /// Taps a "Continue" button.
   Future<void> tapContinue() => tapButton(ulang.continueAction);

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -31,7 +31,7 @@ class WizardAction {
     WizardCallback? onBack,
   }) {
     return WizardAction(
-      label: UbuntuLocalizations.of(context).backAction,
+      label: UbuntuLocalizations.of(context).backLabel,
       visible: visible,
       enabled: enabled ?? Wizard.maybeOf(context)?.hasPrevious ?? false,
       onActivated: onBack,

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -167,7 +167,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(OutlinedButton),
-        matching: find.text(lang.backAction),
+        matching: find.text(lang.backLabel),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Use `UbuntuLocalizations.backLabel` from the new [stock labels](https://github.com/canonical/ubuntu-flutter-plugins/pull/63). The continue button needs the same treatment but it's used all over the place so let's leave it to a separate step.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/222243295-78994b30-4c43-4f8f-a68b-8e32b29220ff.png) | ![image](https://user-images.githubusercontent.com/140617/222243235-1c305524-be7d-4d32-ad0f-caffeca280f0.png) |

Fixes: #1479