### PR TITLE
snap: add flash-kernel postinst hook

### DIFF
--- a/snap/local/postinst.d/10_flash_kernel
+++ b/snap/local/postinst.d/10_flash_kernel
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+# Currently curtin doesn't call flash-kernel after installing kernel
+# and generating initrd, but we need it on arm64
+# and we need to update-grub after flash-kernel installed dtb
+if [ -e /target/usr/sbin/flash-kernel ]; then
+	FK_FORCE=yes curtin in-target -t /target -- flash-kernel
+fi
+if [ -e /target/usr/sbin/update-grub ]; then
+	curtin in-target -t /target -- update-grub
+fi


### PR DESCRIPTION
This is a temp hack, that is needed to instal arm64 desktops correctly.

not yet tested, will inject and test.