### PR TITLE
WhoAreYouModel: prepare site-wide connectivity check for AD

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -25,10 +25,12 @@ class WhoAreYouPage extends StatefulWidget {
 
   /// Creates an instance with [WhoAreYouModel].
   static Widget create(BuildContext context) {
-    final client = getService<SubiquityClient>();
-    final config = getService<ConfigService>();
     return ChangeNotifierProvider(
-      create: (_) => WhoAreYouModel(client, config),
+      create: (_) => WhoAreYouModel(
+        client: getService<SubiquityClient>(),
+        config: getService<ConfigService>(),
+        network: getService<NetworkService>(),
+      ),
       child: const WhoAreYouPage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/services/network_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/network_service.dart
@@ -15,6 +15,11 @@ class NetworkService extends NetworkManagerClient {
     return connectivity == NetworkManagerConnectivityState.full;
   }
 
+  /// `true` if there is a limited site-wide connectivity.
+  bool get isConnectedSite {
+    return state == NetworkManagerState.connectedSite;
+  }
+
   /// The list of wired network devices.
   List<NetworkManagerDevice> get wiredDevices {
     return devices.where((device) => device.wired != null).toList();

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/connect_to_internet_page_test.mocks.dart
@@ -1118,6 +1118,11 @@ class MockNetworkService extends _i1.Mock implements _i2.NetworkService {
         returnValue: false,
       ) as bool);
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
         Invocation.getter(#wiredDevices),
         returnValue: <_i2.NetworkManagerDevice>[],

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/ethernet_model_test.mocks.dart
@@ -422,6 +422,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
         returnValue: false,
       ) as bool);
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
         Invocation.getter(#wiredDevices),
         returnValue: <_i2.NetworkManagerDevice>[],

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/hidden_wifi_model_test.mocks.dart
@@ -547,6 +547,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
         returnValue: false,
       ) as bool);
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
         Invocation.getter(#wiredDevices),
         returnValue: <_i2.NetworkManagerDevice>[],

--- a/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/connect_to_internet/wifi_model_test.mocks.dart
@@ -547,6 +547,11 @@ class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
         returnValue: false,
       ) as bool);
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
         Invocation.getter(#wiredDevices),
         returnValue: <_i2.NetworkManagerDevice>[],

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_model_test.mocks.dart
@@ -91,6 +91,11 @@ class MockNetworkService extends _i1.Mock implements _i4.NetworkService {
         returnValue: false,
       ) as bool);
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
         Invocation.getter(#wiredDevices),
         returnValue: <_i2.NetworkManagerDevice>[],

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -21,7 +22,7 @@ class MockProductNameFile extends Mock implements File {
   Future<String> readAsString({Encoding encoding = utf8}) async => _product;
 }
 
-@GenerateMocks([ConfigService])
+@GenerateMocks([ConfigService, NetworkService])
 void main() {
   test('load identity', () async {
     const identity = IdentityData(
@@ -38,7 +39,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
 
     await IOOverrides.runZoned(() async {
       await model.loadIdentity();
@@ -61,7 +69,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => 'someone');
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
 
     await IOOverrides.runZoned(() async {
       await model.loadIdentity();
@@ -80,7 +95,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
     await IOOverrides.runZoned(() async {
       await model.loadIdentity();
     }, createFile: (path) => MockProductNameFile('impish'));
@@ -99,7 +121,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
     await IOOverrides.runZoned(() async {
       await model.loadIdentity();
     }, createFile: (path) => MockProductNameFile('impish'));
@@ -121,7 +150,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
     model.realName = identity.realname;
     model.username = identity.username;
     model.hostname = identity.hostname;
@@ -141,7 +177,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
     model.username = 'someone';
     model.password = 'not-empty';
 
@@ -156,7 +199,15 @@ void main() {
 
   test('password strength', () {
     // see password_test.dart for more detailed password strength tests
-    final model = WhoAreYouModel(MockSubiquityClient(), MockConfigService());
+    final client = MockSubiquityClient();
+    final config = MockConfigService();
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
 
     void testPasswordStrength(String password, Matcher matcher) {
       model.password = password;
@@ -170,7 +221,15 @@ void main() {
   });
 
   test('notify changes', () {
-    final model = WhoAreYouModel(MockSubiquityClient(), MockConfigService());
+    final client = MockSubiquityClient();
+    final config = MockConfigService();
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
 
     var wasNotified = false;
     model.addListener(() => wasNotified = true);
@@ -207,7 +266,16 @@ void main() {
   });
 
   test('validation', () {
-    final model = WhoAreYouModel(MockSubiquityClient(), MockConfigService());
+    final client = MockSubiquityClient();
+    final config = MockConfigService();
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
+
     expect(model.isValid, isFalse);
 
     void testValid(
@@ -261,7 +329,14 @@ void main() {
     when(client.validateUsername(kTooLong))
         .thenAnswer((_) async => UsernameValidation.TOO_LONG);
 
-    final model = WhoAreYouModel(client, MockConfigService());
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: MockConfigService(),
+      network: network,
+    );
     expect(model.isValid, isFalse);
 
     void testValid(
@@ -298,7 +373,14 @@ void main() {
     when(config.get(WhoAreYouModel.kAutoLoginUser))
         .thenAnswer((_) async => null);
 
-    final model = WhoAreYouModel(client, config);
+    final network = MockNetworkService();
+    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
     model.realName = 'User';
     model.username = 'user';
     model.hostname = 'ubuntu';
@@ -311,5 +393,31 @@ void main() {
     expect(model.realName, equals('User'));
     expect(model.username, equals('user'));
     expect(model.hostname, equals('ubuntu'));
+  });
+
+  test('site connectivity', () async {
+    final networkChanged = StreamController<List<String>>(sync: true);
+
+    final client = MockSubiquityClient();
+    final config = MockConfigService();
+    final network = MockNetworkService();
+    when(network.isConnectedSite).thenReturn(false);
+    when(network.propertiesChanged).thenAnswer((_) => networkChanged.stream);
+
+    final model = WhoAreYouModel(
+      client: client,
+      config: config,
+      network: network,
+    );
+    expect(model.isConnectedSite, isFalse);
+
+    var wasNotified = false;
+    model.addListener(() => wasNotified = true);
+
+    when(network.isConnectedSite).thenReturn(true);
+    networkChanged.add(['State']);
+
+    expect(wasNotified, isTrue);
+    expect(model.isConnectedSite, isTrue);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_model_test.mocks.dart
@@ -3,10 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
+import 'package:dbus/dbus.dart' as _i6;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services/config_service.dart' as _i2;
+import 'package:nm/nm.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services/config_service.dart' as _i3;
+import 'package:ubuntu_desktop_installer/services/network_service.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -19,24 +22,57 @@ import 'package:ubuntu_desktop_installer/services/config_service.dart' as _i2;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakeNetworkManagerSettings_0 extends _i1.SmartFake
+    implements _i2.NetworkManagerSettings {
+  _FakeNetworkManagerSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNetworkManagerDnsManager_1 extends _i1.SmartFake
+    implements _i2.NetworkManagerDnsManager {
+  _FakeNetworkManagerDnsManager_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNetworkManagerActiveConnection_2 extends _i1.SmartFake
+    implements _i2.NetworkManagerActiveConnection {
+  _FakeNetworkManagerActiveConnection_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [ConfigService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockConfigService extends _i1.Mock implements _i2.ConfigService {
+class MockConfigService extends _i1.Mock implements _i3.ConfigService {
   MockConfigService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<String?> get(String? key) => (super.noSuchMethod(
+  _i4.Future<String?> get(String? key) => (super.noSuchMethod(
         Invocation.method(
           #get,
           [key],
         ),
-        returnValue: _i3.Future<String?>.value(),
-      ) as _i3.Future<String?>);
+        returnValue: _i4.Future<String?>.value(),
+      ) as _i4.Future<String?>);
   @override
-  _i3.Future<void> set(
+  _i4.Future<void> set(
     String? key,
     String? value,
   ) =>
@@ -48,25 +84,321 @@ class MockConfigService extends _i1.Mock implements _i2.ConfigService {
             value,
           ],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<Map<String, String?>> load() => (super.noSuchMethod(
+  _i4.Future<Map<String, String?>> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
         returnValue:
-            _i3.Future<Map<String, String?>>.value(<String, String?>{}),
-      ) as _i3.Future<Map<String, String?>>);
+            _i4.Future<Map<String, String?>>.value(<String, String?>{}),
+      ) as _i4.Future<Map<String, String?>>);
   @override
-  _i3.Future<void> save(Map<String, String?>? config) => (super.noSuchMethod(
+  _i4.Future<void> save(Map<String, String?>? config) => (super.noSuchMethod(
         Invocation.method(
           #save,
           [config],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+}
+
+/// A class which mocks [NetworkService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockNetworkService extends _i1.Mock implements _i5.NetworkService {
+  MockNetworkService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get isConnected => (super.noSuchMethod(
+        Invocation.getter(#isConnected),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
+  List<_i2.NetworkManagerDevice> get wiredDevices => (super.noSuchMethod(
+        Invocation.getter(#wiredDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
+  @override
+  List<_i2.NetworkManagerDevice> get wirelessDevices => (super.noSuchMethod(
+        Invocation.getter(#wirelessDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
+  @override
+  _i4.Stream<_i2.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+        Invocation.getter(#deviceAdded),
+        returnValue: _i4.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i4.Stream<_i2.NetworkManagerDevice>);
+  @override
+  _i4.Stream<_i2.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+        Invocation.getter(#deviceRemoved),
+        returnValue: _i4.Stream<_i2.NetworkManagerDevice>.empty(),
+      ) as _i4.Stream<_i2.NetworkManagerDevice>);
+  @override
+  _i4.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionAdded =>
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionAdded),
+        returnValue: _i4.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i4.Stream<_i2.NetworkManagerActiveConnection>);
+  @override
+  _i4.Stream<_i2.NetworkManagerActiveConnection> get activeConnectionRemoved =>
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnectionRemoved),
+        returnValue: _i4.Stream<_i2.NetworkManagerActiveConnection>.empty(),
+      ) as _i4.Stream<_i2.NetworkManagerActiveConnection>);
+  @override
+  _i4.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i4.Stream<List<String>>.empty(),
+      ) as _i4.Stream<List<String>>);
+  @override
+  List<_i2.NetworkManagerDevice> get devices => (super.noSuchMethod(
+        Invocation.getter(#devices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
+  @override
+  List<_i2.NetworkManagerDevice> get allDevices => (super.noSuchMethod(
+        Invocation.getter(#allDevices),
+        returnValue: <_i2.NetworkManagerDevice>[],
+      ) as List<_i2.NetworkManagerDevice>);
+  @override
+  bool get networkingEnabled => (super.noSuchMethod(
+        Invocation.getter(#networkingEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get wirelessEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get wirelessHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wirelessHardwareEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get wwanEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get wwanHardwareEnabled => (super.noSuchMethod(
+        Invocation.getter(#wwanHardwareEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  List<_i2.NetworkManagerActiveConnection> get activeConnections =>
+      (super.noSuchMethod(
+        Invocation.getter(#activeConnections),
+        returnValue: <_i2.NetworkManagerActiveConnection>[],
+      ) as List<_i2.NetworkManagerActiveConnection>);
+  @override
+  String get primaryConnectionType => (super.noSuchMethod(
+        Invocation.getter(#primaryConnectionType),
+        returnValue: '',
+      ) as String);
+  @override
+  _i2.NetworkManagerMetered get metered => (super.noSuchMethod(
+        Invocation.getter(#metered),
+        returnValue: _i2.NetworkManagerMetered.unknown,
+      ) as _i2.NetworkManagerMetered);
+  @override
+  bool get startup => (super.noSuchMethod(
+        Invocation.getter(#startup),
+        returnValue: false,
+      ) as bool);
+  @override
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: '',
+      ) as String);
+  @override
+  _i2.NetworkManagerConnectivityState get connectivity => (super.noSuchMethod(
+        Invocation.getter(#connectivity),
+        returnValue: _i2.NetworkManagerConnectivityState.unknown,
+      ) as _i2.NetworkManagerConnectivityState);
+  @override
+  bool get connectivityCheckAvailable => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckAvailable),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get connectivityCheckEnabled => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckEnabled),
+        returnValue: false,
+      ) as bool);
+  @override
+  String get connectivityCheckUri => (super.noSuchMethod(
+        Invocation.getter(#connectivityCheckUri),
+        returnValue: '',
+      ) as String);
+  @override
+  _i2.NetworkManagerState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i2.NetworkManagerState.unknown,
+      ) as _i2.NetworkManagerState);
+  @override
+  _i2.NetworkManagerSettings get settings => (super.noSuchMethod(
+        Invocation.getter(#settings),
+        returnValue: _FakeNetworkManagerSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
+      ) as _i2.NetworkManagerSettings);
+  @override
+  _i2.NetworkManagerDnsManager get dnsManager => (super.noSuchMethod(
+        Invocation.getter(#dnsManager),
+        returnValue: _FakeNetworkManagerDnsManager_1(
+          this,
+          Invocation.getter(#dnsManager),
+        ),
+      ) as _i2.NetworkManagerDnsManager);
+  @override
+  Map<String, Map<String, _i6.DBusValue>> getWifiSettings(
+          {required String? ssid}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getWifiSettings,
+          [],
+          {#ssid: ssid},
+        ),
+        returnValue: <String, Map<String, _i6.DBusValue>>{},
+      ) as Map<String, Map<String, _i6.DBusValue>>);
+  @override
+  _i4.Future<void> markConfigured() => (super.noSuchMethod(
+        Invocation.method(
+          #markConfigured,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> connect() => (super.noSuchMethod(
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #setWirelessEnabled,
+          [value],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #setWwanEnabled,
+          [value],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> setConnectivityCheckEnabled(bool? value) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setConnectivityCheckEnabled,
+          [value],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<_i2.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i6.DBusValue>>? connection = const {},
+    required _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAndActivateConnection,
+          [],
+          {
+            #connection: connection,
+            #device: device,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i4.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_2(
+          this,
+          Invocation.method(
+            #addAndActivateConnection,
+            [],
+            {
+              #connection: connection,
+              #device: device,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i4.Future<_i2.NetworkManagerActiveConnection>);
+  @override
+  _i4.Future<_i2.NetworkManagerActiveConnection> activateConnection({
+    required _i2.NetworkManagerDevice? device,
+    _i2.NetworkManagerSettingsConnection? connection,
+    _i2.NetworkManagerAccessPoint? accessPoint,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #activateConnection,
+          [],
+          {
+            #device: device,
+            #connection: connection,
+            #accessPoint: accessPoint,
+          },
+        ),
+        returnValue: _i4.Future<_i2.NetworkManagerActiveConnection>.value(
+            _FakeNetworkManagerActiveConnection_2(
+          this,
+          Invocation.method(
+            #activateConnection,
+            [],
+            {
+              #device: device,
+              #connection: connection,
+              #accessPoint: accessPoint,
+            },
+          ),
+        )),
+      ) as _i4.Future<_i2.NetworkManagerActiveConnection>);
+  @override
+  _i4.Future<void> deactivateConnection(
+          _i2.NetworkManagerActiveConnection? connection) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deactivateConnection,
+          [connection],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/who_are_you/who_are_you_page_test.mocks.dart
@@ -115,6 +115,11 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
         returnValueForMissingStub: null,
       );
   @override
+  bool get isConnectedSite => (super.noSuchMethod(
+        Invocation.getter(#isConnectedSite),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get isValid => (super.noSuchMethod(
         Invocation.getter(#isValid),
         returnValue: false,
@@ -181,6 +186,54 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
+  void setProperties(_i5.Stream<List<String>>? properties) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setProperties,
+          [properties],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void addPropertyListener(
+    String? property,
+    _i6.VoidCallback? onChanged,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #addPropertyListener,
+          [
+            property,
+            onChanged,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void enablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #enablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void disablePropertyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #disablePropertyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
@@ -193,14 +246,6 @@ class MockWhoAreYouModel extends _i1.Mock implements _i2.WhoAreYouModel {
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
This property will be used to enable/disable the upcoming "Use Active Directory" checkbox.

[`NM_STATE_CONNECTED_SITE`](https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMState)
> There is only site-wide IPv4 and/or IPv6 connectivity. This means a default route is available, but the Internet connectivity check (see "Connectivity" property) did not succeed. The graphical shell should indicate limited network connectivity.

Ref: #41