### PR TITLE
Disable screensaver, screen blanking, automounting

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
-          sudo apt install -y dbus-x11 network-manager upower
+          sudo apt install -y dbus-x11 network-manager ubuntu-desktop-minimal upower
           make install_deps
 
       - name: Install Flutter

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -143,6 +143,11 @@ Future<void> runInstallerApp(
 
   final storage = getService<DiskStorageService>();
   await storage.init();
+
+  final desktop = getService<DesktopService>();
+  await desktop.disableAutoMounting();
+  await desktop.disableScreenBlanking();
+  await desktop.disableScreensaver();
 }
 
 class UbuntuDesktopInstallerApp extends StatefulWidget {

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -117,6 +117,7 @@ Future<void> runInstallerApp(
         '--bootloader=${options['bootloader']}',
       '--storage-version=2',
     ],
+    dispose: () => getService<DesktopService>().close(),
   );
 
   await subiquityClient.setVariant(Variant.DESKTOP);

--- a/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
@@ -29,11 +29,14 @@ class GnomeService implements DesktopService {
   /// Creates a GNOME settings instance using the given GSettings as a backend
   /// for storing the settings.
   GnomeService({
+    @visibleForTesting GSettings? dingSettings,
     @visibleForTesting GSettings? interfaceSettings,
     @visibleForTesting GSettings? mediaHandlingSettings,
     @visibleForTesting GSettings? sessionSettings,
     @visibleForTesting GSettings? screensaverSettings,
-  })  : _interfaceSettings =
+  })  : _dingSettings =
+            dingSettings ?? GSettings('org.gnome.shell.extensions.ding'),
+        _interfaceSettings =
             interfaceSettings ?? GSettings('org.gnome.desktop.interface'),
         _mediaHandlingSettings = mediaHandlingSettings ??
             GSettings('org.gnome.desktop.media-handling'),
@@ -42,6 +45,7 @@ class GnomeService implements DesktopService {
         _sessionSettings =
             sessionSettings ?? GSettings('org.gnome.desktop.session');
 
+  final GSettings _dingSettings;
   final GSettings _interfaceSettings;
   final GSettings _mediaHandlingSettings;
   final GSettings _screensaverSettings;
@@ -57,14 +61,22 @@ class GnomeService implements DesktopService {
         await _mediaHandlingSettings.get('automount-open');
     final previousAutoRunNever =
         await _mediaHandlingSettings.get('autorun-never');
+    final previousShowVolumes = await _dingSettings.get('show-volumes');
+    final previousShowNetworkVolumes =
+        await _dingSettings.get('show-network-volumes');
     await _mediaHandlingSettings.set('automount', const DBusBoolean(false));
     await _mediaHandlingSettings.set(
         'automount-open', const DBusBoolean(false));
     await _mediaHandlingSettings.set('autorun-never', const DBusBoolean(true));
+    await _dingSettings.set('show-volumes', const DBusBoolean(false));
+    await _dingSettings.set('show-network-volumes', const DBusBoolean(false));
     restoreSettings.add(() async {
       await _mediaHandlingSettings.set('automount', previousAutoMount);
       await _mediaHandlingSettings.set('automount-open', previousAutoMountOpen);
       await _mediaHandlingSettings.set('autorun-never', previousAutoRunNever);
+      await _dingSettings.set('show-volumes', previousShowVolumes);
+      await _dingSettings.set(
+          'show-network-volumes', previousShowNetworkVolumes);
     });
   }
 

--- a/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
@@ -1,9 +1,22 @@
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+/// @internal
+final logger = Logger('desktop');
 
 /// An interface for accessing to desktop settings.
 abstract class DesktopService {
+  /// Disables automatic volume mounting to avoid problems during partitioning.
+  Future<void> disableAutoMounting();
+
+  /// Disables the screensaver.
+  Future<void> disableScreensaver();
+
+  /// Disables screen blanking.
+  Future<void> disableScreenBlanking();
+
   /// Applies a desktop theme matching the given [brightness].
   Future<void> setTheme(Brightness brightness);
 
@@ -15,29 +28,94 @@ abstract class DesktopService {
 class GnomeService implements DesktopService {
   /// Creates a GNOME settings instance using the given GSettings as a backend
   /// for storing the settings.
-  GnomeService([@visibleForTesting GSettings? gsettings])
-      : _gsettings = gsettings ?? GSettings('org.gnome.desktop.interface');
+  GnomeService({
+    @visibleForTesting GSettings? interfaceSettings,
+    @visibleForTesting GSettings? mediaHandlingSettings,
+    @visibleForTesting GSettings? sessionSettings,
+    @visibleForTesting GSettings? screensaverSettings,
+  })  : _interfaceSettings =
+            interfaceSettings ?? GSettings('org.gnome.desktop.interface'),
+        _mediaHandlingSettings = mediaHandlingSettings ??
+            GSettings('org.gnome.desktop.media-handling'),
+        _screensaverSettings =
+            screensaverSettings ?? GSettings('org.gnome.desktop.screensaver'),
+        _sessionSettings =
+            sessionSettings ?? GSettings('org.gnome.desktop.session');
 
-  final GSettings _gsettings;
+  final GSettings _interfaceSettings;
+  final GSettings _mediaHandlingSettings;
+  final GSettings _screensaverSettings;
+  final GSettings _sessionSettings;
+
+  final restoreSettings = <Future<void> Function()>[];
+
+  @override
+  Future<void> disableAutoMounting() async {
+    logger.debug('Disabling automounting');
+    final previousAutoMount = await _mediaHandlingSettings.get('automount');
+    final previousAutoMountOpen =
+        await _mediaHandlingSettings.get('automount-open');
+    final previousAutoRunNever =
+        await _mediaHandlingSettings.get('autorun-never');
+    await _mediaHandlingSettings.set('automount', const DBusBoolean(false));
+    await _mediaHandlingSettings.set(
+        'automount-open', const DBusBoolean(false));
+    await _mediaHandlingSettings.set('autorun-never', const DBusBoolean(true));
+    restoreSettings.add(() async {
+      await _mediaHandlingSettings.set('automount', previousAutoMount);
+      await _mediaHandlingSettings.set('automount-open', previousAutoMountOpen);
+      await _mediaHandlingSettings.set('autorun-never', previousAutoRunNever);
+    });
+  }
+
+  @override
+  Future<void> disableScreenBlanking() async {
+    logger.debug('Disabling screen blanking');
+    final previousValue = await _sessionSettings.get('idle-delay');
+    await _sessionSettings.set('idle-delay', const DBusUint32(0));
+    restoreSettings
+        .add(() => _sessionSettings.set('idle-delay', previousValue));
+  }
+
+  @override
+  Future<void> disableScreensaver() async {
+    logger.debug('Disabling screensaver');
+    final previousValue =
+        await _screensaverSettings.get('idle-activation-enabled');
+    await _screensaverSettings.set(
+        'idle-activation-enabled', const DBusBoolean(false));
+    restoreSettings.add(() =>
+        _screensaverSettings.set('idle-activation-enabled', previousValue));
+  }
 
   @override
   Future<void> setTheme(Brightness brightness) async {
-    final theme = await _gsettings.get('gtk-theme').then((v) => v.asString());
+    final theme =
+        await _interfaceSettings.get('gtk-theme').then((v) => v.asString());
     switch (brightness) {
       case Brightness.dark:
-        await _gsettings.set('gtk-theme', DBusString(theme.addSuffix('-dark')));
-        await _gsettings.set('color-scheme', const DBusString('prefer-dark'));
+        await _interfaceSettings.set(
+            'gtk-theme', DBusString(theme.addSuffix('-dark')));
+        await _interfaceSettings.set(
+            'color-scheme', const DBusString('prefer-dark'));
         break;
       case Brightness.light:
-        await _gsettings.set(
+        await _interfaceSettings.set(
             'gtk-theme', DBusString(theme.removeSuffix('-dark')));
-        await _gsettings.set('color-scheme', const DBusString('prefer-light'));
+        await _interfaceSettings.set(
+            'color-scheme', const DBusString('prefer-light'));
         break;
     }
   }
 
   @override
-  Future<void> close() => _gsettings.close();
+  Future<void> close() async {
+    logger.debug('Restoring desktop settings');
+    await Future.wait(restoreSettings.map((r) => r.call()));
+    await _interfaceSettings.close();
+    await _sessionSettings.close();
+    await _screensaverSettings.close();
+  }
 }
 
 extension on String {

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -29,6 +29,33 @@ class MockDesktopService extends _i1.Mock implements _i2.DesktopService {
   }
 
   @override
+  _i3.Future<void> disableAutoMounting() => (super.noSuchMethod(
+        Invocation.method(
+          #disableAutoMounting,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> disableScreensaver() => (super.noSuchMethod(
+        Invocation.method(
+          #disableScreensaver,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
+  _i3.Future<void> disableScreenBlanking() => (super.noSuchMethod(
+        Invocation.method(
+          #disableScreenBlanking,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+  @override
   _i3.Future<void> setTheme(_i4.Brightness? brightness) => (super.noSuchMethod(
         Invocation.method(
           #setTheme,

--- a/packages/ubuntu_desktop_installer/test/services/desktop_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/desktop_service_test.dart
@@ -6,28 +6,88 @@ import 'package:ubuntu_desktop_installer/services/desktop_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 
 void main() {
+  late MockGSettings interfaceSettings;
+  late MockGSettings mediaHandlingSettings;
+  late MockGSettings sessionSettings;
+  late MockGSettings screensaverSettings;
+  late DesktopService service;
+  setUp(() {
+    interfaceSettings = MockGSettings();
+    mediaHandlingSettings = MockGSettings();
+    sessionSettings = MockGSettings();
+    screensaverSettings = MockGSettings();
+    when(interfaceSettings.set(any, any)).thenAnswer((_) async {});
+    when(mediaHandlingSettings.set(any, any)).thenAnswer((_) async {});
+    when(sessionSettings.set(any, any)).thenAnswer((_) async {});
+    when(screensaverSettings.set(any, any)).thenAnswer((_) async {});
+
+    service = GnomeService(
+        interfaceSettings: interfaceSettings,
+        mediaHandlingSettings: mediaHandlingSettings,
+        sessionSettings: sessionSettings,
+        screensaverSettings: screensaverSettings);
+  });
+
   test('set color-scheme via gsettings', () async {
-    final gsettings = MockGSettings();
-    when(gsettings.set(any, any)).thenAnswer((_) async {});
-
-    final settings = GnomeService(gsettings);
-
-    when(gsettings.get('gtk-theme'))
+    when(interfaceSettings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru-dark'));
 
-    await settings.setTheme(Brightness.light);
+    await service.setTheme(Brightness.light);
     verifyInOrder([
-      gsettings.set('gtk-theme', const DBusString('Yaru')),
-      gsettings.set('color-scheme', const DBusString('prefer-light')),
+      interfaceSettings.set('gtk-theme', const DBusString('Yaru')),
+      interfaceSettings.set('color-scheme', const DBusString('prefer-light')),
     ]);
 
-    when(gsettings.get('gtk-theme'))
+    when(interfaceSettings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru'));
 
-    await settings.setTheme(Brightness.dark);
+    await service.setTheme(Brightness.dark);
     verifyInOrder([
-      gsettings.set('gtk-theme', const DBusString('Yaru-dark')),
-      gsettings.set('color-scheme', const DBusString('prefer-dark')),
+      interfaceSettings.set('gtk-theme', const DBusString('Yaru-dark')),
+      interfaceSettings.set('color-scheme', const DBusString('prefer-dark')),
     ]);
+  });
+
+  test('disable automounting', () async {
+    when(mediaHandlingSettings.get('automount'))
+        .thenAnswer((_) async => const DBusBoolean(true));
+    when(mediaHandlingSettings.get('automount-open'))
+        .thenAnswer((_) async => const DBusBoolean(true));
+    when(mediaHandlingSettings.get('autorun-never'))
+        .thenAnswer((_) async => const DBusBoolean(false));
+    await service.disableAutoMounting();
+    verifyInOrder([
+      mediaHandlingSettings.set('automount', const DBusBoolean(false)),
+      mediaHandlingSettings.set('automount-open', const DBusBoolean(false)),
+      mediaHandlingSettings.set('autorun-never', const DBusBoolean(true)),
+    ]);
+    await service.close();
+    verifyInOrder([
+      mediaHandlingSettings.set('automount', const DBusBoolean(true)),
+      mediaHandlingSettings.set('automount-open', const DBusBoolean(true)),
+      mediaHandlingSettings.set('autorun-never', const DBusBoolean(false)),
+    ]);
+  });
+
+  test('disable screen blanking', () async {
+    when(sessionSettings.get('idle-delay'))
+        .thenAnswer((_) async => const DBusUint32(600));
+    await service.disableScreenBlanking();
+    verify(sessionSettings.set('idle-delay', const DBusUint32(0))).called(1);
+    await service.close();
+    verify(sessionSettings.set('idle-delay', const DBusUint32(600))).called(1);
+  });
+
+  test('disable screensaver', () async {
+    when(screensaverSettings.get('idle-activation-enabled'))
+        .thenAnswer((_) async => const DBusBoolean(true));
+    await service.disableScreensaver();
+    verify(screensaverSettings.set(
+            'idle-activation-enabled', const DBusBoolean(false)))
+        .called(1);
+    await service.close();
+    verify(screensaverSettings.set(
+            'idle-activation-enabled', const DBusBoolean(true)))
+        .called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/services/desktop_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/desktop_service_test.dart
@@ -6,22 +6,26 @@ import 'package:ubuntu_desktop_installer/services/desktop_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 
 void main() {
+  late MockGSettings dingSettings;
   late MockGSettings interfaceSettings;
   late MockGSettings mediaHandlingSettings;
   late MockGSettings sessionSettings;
   late MockGSettings screensaverSettings;
   late DesktopService service;
   setUp(() {
+    dingSettings = MockGSettings();
     interfaceSettings = MockGSettings();
     mediaHandlingSettings = MockGSettings();
     sessionSettings = MockGSettings();
     screensaverSettings = MockGSettings();
+    when(dingSettings.set(any, any)).thenAnswer((_) async {});
     when(interfaceSettings.set(any, any)).thenAnswer((_) async {});
     when(mediaHandlingSettings.set(any, any)).thenAnswer((_) async {});
     when(sessionSettings.set(any, any)).thenAnswer((_) async {});
     when(screensaverSettings.set(any, any)).thenAnswer((_) async {});
 
     service = GnomeService(
+        dingSettings: dingSettings,
         interfaceSettings: interfaceSettings,
         mediaHandlingSettings: mediaHandlingSettings,
         sessionSettings: sessionSettings,
@@ -55,17 +59,25 @@ void main() {
         .thenAnswer((_) async => const DBusBoolean(true));
     when(mediaHandlingSettings.get('autorun-never'))
         .thenAnswer((_) async => const DBusBoolean(false));
+    when(dingSettings.get('show-volumes'))
+        .thenAnswer((_) async => const DBusBoolean(true));
+    when(dingSettings.get('show-network-volumes'))
+        .thenAnswer((_) async => const DBusBoolean(true));
     await service.disableAutoMounting();
     verifyInOrder([
       mediaHandlingSettings.set('automount', const DBusBoolean(false)),
       mediaHandlingSettings.set('automount-open', const DBusBoolean(false)),
       mediaHandlingSettings.set('autorun-never', const DBusBoolean(true)),
+      dingSettings.set('show-volumes', const DBusBoolean(false)),
+      dingSettings.set('show-network-volumes', const DBusBoolean(false)),
     ]);
     await service.close();
     verifyInOrder([
       mediaHandlingSettings.set('automount', const DBusBoolean(true)),
       mediaHandlingSettings.set('automount-open', const DBusBoolean(true)),
       mediaHandlingSettings.set('autorun-never', const DBusBoolean(false)),
+      dingSettings.set('show-volumes', const DBusBoolean(true)),
+      dingSettings.set('show-network-volumes', const DBusBoolean(true)),
     ]);
   });
 

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -34,6 +34,7 @@ Future<bool?> runWizardApp(
   SubiquityStatusMonitor? subiquityMonitor,
   List<String>? serverArgs,
   Map<String, String>? serverEnvironment,
+  FutureOr<void> Function()? dispose,
 }) async {
   if (options != null) {
     Logger.setup(
@@ -62,6 +63,7 @@ Future<bool?> runWizardApp(
     await subiquityMonitor?.stop();
     await subiquityClient.close();
     await subiquityServer.stop();
+    await dispose?.call();
     return true;
   });
 


### PR DESCRIPTION
Disables the screensaver, screen blanking and automatic volume mounting when the installer is run, and restores the previous settings when its closed.

I mostly followed https://git.launchpad.net/ubiquity/tree/ubiquity/frontend/gtk_ui.py#n842 with two exceptions:
- I didn't implement `disablePowermgr` yet. In ubiquity this is done by setting `active=false` in `org.gnome.settings-daemon.plugins.power`, however gsettings doesn't list an `active` key for that interface on my system (22.10).
- `org.gnome.nautilus.desktop` doesn't exist on my system either, so I left that part out of `disableAutoMount`

I'll do more research on those things tomorrow, but please feel free to enlighten me if anyone knows more about this.

Ref #1543
Edit: I'll tackle power management in a separate PR.