### PR TITLE
snap: copy shader_lib/*.glsl artifacts for arm64

### DIFF
--- a/snap/local/flutter/LICENSE
+++ b/snap/local/flutter/LICENSE
@@ -1,0 +1,25 @@
+Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/snap/local/flutter/README.md
+++ b/snap/local/flutter/README.md
@@ -1,0 +1,13 @@
+The `shader_lib` directory contains Flutter engine artifacts that are missing
+for arm64. The files are platform-agnostic GLSL files that have been copied
+from the x64 tarball.
+
+The files can be updated to the latest stable by running `update-artifacts.sh`
+or to a specific version by running `update-artifacts.sh x.y.z`. The script
+downloads the given Flutter release, extracts `shader_lib` from it, and updates
+the local copy.
+
+See:
+- https://github.com/canonical/ubuntu-desktop-installer/issues/1519
+- https://github.com/flutter/flutter/issues/116703#issuecomment-1403956612
+- https://github.com/flutter/engine/tree/main/impeller/compiler/shader_lib

--- a/snap/local/flutter/shader_lib/flutter/runtime_effect.glsl
+++ b/snap/local/flutter/shader_lib/flutter/runtime_effect.glsl
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef RUNTIME_EFFECT_GLSL_
+#define RUNTIME_EFFECT_GLSL_
+
+#if defined(IMPELLER_GRAPHICS_BACKEND)
+
+// Note: The GLES backend uses name matching for attribute locations. This name
+// must match the name of the attribute output in:
+// impeller/entity/shaders/runtime_effect.vert
+in vec2 _fragCoord;
+vec2 FlutterFragCoord() {
+  return _fragCoord;
+}
+
+#elif defined(SKIA_GRAPHICS_BACKEND)
+
+vec2 FlutterFragCoord() {
+  return gl_FragCoord.xy;
+}
+
+#else
+#error "Runtime effect builtins are not supported for this graphics backend."
+#endif
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/blending.glsl
+++ b/snap/local/flutter/shader_lib/impeller/blending.glsl
@@ -1,0 +1,193 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BLENDING_GLSL_
+#define BLENDING_GLSL_
+
+#include <impeller/branching.glsl>
+#include <impeller/constants.glsl>
+
+//------------------------------------------------------------------------------
+/// HSV utilities.
+///
+
+float IPLuminosity(vec3 color) {
+  return color.r * 0.3 + color.g * 0.59 + color.b * 0.11;
+}
+
+/// Scales the color's luma by the amount necessary to place the color
+/// components in a 1-0 range.
+vec3 IPClipColor(vec3 color) {
+  float lum = IPLuminosity(color);
+  float mn = min(min(color.r, color.g), color.b);
+  float mx = max(max(color.r, color.g), color.b);
+  // `lum - mn` and `mx - lum` will always be >= 0 in the following conditions,
+  // so adding a tiny value is enough to make these divisions safe.
+  if (mn < 0) {
+    color = lum + (((color - lum) * lum) / (lum - mn + kEhCloseEnough));
+  }
+  if (mx > 1) {
+    color = lum + (((color - lum) * (1 - lum)) / (mx - lum + kEhCloseEnough));
+  }
+  return color;
+}
+
+vec3 IPSetLuminosity(vec3 color, float luminosity) {
+  float relative_lum = luminosity - IPLuminosity(color);
+  return IPClipColor(color + relative_lum);
+}
+
+float IPSaturation(vec3 color) {
+  return max(max(color.r, color.g), color.b) -
+         min(min(color.r, color.g), color.b);
+}
+
+vec3 IPSetSaturation(vec3 color, float saturation) {
+  float mn = min(min(color.r, color.g), color.b);
+  float mx = max(max(color.r, color.g), color.b);
+  return (mn < mx) ? ((color - mn) * saturation) / (mx - mn) : vec3(0);
+}
+
+//------------------------------------------------------------------------------
+/// Color blend functions.
+///
+/// These routines take two unpremultiplied RGB colors and output a third color.
+/// They can be combined with any alpha compositing operation. When these blend
+/// functions are used for drawing Entities in Impeller, the output is always
+/// applied to the destination using `SourceOver` alpha compositing.
+///
+
+vec3 IPBlendScreen(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingscreen
+  return dst + src - (dst * src);
+}
+
+vec3 IPBlendHardLight(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendinghardlight
+  return IPVec3Choose(dst * (2 * src), IPBlendScreen(dst, 2 * src - 1), src);
+}
+
+vec3 IPBlendOverlay(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingoverlay
+  // HardLight, but with reversed parameters.
+  return IPBlendHardLight(src, dst);
+}
+
+vec3 IPBlendDarken(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingdarken
+  return min(dst, src);
+}
+
+vec3 IPBlendLighten(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendinglighten
+  return max(dst, src);
+}
+
+vec3 IPBlendColorDodge(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingcolordodge
+
+  vec3 color = min(vec3(1), dst / (1 - src));
+
+  if (dst.r < kEhCloseEnough) {
+    color.r = 0;
+  }
+  if (dst.g < kEhCloseEnough) {
+    color.g = 0;
+  }
+  if (dst.b < kEhCloseEnough) {
+    color.b = 0;
+  }
+
+  if (1 - src.r < kEhCloseEnough) {
+    color.r = 1;
+  }
+  if (1 - src.g < kEhCloseEnough) {
+    color.g = 1;
+  }
+  if (1 - src.b < kEhCloseEnough) {
+    color.b = 1;
+  }
+
+  return color;
+}
+
+vec3 IPBlendColorBurn(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingcolorburn
+
+  vec3 color = 1 - min(vec3(1), (1 - dst) / src);
+
+  if (1 - dst.r < kEhCloseEnough) {
+    color.r = 1;
+  }
+  if (1 - dst.g < kEhCloseEnough) {
+    color.g = 1;
+  }
+  if (1 - dst.b < kEhCloseEnough) {
+    color.b = 1;
+  }
+
+  if (src.r < kEhCloseEnough) {
+    color.r = 0;
+  }
+  if (src.g < kEhCloseEnough) {
+    color.g = 0;
+  }
+  if (src.b < kEhCloseEnough) {
+    color.b = 0;
+  }
+
+  return color;
+}
+
+vec3 IPBlendSoftLight(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingsoftlight
+
+  vec3 D = IPVec3ChooseCutoff(((16 * dst - 12) * dst + 4) * dst,  //
+                              sqrt(dst),                          //
+                              dst,                                //
+                              0.25);
+
+  return IPVec3Choose(dst - (1 - 2 * src) * dst * (1 - dst),  //
+                      dst + (2 * src - 1) * (D - dst),        //
+                      src);
+}
+
+vec3 IPBlendDifference(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingdifference
+  return abs(dst - src);
+}
+
+vec3 IPBlendExclusion(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingexclusion
+  return dst + src - 2 * dst * src;
+}
+
+vec3 IPBlendMultiply(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingmultiply
+  return dst * src;
+}
+
+vec3 IPBlendHue(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendinghue
+  return IPSetLuminosity(IPSetSaturation(src, IPSaturation(dst)),
+                         IPLuminosity(dst));
+}
+
+vec3 IPBlendSaturation(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingsaturation
+  return IPSetLuminosity(IPSetSaturation(dst, IPSaturation(src)),
+                         IPLuminosity(dst));
+}
+
+vec3 IPBlendColor(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingcolor
+  return IPSetLuminosity(src, IPLuminosity(dst));
+}
+
+vec3 IPBlendLuminosity(vec3 dst, vec3 src) {
+  // https://www.w3.org/TR/compositing-1/#blendingluminosity
+  return IPSetLuminosity(dst, IPLuminosity(src));
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/branching.glsl
+++ b/snap/local/flutter/shader_lib/impeller/branching.glsl
@@ -1,0 +1,52 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BRANCHING_GLSL_
+#define BRANCHING_GLSL_
+
+#include <impeller/constants.glsl>
+#include <impeller/types.glsl>
+
+/// Perform an equality check for each vec3 component.
+///
+/// Returns 1.0 if x == y, otherwise 0.0.
+BoolV3 IPVec3IsEqual(vec3 x, float y) {
+  vec3 diff = abs(x - y);
+  return vec3(diff.r < kEhCloseEnough,  //
+              diff.g < kEhCloseEnough,  //
+              diff.b < kEhCloseEnough);
+}
+
+/// Perform a branchless greater than check.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+BoolF IPFloatIsGreaterThan(float x, float y) {
+  return max(sign(x - y), 0);
+}
+
+/// Perform a branchless greater than check for each vec3 component.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+BoolV3 IPVec3IsGreaterThan(vec3 x, vec3 y) {
+  return max(sign(x - y), 0);
+}
+
+/// Perform a branchless less than check.
+///
+/// Returns 1.0 if x < y, otherwise 0.0.
+BoolF IPFloatIsLessThan(float x, float y) {
+  return max(sign(y - x), 0);
+}
+
+/// For each vec3 component, if value > cutoff, return b, otherwise return a.
+vec3 IPVec3ChooseCutoff(vec3 a, vec3 b, vec3 value, float cutoff) {
+  return mix(a, b, IPVec3IsGreaterThan(value, vec3(cutoff)));
+}
+
+/// For each vec3 component, if value > 0.5, return b, otherwise return a.
+vec3 IPVec3Choose(vec3 a, vec3 b, vec3 value) {
+  return IPVec3ChooseCutoff(a, b, value, 0.5);
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/color.glsl
+++ b/snap/local/flutter/shader_lib/impeller/color.glsl
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COLOR_GLSL_
+#define COLOR_GLSL_
+
+#include <impeller/branching.glsl>
+
+/// Convert a premultiplied color (a color which has its color components
+/// multiplied with its alpha value) to an unpremultiplied color.
+///
+/// Returns (0, 0, 0, 0) if the alpha component is 0.
+vec4 IPUnpremultiply(vec4 color) {
+  if (color.a == 0) {
+    return vec4(0);
+  }
+  return vec4(color.rgb / color.a, color.a);
+}
+
+/// Convert an unpremultiplied color (a color which has its color components
+/// separated from its alpha value) to a premultiplied color.
+///
+/// Returns (0, 0, 0, 0) if the alpha component is 0.
+vec4 IPPremultiply(vec4 color) {
+  return vec4(color.rgb * color.a, color.a);
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/constants.glsl
+++ b/snap/local/flutter/shader_lib/impeller/constants.glsl
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONSTANTS_GLSL_
+#define CONSTANTS_GLSL_
+
+const float kEhCloseEnough = 0.000001;
+
+// 1 / (2 * pi)
+const float k1Over2Pi = 0.1591549430918;
+
+// sqrt(2 * pi)
+const float kSqrtTwoPi = 2.50662827463;
+
+// sqrt(2) / 2 == 1 / sqrt(2)
+const float kHalfSqrtTwo = 0.70710678118;
+
+// sqrt(3)
+const float kSqrtThree = 1.73205080757;
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/gaussian.glsl
+++ b/snap/local/flutter/shader_lib/impeller/gaussian.glsl
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef GAUSSIAN_GLSL_
+#define GAUSSIAN_GLSL_
+
+#include <impeller/constants.glsl>
+
+/// Gaussian distribution function.
+float IPGaussian(float x, float sigma) {
+  float variance = sigma * sigma;
+  return exp(-0.5 * x * x / variance) / (kSqrtTwoPi * sigma);
+}
+
+/// Abramowitz and Stegun erf approximation.
+float IPErf(float x) {
+  float a = abs(x);
+  // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
+  float b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
+  return sign(x) * (1 - 1 / (b * b * b * b));
+}
+
+/// Vec2 variation for the Abramowitz and Stegun erf approximation.
+vec2 IPVec2Erf(vec2 x) {
+  vec2 a = abs(x);
+  // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
+  vec2 b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
+  return sign(x) * (1 - 1 / (b * b * b * b));
+}
+
+/// The indefinite integral of the Gaussian function.
+/// Uses a very close approximation of Erf.
+float IPGaussianIntegral(float x, float sigma) {
+  // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
+  return (1 + IPErf(x * (kHalfSqrtTwo / sigma))) * 0.5;
+}
+
+/// Vec2 variation for the indefinite integral of the Gaussian function.
+/// Uses a very close approximation of Erf.
+vec2 IPVec2GaussianIntegral(vec2 x, float sigma) {
+  // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
+  return (1 + IPVec2Erf(x * (kHalfSqrtTwo / sigma))) * 0.5;
+}
+
+/// Simpler (but less accurate) approximation of the Gaussian integral.
+vec2 IPVec2FastGaussianIntegral(vec2 x, float sigma) {
+  return 1 / (1 + exp(-kSqrtThree / sigma * x));
+}
+
+/// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].
+float IPSigmoid(float x) {
+  return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/gradient.glsl
+++ b/snap/local/flutter/shader_lib/impeller/gradient.glsl
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef GRADIENT_GLSL_
+#define GRADIENT_GLSL_
+
+#include <impeller/texture.glsl>
+
+/// Compute the indexes and mix coefficient used to mix colors for an
+/// arbitrarily sized color gradient.
+///
+/// The returned values are the lower index, upper index, and mix
+/// coefficient.
+vec3 IPComputeFixedGradientValues(float t, float colors_length) {
+  float rough_index = (colors_length - 1) * t;
+  float lower_index = floor(rough_index);
+  float upper_index = ceil(rough_index);
+  float scale = rough_index - lower_index;
+
+  return vec3(lower_index, upper_index, scale);
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/texture.glsl
+++ b/snap/local/flutter/shader_lib/impeller/texture.glsl
@@ -1,0 +1,153 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TEXTURE_GLSL_
+#define TEXTURE_GLSL_
+
+#include <impeller/branching.glsl>
+
+/// Sample from a texture.
+///
+/// If `y_coord_scale` < 0.0, the Y coordinate is flipped. This is useful
+/// for Impeller graphics backends that use a flipped framebuffer coordinate
+/// space.
+vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
+  if (y_coord_scale < 0.0) {
+    coords.y = 1.0 - coords.y;
+  }
+  return texture(texture_sampler, coords);
+}
+
+vec2 IPRemapCoords(vec2 coords, float y_coord_scale) {
+  if (y_coord_scale < 0.0) {
+    coords.y = 1.0 - coords.y;
+  }
+  return coords;
+}
+
+/// Sample from a texture.
+///
+/// If `y_coord_scale` < 0.0, the Y coordinate is flipped. This is useful
+/// for Impeller graphics backends that use a flipped framebuffer coordinate
+/// space.
+/// The range of `coods` will be mapped from [0, 1] to [half_texel, 1 -
+/// half_texel]
+vec4 IPSampleLinear(sampler2D texture_sampler,
+                    vec2 coords,
+                    float y_coord_scale,
+                    vec2 half_texel) {
+  coords.x = mix(half_texel.x, 1 - half_texel.x, coords.x);
+  coords.y = mix(half_texel.y, 1 - half_texel.y, coords.y);
+  return IPSample(texture_sampler, coords, y_coord_scale);
+}
+
+// These values must correspond to the order of the items in the
+// 'Entity::TileMode' enum class.
+const float kTileModeClamp = 0;
+const float kTileModeRepeat = 1;
+const float kTileModeMirror = 2;
+const float kTileModeDecal = 3;
+
+/// Remap a float using a tiling mode.
+///
+/// When `tile_mode` is `kTileModeDecal`, no tiling is applied and `t` is
+/// returned. In all other cases, a value between 0 and 1 is returned by tiling
+/// `t`.
+/// When `t` is between [0 to 1), the original unchanged `t` is always returned.
+float IPFloatTile(float t, float tile_mode) {
+  if (tile_mode == kTileModeClamp) {
+    t = clamp(t, 0.0, 1.0);
+  } else if (tile_mode == kTileModeRepeat) {
+    t = fract(t);
+  } else if (tile_mode == kTileModeMirror) {
+    float t1 = t - 1;
+    float t2 = t1 - 2 * floor(t1 * 0.5) - 1;
+    t = abs(t2);
+  }
+  return t;
+}
+
+/// Remap a vec2 using a tiling mode.
+///
+/// Runs each component of the vec2 through `IPFloatTile`.
+vec2 IPVec2Tile(vec2 coords, float x_tile_mode, float y_tile_mode) {
+  return vec2(IPFloatTile(coords.x, x_tile_mode),
+              IPFloatTile(coords.y, y_tile_mode));
+}
+
+/// Sample a texture, emulating a specific tile mode.
+///
+/// This is useful for Impeller graphics backend that don't have native support
+/// for Decal.
+vec4 IPSampleWithTileMode(sampler2D tex,
+                          vec2 coords,
+                          float y_coord_scale,
+                          float x_tile_mode,
+                          float y_tile_mode) {
+  if (x_tile_mode == kTileModeDecal && (coords.x < 0 || coords.x >= 1) ||
+      y_tile_mode == kTileModeDecal && (coords.y < 0 || coords.y >= 1)) {
+    return vec4(0);
+  }
+
+  return IPSample(tex, IPVec2Tile(coords, x_tile_mode, y_tile_mode),
+                  y_coord_scale);
+}
+
+/// Sample a texture, emulating a specific tile mode.
+///
+/// This is useful for Impeller graphics backend that don't have native support
+/// for Decal.
+vec4 IPSampleWithTileMode(sampler2D tex,
+                          vec2 coords,
+                          float y_coord_scale,
+                          float tile_mode) {
+  return IPSampleWithTileMode(tex, coords, y_coord_scale, tile_mode, tile_mode);
+}
+
+/// Sample a texture, emulating a specific tile mode.
+///
+/// This is useful for Impeller graphics backend that don't have native support
+/// for Decal.
+/// The range of `coods` will be mapped from [0, 1] to [half_texel, 1 -
+/// half_texel]
+vec4 IPSampleLinearWithTileMode(sampler2D tex,
+                                vec2 coords,
+                                float y_coord_scale,
+                                vec2 half_texel,
+                                float x_tile_mode,
+                                float y_tile_mode) {
+  if (x_tile_mode == kTileModeDecal && (coords.x < 0 || coords.x >= 1) ||
+      y_tile_mode == kTileModeDecal && (coords.y < 0 || coords.y >= 1)) {
+    return vec4(0);
+  }
+
+  return IPSampleLinear(tex, IPVec2Tile(coords, x_tile_mode, y_tile_mode),
+                        y_coord_scale, half_texel);
+}
+
+/// Sample a texture with decal tile mode.
+vec4 IPSampleDecal(sampler2D texture_sampler, vec2 coords) {
+  if (any(lessThan(coords, vec2(0))) ||
+      any(greaterThanEqual(coords, vec2(1)))) {
+    return vec4(0);
+  }
+  return texture(texture_sampler, coords);
+}
+
+/// Sample a texture, emulating a specific tile mode.
+///
+/// This is useful for Impeller graphics backend that don't have native support
+/// for Decal.
+/// The range of `coods` will be mapped from [0, 1] to [half_texel, 1 -
+/// half_texel]
+vec4 IPSampleLinearWithTileMode(sampler2D tex,
+                                vec2 coords,
+                                float y_coord_scale,
+                                vec2 half_texel,
+                                float tile_mode) {
+  return IPSampleLinearWithTileMode(tex, coords, y_coord_scale, half_texel,
+                                    tile_mode, tile_mode);
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/transform.glsl
+++ b/snap/local/flutter/shader_lib/impeller/transform.glsl
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TRANSFORM_GLSL_
+#define TRANSFORM_GLSL_
+
+/// Returns the Cartesian coordinates of `position` in `transform` space.
+vec2 IPVec2TransformPosition(mat4 matrix, vec2 point) {
+  vec4 transformed = matrix * vec4(point, 0, 1);
+  return transformed.xy / transformed.w;
+}
+
+// Returns the transformed gl_Position for a given glyph position in a glyph
+// atlas.
+vec4 IPPositionForGlyphPosition(mat4 mvp,
+                                vec2 unit_position,
+                                vec2 destination_position,
+                                vec2 destination_size) {
+  mat4 translation = mat4(1, 0, 0, 0,  //
+                          0, 1, 0, 0,  //
+                          0, 0, 1, 0,  //
+                          destination_position.xy, 0, 1);
+  return mvp * translation *
+         vec4(unit_position.x * destination_size.x,
+              unit_position.y * destination_size.y, 0.0, 1.0);
+}
+
+#endif

--- a/snap/local/flutter/shader_lib/impeller/types.glsl
+++ b/snap/local/flutter/shader_lib/impeller/types.glsl
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TYPES_GLSL_
+#define TYPES_GLSL_
+
+#extension GL_AMD_gpu_shader_half_float : enable
+
+#ifndef IMPELLER_TARGET_METAL
+
+precision mediump sampler2D;
+precision mediump float;
+
+#define float16_t float
+#define f16vec2 vec2
+#define f16vec3 vec3
+#define f16vec4 vec4
+#define f16mat4 mat4
+
+#endif  // IMPELLER_TARGET_METAL
+
+#define BoolF float
+#define BoolV2 vec2
+#define BoolV3 vec3
+#define BoolV4 vec4
+
+#endif

--- a/snap/local/flutter/update-artifacts.sh
+++ b/snap/local/flutter/update-artifacts.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+project_dir=$(cd "$(dirname "$0")/.." && pwd)
+version="$1"
+
+pushd /tmp > /dev/null
+if [ -z "$version" ]; then
+  curl -s -o releases_linux.json https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json
+  base_url=$(cat releases_linux.json | jq -r '.base_url')
+  stable=$(cat releases_linux.json | jq -r '.current_release' | jq '.stable')
+  archive=$(cat releases_linux.json | jq -r --arg stable "$stable" '[.releases[] | select(.hash=='$stable')][0].archive')
+  url=$base_url/$archive
+else
+  url=https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_$version-stable.tar.xz
+fi
+
+echo "Downloading $url"
+curl -o flutter-stable.tar.xz $url
+echo "Extracting shader_lib"
+tar -xvf flutter-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+echo "Updating shader_lib"
+rsync -avu --delete flutter/bin/cache/artifacts/engine/linux-x64/shader_lib $project_dir/snap/local/
+popd  > /dev/null

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,7 +128,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.7.6
+    source-tag: 3.7.6 # run local/flutter/update-artifacts.sh [x.y.z]
     source-depth: 1
     plugin: nil
     override-build: |
@@ -137,6 +137,9 @@ parts:
       cp -r $SNAPCRAFT_PART_SRC $SNAPCRAFT_PART_INSTALL/usr/libexec/flutter
       ln -s $SNAPCRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $SNAPCRAFT_PART_INSTALL/usr/bin/flutter
       $SNAPCRAFT_PART_INSTALL/usr/bin/flutter doctor
+      if [[ "$SNAPCRAFT_TARGET_ARCH" == "arm64" ]]; then
+        cp -R $SNAPCRAFT_PROJECT_DIR/snap/local/flutter/shader_lib $SNAPCRAFT_PART_INSTALL/usr/libexec/flutter/bin/cache/artifacts/engine/linux-arm64
+      fi
     build-packages:
       - clang
       - cmake


### PR DESCRIPTION
The `shader_lib` directory contains Flutter engine [artifacts](https://github.com/flutter/engine/tree/main/impeller/compiler/shader_lib) that are missing
for arm64. The files are platform-agnostic GLSL files that have been copied
from the x64 tarball.

The files can be updated to the latest stable by running `update-artifacts.sh`
or to a specific version by running `update-artifacts.sh x.y.z`. The script
downloads the given Flutter release, extracts `shader_lib` from it, and updates
the local copy.

See:
- https://github.com/canonical/ubuntu-desktop-installer/issues/1519
- https://github.com/flutter/flutter/issues/116703#issuecomment-1403956612

Fixes: #1519