### PR TITLE
Allocate disk space: present "leave unformatted" as "none" format

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -94,7 +94,10 @@ Future<void> showCreatePartitionDialog(
               Text(lang.partitionFormatLabel, textAlign: TextAlign.end),
               _PartitionFormatSelector(
                 partitionFormat: partitionFormat,
-                partitionFormats: [...PartitionFormat.supported, null],
+                partitionFormats: [
+                  ...PartitionFormat.supported,
+                  PartitionFormat.none,
+                ],
               )
             ],
             <Widget>[
@@ -134,6 +137,8 @@ Future<void> showCreatePartitionDialog(
 extension _PartitionFormatLang on PartitionFormat {
   String localize(AppLocalizations lang) {
     switch (this) {
+      case PartitionFormat.none:
+        return lang.partitionFormatNone;
       case PartitionFormat.btrfs:
         return lang.partitionFormatBtrfs;
       case PartitionFormat.ext2:

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -32,6 +32,7 @@ class PartitionFormat {
   @override
   String toString() => type;
 
+  static const none = PartitionFormat._('');
   static const btrfs = PartitionFormat._('btrfs');
   static const ext2 = PartitionFormat._('ext2');
   static const ext3 = PartitionFormat._('ext3');


### PR DESCRIPTION
Previously, we presented the "Leave unformatted" option as `null`. However, we want to have an additional separator which will be supported by the upcoming `MenuButtonBuilder` in `ubuntu_widgets`. The separator will be presented as `null` so let's present the "Leave unformatted" option with its own dedicated value instead, to leave `null` for the separator.

NOTE: I just added the Subiquity screenshot for reference and noticed that it actually has two separators but it's irrelevant for this PR because this does not change the visuals. This is just a preparation step for being able to present both separators (`null`) and the "Leave unformatted" option (`PartitionFormat.none`).

| Current | Future | Subiquity|
|---|---|---|
| ![Screenshot from 2023-03-08 07-40-55](https://user-images.githubusercontent.com/140617/223639334-9069b6b4-e387-4c6f-aae1-bf6d44368918.png) | ![Screenshot from 2023-03-08 07-37-50](https://user-images.githubusercontent.com/140617/223639361-a2d13bc4-56e1-41b4-a497-70411511aa8f.png) | ![image](https://user-images.githubusercontent.com/140617/223640287-6d3b6ad4-97d6-4ebe-b1c6-37c82731b713.png) |

See also:
- #1335
- canonical/ubuntu-flutter-plugins#148
