### PR TITLE
Outlined Back button vs. filled Continue button

### DIFF
--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -340,7 +340,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);
@@ -354,11 +354,11 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 
   testWidgets('too many primary partitions', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_page_test.dart
@@ -64,10 +64,10 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -75,10 +75,10 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 
   testWidgets('show security key', (tester) async {
@@ -98,7 +98,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/configure_secure_boot/configure_secure_boot_page_test.dart
@@ -110,10 +110,10 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -121,9 +121,9 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.dart
@@ -186,7 +186,7 @@ void main() {
     verifyNever(model.cleanup());
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
     await tester.tap(continueButton);
     await tester.pumpAndSettle();
@@ -278,7 +278,7 @@ void main() {
     verifyNever(model.cleanup());
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
     await tester.tap(continueButton);
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -346,11 +346,11 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, false);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, false);
 
     await tester.tap(continueButton);
     verifyNever(model.save());
@@ -361,7 +361,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_page_test.dart
@@ -128,11 +128,11 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -140,11 +140,11 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 
   testWidgets('key search', (tester) async {
@@ -183,7 +183,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
@@ -66,7 +66,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final button =
-        find.widgetWithText(OutlinedButton, tester.lang.quitButtonText);
+        find.widgetWithText(FilledButton, tester.lang.quitButtonText);
     expect(button, findsOneWidget);
 
     var windowClosed = false;

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -113,7 +113,7 @@ void main() {
     verifyNever(model.saveGuidedStorage());
 
     final installButton = find.widgetWithText(
-        OutlinedButton, tester.lang.selectGuidedStorageInstallNow);
+        FilledButton, tester.lang.selectGuidedStorageInstallNow);
     expect(installButton, findsOneWidget);
 
     await tester.tap(installButton);

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
@@ -92,9 +92,10 @@ void main() {
   testWidgets('selecting an option should enable continuing', (tester) async {
     await setUpApp(tester);
 
-    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    final continueButton = find.widgetWithText(FilledButton, 'Continue');
     expect(continueButton, findsOneWidget);
-    expect((continueButton.evaluate().single.widget as OutlinedButton).enabled,
+    expect(
+        (continueButton.evaluate().single.widget as ButtonStyleButton).enabled,
         false);
 
     final options = find.byType(OptionCard);
@@ -103,7 +104,8 @@ void main() {
     await tester.tap(options.first);
     await tester.pump();
 
-    expect((continueButton.evaluate().single.widget as OutlinedButton).enabled,
+    expect(
+        (continueButton.evaluate().single.widget as ButtonStyleButton).enabled,
         true);
   });
 
@@ -117,7 +119,7 @@ void main() {
     await tester.tap(option);
     await tester.pump();
 
-    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    final continueButton = find.widgetWithText(FilledButton, 'Continue');
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);
@@ -130,9 +132,9 @@ void main() {
   testWidgets('try ubuntu', (tester) async {
     await setUpApp(tester);
 
-    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    final continueButton = find.widgetWithText(FilledButton, 'Continue');
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
 
     final option =
         find.widgetWithText(OptionCard, tester.lang.tryUbuntu('Ubuntu'));
@@ -141,7 +143,7 @@ void main() {
     await tester.tap(option);
     await tester.pump();
 
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
 
     var windowClosed = false;
     final methodChannel = MethodChannel('yaru_window');

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.dart
@@ -171,7 +171,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -160,7 +160,7 @@ void main() {
   testWidgets('should continue to next page', (tester) async {
     await setUpApp(tester);
 
-    final continueButton = find.widgetWithText(OutlinedButton, 'Continue');
+    final continueButton = find.widgetWithText(FilledButton, 'Continue');
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);

--- a/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/where_are_you/where_are_you_page_test.dart
@@ -69,7 +69,7 @@ void main() {
         .pumpWidget(tester.buildApp((_) => buildPage(model, controller)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     await tester.tap(continueButton);
@@ -300,6 +300,6 @@ void main() {
       tester.ulang.backLabel,
     );
     expect(backButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(backButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(backButton).enabled, isFalse);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.dart
@@ -202,10 +202,10 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -213,10 +213,10 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 
   testWidgets('auto-login', (tester) async {
@@ -268,7 +268,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final continueButton = find.widgetWithText(
-      OutlinedButton,
+      FilledButton,
       tester.ulang.continueAction,
     );
     expect(continueButton, findsOneWidget);

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -18,6 +18,7 @@ class WizardAction {
     this.label,
     this.visible,
     this.highlighted,
+    this.flat,
     this.enabled,
     this.onActivated,
     this.execute,
@@ -33,6 +34,7 @@ class WizardAction {
     return WizardAction(
       label: UbuntuLocalizations.of(context).backLabel,
       visible: visible,
+      flat: true,
       enabled: enabled ?? Wizard.maybeOf(context)?.hasPrevious ?? false,
       onActivated: onBack,
       execute: () => Wizard.maybeOf(context)?.back(),
@@ -45,6 +47,7 @@ class WizardAction {
     String? label,
     bool? visible,
     bool? enabled,
+    bool? flat,
     bool? highlighted,
     Object? arguments,
     WizardCallback? onNext,
@@ -54,6 +57,7 @@ class WizardAction {
       label: label ?? UbuntuLocalizations.of(context).continueAction,
       visible: visible,
       enabled: enabled,
+      flat: flat,
       highlighted: highlighted,
       onActivated: onNext,
       execute: () async {
@@ -69,6 +73,7 @@ class WizardAction {
     String? label,
     bool? visible,
     bool? enabled,
+    bool? flat,
     bool? highlighted,
     Object? result,
     WizardCallback? onDone,
@@ -77,6 +82,7 @@ class WizardAction {
       label: label,
       visible: visible,
       enabled: enabled,
+      flat: flat,
       highlighted: highlighted,
       onActivated: onDone,
       execute: () => Wizard.maybeOf(context)?.done(result: result),
@@ -90,6 +96,11 @@ class WizardAction {
   ///
   /// The default value is `true`
   final bool? visible;
+
+  /// Determines whether the action is flat (no background).
+  ///
+  /// The default value is `false`.
+  final bool? flat;
 
   /// Determines whether the action is highlighted (green);
   ///

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -158,12 +158,15 @@ class _WizardPageState extends State<WizardPage> {
           }
         : null;
 
+    final child = Text(action.label!);
+
     return ConstrainedBox(
       constraints: const BoxConstraints(minWidth: 136),
       child: action.highlighted == true
-          ? ElevatedButton(onPressed: maybeActivate, child: Text(action.label!))
-          : OutlinedButton(
-              onPressed: maybeActivate, child: Text(action.label!)),
+          ? ElevatedButton(onPressed: maybeActivate, child: child)
+          : action.flat == true
+              ? OutlinedButton(onPressed: maybeActivate, child: child)
+              : FilledButton(onPressed: maybeActivate, child: child),
     );
   }
 }

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -21,7 +21,7 @@ void main() {
     );
 
     await tester.tap(find.descendant(
-      of: find.byType(OutlinedButton),
+      of: find.byType(FilledButton),
       matching: find.text('action'),
     ));
     expect(activated, isTrue);
@@ -72,30 +72,21 @@ void main() {
         tester.getCenter(next).dx, greaterThan(tester.getCenter(content).dx));
   });
 
-  testWidgets('highlighted action', (tester) async {
+  testWidgets('normal/flat/highlighted action', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
           actions: const <WizardAction>[
-            WizardAction(label: 'action', highlighted: false),
+            WizardAction(label: 'normal'),
+            WizardAction(label: 'flat', flat: true),
+            WizardAction(label: 'highlighted', highlighted: true),
           ],
         ),
       ),
     );
-    expect(find.widgetWithText(OutlinedButton, 'action'), findsOneWidget);
-    expect(find.widgetWithText(ElevatedButton, 'action'), findsNothing);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: WizardPage(
-          actions: const <WizardAction>[
-            WizardAction(label: 'action', highlighted: true),
-          ],
-        ),
-      ),
-    );
-    expect(find.widgetWithText(OutlinedButton, 'action'), findsNothing);
-    expect(find.widgetWithText(ElevatedButton, 'action'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'normal'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'flat'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'highlighted'), findsOneWidget);
   });
 
   testWidgets('disabled action', (tester) async {
@@ -116,7 +107,7 @@ void main() {
     );
 
     await tester.tap(find.descendant(
-      of: find.byType(OutlinedButton),
+      of: find.byType(FilledButton),
       matching: find.text('action'),
     ));
     expect(activated, isFalse);
@@ -174,7 +165,7 @@ void main() {
 
     expect(
       find.descendant(
-        of: find.byType(OutlinedButton),
+        of: find.byType(FilledButton),
         matching: find.text(lang.continueAction),
       ),
       findsOneWidget,

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -165,9 +165,9 @@ void main() {
     await tester.pumpWidget(buildApp(tester, model));
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -175,9 +175,9 @@ void main() {
     await tester.pumpWidget(buildApp(tester, model));
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
-    expect(tester.widget<OutlinedButton>(continueButton).enabled, isFalse);
+    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
   });
 
   // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
@@ -207,7 +207,7 @@ void main() {
     verifyNever(model.saveProfileSetup());
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -89,7 +89,7 @@ void main() {
     verify(model.selectLocale(Locale('fr_FR'))).called(1);
 
     final continueButton =
-        find.widgetWithText(OutlinedButton, tester.ulang.continueAction);
+        find.widgetWithText(FilledButton, tester.ulang.continueAction);
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);


### PR DESCRIPTION
Specifically, the Back button on the left is flat/outlined. All other buttons on the right, such as Continue, are filled. The change applies to all pages.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/222423743-fe6f737e-2905-4503-805a-63321d72a595.png) | ![image](https://user-images.githubusercontent.com/140617/222423655-980ab7ef-f157-482d-9bb0-c17af9077891.png) |
| ![image](https://user-images.githubusercontent.com/140617/222423766-5748d331-c906-4002-95f9-93e6de45821f.png) | ![image](https://user-images.githubusercontent.com/140617/222423623-49f85e93-8506-4fc8-bacd-591b8748db62.png) |

Close: #1467