### PR TITLE
snap: update to flutter 3.7.7

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,7 +128,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.7.6 # run local/flutter/update-artifacts.sh [x.y.z]
+    source-tag: 3.7.7 # run local/flutter/update-artifacts.sh [x.y.z]
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
> We are pleased to announce the release of Flutter 3.7.7 to the stable channel; this release contains the following hotfixes:
>
> - [dart/121270](https://github.com/flutter/flutter/issues/121270) - Fixes mobile devices vm crashes caused by particular use of RegExp on mobile devices.
> - [flutter/121256](http://github.com/flutter/flutter/issues/121256) Fixes an issue where Android users can not use add2app because it can not locate build/host/apk/app-debug.apk.
> - [flutter/120455](https://github.com/flutter/flutter/issues/120455) Cached DisplayList opacity inheritance fix.
>
> In order to get the latest, run ‘flutter upgrade’.

https://groups.google.com/g/flutter-announce/c/UdHywgUelvU/m/eVNSPT5IAAAJ?utm_medium=email&utm_source=footer