### PR TITLE
Pass USERNAME to setInputSource()

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:dartx/dartx.dart';
 import 'package:diacritic/diacritic.dart';
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -13,9 +15,11 @@ final log = Logger('keyboard_layout');
 /// Implements the business logic of the Keyboard Layout page.
 class KeyboardLayoutModel extends SafeChangeNotifier {
   /// Creates a model with the specified client.
-  KeyboardLayoutModel(this._client);
+  KeyboardLayoutModel(this._client, {@visibleForTesting Platform? platform})
+      : _platform = platform ?? const LocalPlatform();
 
   final SubiquityClient _client;
+  final Platform _platform;
   List<KeyboardLayout> _layouts = [];
 
   /// The number of available keyboard layouts.
@@ -140,7 +144,10 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
     final variant = _selectedVariant?.code;
     final keyboard = KeyboardSetting(layout: layout, variant: variant ?? '');
     log.info('Updated $layout ($variant) input source');
-    return _client.setInputSource(keyboard);
+    return _client.setInputSource(
+      keyboard,
+      user: _platform.environment['USERNAME'],
+    );
   }
 
   /// Saves the selected keyboard layout and variant.

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   meta: ^1.7.0
   nm: ^0.5.0
   path: ^1.8.0
+  platform: ^3.1.0
   provider: ^6.0.0
   safe_change_notifier: ^0.2.0
   scroll_to_index: ^3.0.0

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_model.dart';
 import 'package:ubuntu_test/mocks.dart';
@@ -107,7 +108,8 @@ void main() {
         ], layout: '', variant: '');
       });
 
-      model = KeyboardLayoutModel(client);
+      model = KeyboardLayoutModel(client,
+          platform: FakePlatform(environment: {'USERNAME': 'usr'}));
       await model.init();
     });
 
@@ -166,16 +168,19 @@ void main() {
 
     test('selection updates input source', () async {
       await model.selectLayout(0);
-      verify(client.setInputSource(KeyboardSetting(layout: 'bar'))).called(1);
+      verify(client.setInputSource(KeyboardSetting(layout: 'bar'), user: 'usr'))
+          .called(1);
 
       await model.selectLayout(1);
-      verify(client
-              .setInputSource(KeyboardSetting(layout: 'foo', variant: 'baz')))
+      verify(client.setInputSource(
+              KeyboardSetting(layout: 'foo', variant: 'baz'),
+              user: 'usr'))
           .called(1);
 
       await model.selectVariant(1);
-      verify(client
-              .setInputSource(KeyboardSetting(layout: 'foo', variant: 'qux')))
+      verify(client.setInputSource(
+              KeyboardSetting(layout: 'foo', variant: 'qux'),
+              user: 'usr'))
           .called(1);
     });
 


### PR DESCRIPTION
Subiquity runs as root. It doesn't know the desktop live session user. The GUI must pass the appropriate username to make it possible for Subiquity to change the desktop input source for the live session user. It defaults to 'ubuntu' which won't work for flavors that may have a different live session username.

Ref: canonical/ubuntu-flavor-installer#10