### PR TITLE
update-artifacts.sh: fix output directory

### DIFF
--- a/snap/local/flutter/update-artifacts.sh
+++ b/snap/local/flutter/update-artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-project_dir=$(cd "$(dirname "$0")/.." && pwd)
+snap_local=$(cd "$(dirname "$0")/.." && pwd)
 version="$1"
 
 pushd /tmp > /dev/null
@@ -19,5 +19,5 @@ curl -o flutter-stable.tar.xz $url
 echo "Extracting shader_lib"
 tar -xvf flutter-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
 echo "Updating shader_lib"
-rsync -avu --delete flutter/bin/cache/artifacts/engine/linux-x64/shader_lib $project_dir/snap/local/
+rsync -avu --delete flutter/bin/cache/artifacts/engine/linux-x64/shader_lib $snap_local/flutter
 popd  > /dev/null


### PR DESCRIPTION
At first, [the script](https://github.com/canonical/ubuntu-desktop-installer/pull/1527) was in `/scripts` and `shader_lib` directly under `/snap/local` but I shuffled things around last minute, created `snap/local/flutter` to have a place for the license & readme, and decided to move the script as well but forgot to update it. :)

### Before

```sh
$ ./snap/local/flutter/update-artifacts.sh 3.7.7
Downloading https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.7-stable.tar.xz
[...]
Extracting shader_lib
[...]
Updating shader_lib
sending incremental file list
rsync: [Receiver] mkdir "/home/jpnurmi/Projects/canonical/ubuntu-desktop-installer/snap/local/snap/local" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(791) [Receiver=3.2.7]
```

### After

```sh
$ ./snap/local/flutter/update-artifacts.sh 3.7.7
Downloading https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.7-stable.tar.xz
[...]
Extracting shader_lib
[...]
Updating shader_lib
sending incremental file list

sent 352 bytes  received 19 bytes  742,00 bytes/sec
total size is 18.408  speedup is 49,62
```