### PR TITLE
Temporarily mark AD configured on startup

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -137,6 +137,7 @@ Future<void> runInstallerApp(
   // Use the default values for a number of endpoints
   // for which a UI page isn't implemented yet.
   await subiquityClient.markConfigured([
+    'ad',
     'mirror',
     'proxy',
     'ssh',


### PR DESCRIPTION
To avoid that Subiquity gets stuck waiting for AD configuration, until we have the AD GUI in place.