### PR TITLE
Move `InheritedLocale` up in the tree to avoid losing language selection

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -93,12 +93,16 @@ Future<void> runInstallerApp(
   tryRegisterService(UdevService.new);
   tryRegisterService(UrlLauncher.new);
 
+  WidgetsFlutterBinding.ensureInitialized();
+
   await runWizardApp(
-    UbuntuDesktopInstallerApp(
-      flavor: flavor,
-      slides: slides,
-      initialRoute: options['initial-route'],
-      tryOrInstall: options['try-or-install'],
+    InheritedLocale(
+      child: UbuntuDesktopInstallerApp(
+        flavor: flavor,
+        slides: slides,
+        initialRoute: options['initial-route'],
+        tryOrInstall: options['try-or-install'],
+      ),
     ),
     options: options,
     subiquityClient: subiquityClient,
@@ -194,45 +198,42 @@ class _UbuntuDesktopInstallerAppState extends State<UbuntuDesktopInstallerApp> {
         data: widget.flavor,
         child: SlidesContext(
           slides: widget.slides,
-          child: InheritedLocale(
-            child: YaruTheme(
-              data: const YaruThemeData(
-                extensions: [
-                  YaruTitleBarThemeData(
-                    backgroundColor:
-                        MaterialStatePropertyAll(Colors.transparent),
-                  )
-                ],
-              ),
-              builder: (context, yaru, child) {
-                return MaterialApp(
-                  locale: InheritedLocale.of(context),
-                  onGenerateTitle: (context) {
-                    final lang = AppLocalizations.of(context);
-                    final window = YaruWindow.of(context);
-                    window.setTitle(lang.windowTitle(widget.flavor.name));
-                    return lang.appTitle;
-                  },
-                  theme: widget.flavor.theme ?? yaru.theme,
-                  darkTheme: widget.flavor.darkTheme ?? yaru.darkTheme,
-                  debugShowCheckedModeBanner: false,
-                  localizationsDelegates: <LocalizationsDelegate>[
-                    ...localizationsDelegates,
-                    ...?widget.flavor.localizationsDelegates,
-                  ],
-                  supportedLocales: supportedLocales,
-                  home: buildApp(context),
-                  builder: (context, child) => Stack(
-                    children: [
-                      const Positioned.fill(
-                        child: _UbuntuDesktopInstallerBackground(),
-                      ),
-                      Positioned.fill(child: child!),
-                    ],
-                  ),
-                );
-              },
+          child: YaruTheme(
+            data: const YaruThemeData(
+              extensions: [
+                YaruTitleBarThemeData(
+                  backgroundColor: MaterialStatePropertyAll(Colors.transparent),
+                )
+              ],
             ),
+            builder: (context, yaru, child) {
+              return MaterialApp(
+                locale: InheritedLocale.of(context),
+                onGenerateTitle: (context) {
+                  final lang = AppLocalizations.of(context);
+                  final window = YaruWindow.of(context);
+                  window.setTitle(lang.windowTitle(widget.flavor.name));
+                  return lang.appTitle;
+                },
+                theme: widget.flavor.theme ?? yaru.theme,
+                darkTheme: widget.flavor.darkTheme ?? yaru.darkTheme,
+                debugShowCheckedModeBanner: false,
+                localizationsDelegates: <LocalizationsDelegate>[
+                  ...localizationsDelegates,
+                  ...?widget.flavor.localizationsDelegates,
+                ],
+                supportedLocales: supportedLocales,
+                home: buildApp(context),
+                builder: (context, child) => Stack(
+                  children: [
+                    const Positioned.fill(
+                      child: _UbuntuDesktopInstallerBackground(),
+                    ),
+                    Positioned.fill(child: child!),
+                  ],
+                ),
+              );
+            },
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -14,6 +14,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
 import 'choose_your_look/choose_your_look_page_test.mocks.dart';
 import 'installation_slides/installation_slides_model_test.mocks.dart';
@@ -97,6 +98,6 @@ extension on WidgetTester {
     registerMockService<JournalService>(journal);
     registerMockService<TelemetryService>(TelemetryService());
 
-    return UbuntuDesktopInstallerApp();
+    return InheritedLocale(child: UbuntuDesktopInstallerApp());
   }
 }


### PR DESCRIPTION
This fixes a regression introduced by #1535. The app object is rebuilt whenever Subiquity's status changes, so we cannot store InheritedLocale there. :(

Fix: #1550