### PR TITLE
ValidatedFormField: allow initial value changes when focused

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/validated_form_field.dart
@@ -126,11 +126,15 @@ class _ValidatedFormFieldState extends State<ValidatedFormField> {
   @override
   void didUpdateWidget(ValidatedFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!focusNode.hasFocus &&
-        widget.initialValue != null &&
-        oldWidget.initialValue != widget.initialValue) {
+    if (widget.initialValue != null &&
+        widget.initialValue != _controller.text &&
+        widget.initialValue != oldWidget.initialValue) {
       scheduleMicrotask(() {
-        _controller.text = widget.initialValue!;
+        _controller.value = TextEditingValue(
+          text: widget.initialValue!,
+          selection:
+              TextSelection.collapsed(offset: widget.initialValue!.length),
+        );
       });
     }
   }

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -86,6 +86,7 @@ void main() {
       return MaterialApp(
         home: Material(
           child: ValidatedFormField(
+            autofocus: true,
             controller: controller,
             initialValue: initialValue,
           ),


### PR DESCRIPTION
Don't blindly reject initial value changes when focused because most values are initialized asynchronously whenever entering a page. If a field was (auto)focused, it would never get its initial value.

## Before

[Screencast from 2023-03-02 20-16-36.webm](https://user-images.githubusercontent.com/140617/222529200-abd157cd-5533-4c83-8d07-ccf4eda43a10.webm)

## After

[Screencast from 2023-03-02 20-18-39.webm](https://user-images.githubusercontent.com/140617/222529590-7cfd36f3-dbd2-40fd-8041-a755af399b00.webm)

Fixes: #1401