### PR TITLE
Keyboard layout: fall back to `USER` if `USERNAME` is not set

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_model.dart
@@ -146,7 +146,7 @@ class KeyboardLayoutModel extends SafeChangeNotifier {
     log.info('Updated $layout ($variant) input source');
     return _client.setInputSource(
       keyboard,
-      user: _platform.environment['USERNAME'],
+      user: _platform.environment['USERNAME'] ?? _platform.environment['USER'],
     );
   }
 


### PR DESCRIPTION
Ubuntu has both `USER` and `USERNAME` set, whereas flavors only have `USER` set in the live session: https://github.com/canonical/ubuntu-flavor-installer/issues/10#issuecomment-1454721863