### PR TITLE
StorageSizeBox: replace DropdownBuilder with MenuButtonBuilder

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -62,10 +62,10 @@ class StorageSizeBox extends StatelessWidget {
         ),
         SizedBox(width: spacing),
         IntrinsicWidth(
-          child: DropdownBuilder<DataUnit>(
+          child: MenuButtonBuilder<DataUnit>(
             values: DataUnit.values,
             selected: unit,
-            onSelected: (value) => onUnitSelected(value!),
+            onSelected: (value) => onUnitSelected(value),
             itemBuilder: (context, unit, _) {
               return Text(unit.l10n(context), key: ValueKey(unit));
             },

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -8,6 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/allocate_disk_space_page.dart';
 import 'package:ubuntu_desktop_installer/pages/allocate_disk_space/storage_types.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -38,7 +39,7 @@ void main() {
         tester.element(find.byType(AllocateDiskSpacePage)), disk, gap);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButton<DataUnit>));
+    await tester.tap(find.byType(MenuButtonBuilder<DataUnit>));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(ValueKey(DataUnit.bytes)).last);
@@ -106,7 +107,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButton<DataUnit>));
+    await tester.tap(find.byType(MenuButtonBuilder<DataUnit>));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(ValueKey(DataUnit.bytes)).last);

--- a/packages/ubuntu_desktop_installer/test/install_alongside/storage_size_dialog_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/storage_size_dialog_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/pages/install_alongside/storage_size_dialog.dart';
 import 'package:ubuntu_desktop_installer/widgets/storage_size_box.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 import '../test_utils.dart';
@@ -60,7 +61,7 @@ void main() {
     await tester.pumpAndSettle();
 
     for (final unit in DataUnit.values) {
-      await tester.tap(find.byType(DropdownButton<DataUnit>));
+      await tester.tap(find.byType(MenuButtonBuilder<DataUnit>));
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.byKey(ValueKey(unit)).last);

--- a/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
@@ -47,7 +47,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byType(DropdownButton<DataUnit>));
+    await tester.tap(find.byType(MenuAnchor));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(ValueKey(DataUnit.megabytes)).last);


### PR DESCRIPTION
Looks like a Yaru menu, doesn't have hard-coded mobile-oriented transitions, and allows customizing the mouse cursor later.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/223944958-3659f6ec-9326-496f-a985-3cb3067d4cae.png) | ![image](https://user-images.githubusercontent.com/140617/223944880-4fceeccd-8a49-4daa-a8fd-a1f46ce33abb.png) |
| ![image](https://user-images.githubusercontent.com/140617/223944759-8b5849b5-fa34-4d91-b9f2-f4f289ea2229.png) | ![image](https://user-images.githubusercontent.com/140617/223944834-4f21eaaa-8695-4917-af22-52cba12b0d40.png) |
| ![image](https://user-images.githubusercontent.com/140617/223944454-6ef0d024-bdaf-410f-b7b7-8d5051320027.png) | ![image](https://user-images.githubusercontent.com/140617/223944509-441b9071-cf00-4f01-84e5-9ccdc60224ad.png) |
| ![image](https://user-images.githubusercontent.com/140617/223944653-5463be1c-db8a-46a0-9a59-1d1f91ab5832.png) | ![image](https://user-images.githubusercontent.com/140617/223944596-6ddc7285-46df-41f5-8da7-2a3daf22abb1.png) |

Ref: #1563