### PR TITLE
Add --source-catalog command-line argument for testing purposes

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -50,6 +50,10 @@ Future<void> runInstallerApp(
         valueHelp: 'path',
         defaultsTo: 'examples/simple.json',
         help: 'Path of the machine config (dry-run only)');
+    parser.addOption('source-catalog',
+        valueHelp: 'path',
+        defaultsTo: 'examples/mixed-sources.yaml',
+        help: 'Path of the source catalog (dry-run only)');
     parser.addOption('bootloader', hide: true);
     parser.addFlag('try-or-install', hide: true);
   })!;
@@ -125,6 +129,8 @@ Future<void> runInstallerApp(
     serverArgs: [
       if (options['machine-config'] != null)
         '--machine-config=${options['machine-config']}',
+      if (options['source-catalog'] != null)
+        '--source-catalog=${options['source-catalog']}',
       if (options['bootloader'] != null)
         '--bootloader=${options['bootloader']}',
       '--storage-version=2',


### PR DESCRIPTION
Forwarded to subiquity in dry-run mode, similarly to `--machine-config`. Defaults to [`example/mixed-sources.yaml`](https://github.com/canonical/subiquity/blob/main/examples/mixed-sources.yaml) which comes with a desktop source.