### PR TITLE
Inhibit disruptive events during installation

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
@@ -15,6 +16,8 @@ import 'package:ubuntu_desktop_installer/pages/connect_to_internet/connect_model
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_session/ubuntu_session.dart';
+import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaml/yaml.dart';
@@ -27,7 +30,17 @@ import '../test/test_utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() async => await cleanUpSubiquity());
+  setUp(() async {
+    await cleanUpSubiquity();
+    final mockGnomeSessionManager = MockGnomeSessionManager();
+    when(mockGnomeSessionManager.inhibit(
+            appId: anyNamed('appId'),
+            topLevelXId: anyNamed('topLevelXId'),
+            reason: anyNamed('reason'),
+            flags: anyNamed('flags')))
+        .thenAnswer((_) async => 42);
+    registerMockService<GnomeSessionManager>(mockGnomeSessionManager);
+  });
   tearDown(() async => await resetAllServices());
 
   testWidgets('minimal installation', (tester) async {

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -144,9 +144,7 @@ Future<void> runInstallerApp(
   await storage.init();
 
   final desktop = getService<DesktopService>();
-  await desktop.disableAutoMounting();
-  await desktop.disableScreenBlanking();
-  await desktop.disableScreensaver();
+  await desktop.inhibit();
 }
 
 class UbuntuDesktopInstallerApp extends StatefulWidget {

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:timezone_map/timezone_map.dart';
+import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -92,6 +93,7 @@ Future<void> runInstallerApp(
   tryRegisterService(TelemetryService.new);
   tryRegisterService(UdevService.new);
   tryRegisterService(UrlLauncher.new);
+  tryRegisterService(GnomeSessionManager.new);
 
   WidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
@@ -1,6 +1,7 @@
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 
@@ -41,7 +42,8 @@ class GnomeService implements DesktopService {
             screensaverSettings ?? GSettings('org.gnome.desktop.screensaver'),
         _sessionSettings =
             sessionSettings ?? GSettings('org.gnome.desktop.session'),
-        _gnomeSessionManager = gnomeSessionManager ?? GnomeSessionManager();
+        _gnomeSessionManager =
+            gnomeSessionManager ?? getService<GnomeSessionManager>();
 
   final GSettings _dingSettings;
   final GSettings _interfaceSettings;

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   ubuntu_localizations: ^0.0.5
   ubuntu_logger: ^0.0.1
   ubuntu_service: ^0.2.1
+  ubuntu_session: ^0.0.4
   ubuntu_widgets:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -29,27 +29,9 @@ class MockDesktopService extends _i1.Mock implements _i2.DesktopService {
   }
 
   @override
-  _i3.Future<void> disableAutoMounting() => (super.noSuchMethod(
+  _i3.Future<void> inhibit() => (super.noSuchMethod(
         Invocation.method(
-          #disableAutoMounting,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
-  _i3.Future<void> disableScreensaver() => (super.noSuchMethod(
-        Invocation.method(
-          #disableScreensaver,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
-  _i3.Future<void> disableScreenBlanking() => (super.noSuchMethod(
-        Invocation.method(
-          #disableScreenBlanking,
+          #inhibit,
           [],
         ),
         returnValue: _i3.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -7,7 +7,7 @@ import 'dart:async' as _i3;
 import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services/desktop_service.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values

--- a/packages/ubuntu_test/lib/src/generated.dart
+++ b/packages/ubuntu_test/lib/src/generated.dart
@@ -2,10 +2,12 @@ import 'package:gsettings/gsettings.dart';
 import 'package:mockito/annotations.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
+import 'package:ubuntu_session/ubuntu_session.dart';
 
 export 'generated.mocks.dart';
 
 @GenerateMocks([
+  GnomeSessionManager,
   GSettings,
   SubiquityClient,
   SubiquityServer,

--- a/packages/ubuntu_test/lib/src/generated.mocks.dart
+++ b/packages/ubuntu_test/lib/src/generated.mocks.dart
@@ -6,14 +6,15 @@
 import 'dart:async' as _i6;
 
 import 'package:dbus/dbus.dart' as _i2;
-import 'package:gsettings/src/gsettings.dart' as _i5;
+import 'package:gsettings/src/gsettings.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/src/client.dart' as _i7;
+import 'package:subiquity_client/src/client.dart' as _i8;
 import 'package:subiquity_client/src/endpoint.dart' as _i4;
-import 'package:subiquity_client/src/server.dart' as _i8;
-import 'package:subiquity_client/src/server/process.dart' as _i9;
-import 'package:subiquity_client/src/status_monitor.dart' as _i10;
+import 'package:subiquity_client/src/server.dart' as _i9;
+import 'package:subiquity_client/src/server/process.dart' as _i10;
+import 'package:subiquity_client/src/status_monitor.dart' as _i11;
 import 'package:subiquity_client/src/types.dart' as _i3;
+import 'package:ubuntu_session/src/gnome_session_manager.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -235,10 +236,143 @@ class _FakeEndpoint_19 extends _i1.SmartFake implements _i4.Endpoint {
         );
 }
 
+/// A class which mocks [GnomeSessionManager].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGnomeSessionManager extends _i1.Mock
+    implements _i5.GnomeSessionManager {
+  MockGnomeSessionManager() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get renderer => (super.noSuchMethod(
+        Invocation.getter(#renderer),
+        returnValue: '',
+      ) as String);
+  @override
+  bool get sessionIsActive => (super.noSuchMethod(
+        Invocation.getter(#sessionIsActive),
+        returnValue: false,
+      ) as bool);
+  @override
+  String get sessionName => (super.noSuchMethod(
+        Invocation.getter(#sessionName),
+        returnValue: '',
+      ) as String);
+  @override
+  _i6.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+        Invocation.getter(#propertiesChanged),
+        returnValue: _i6.Stream<List<String>>.empty(),
+      ) as _i6.Stream<List<String>>);
+  @override
+  _i6.Future<void> logout(
+          {_i5.GnomeLogoutMode? mode = _i5.GnomeLogoutMode.normal}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+          {#mode: mode},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> reboot() => (super.noSuchMethod(
+        Invocation.method(
+          #reboot,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> shutdown() => (super.noSuchMethod(
+        Invocation.method(
+          #shutdown,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<bool> canShutdown() => (super.noSuchMethod(
+        Invocation.method(
+          #canShutdown,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+  @override
+  _i6.Future<bool> isSessionRunning() => (super.noSuchMethod(
+        Invocation.method(
+          #isSessionRunning,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+  @override
+  _i6.Future<int> inhibit({
+    required String? appId,
+    required int? topLevelXId,
+    required String? reason,
+    required Set<_i5.GnomeInhibitionFlag>? flags,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #inhibit,
+          [],
+          {
+            #appId: appId,
+            #topLevelXId: topLevelXId,
+            #reason: reason,
+            #flags: flags,
+          },
+        ),
+        returnValue: _i6.Future<int>.value(0),
+      ) as _i6.Future<int>);
+  @override
+  _i6.Future<void> uninhibit(int? cookie) => (super.noSuchMethod(
+        Invocation.method(
+          #uninhibit,
+          [cookie],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<bool> isInhibited(Set<_i5.GnomeInhibitionFlag>? flags) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isInhibited,
+          [flags],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+  @override
+  _i6.Future<void> connect() => (super.noSuchMethod(
+        Invocation.method(
+          #connect,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+}
+
 /// A class which mocks [GSettings].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGSettings extends _i1.Mock implements _i5.GSettings {
+class MockGSettings extends _i1.Mock implements _i7.GSettings {
   MockGSettings() {
     _i1.throwOnMissingStub(this);
   }
@@ -346,7 +480,7 @@ class MockGSettings extends _i1.Mock implements _i5.GSettings {
 /// A class which mocks [SubiquityClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
+class MockSubiquityClient extends _i1.Mock implements _i8.SubiquityClient {
   MockSubiquityClient() {
     _i1.throwOnMissingStub(this);
   }
@@ -393,15 +527,15 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
-  _i6.Future<_i7.Variant> variant() => (super.noSuchMethod(
+  _i6.Future<_i8.Variant> variant() => (super.noSuchMethod(
         Invocation.method(
           #variant,
           [],
         ),
-        returnValue: _i6.Future<_i7.Variant>.value(_i7.Variant.SERVER),
-      ) as _i6.Future<_i7.Variant>);
+        returnValue: _i6.Future<_i8.Variant>.value(_i8.Variant.SERVER),
+      ) as _i6.Future<_i8.Variant>);
   @override
-  _i6.Future<void> setVariant(_i7.Variant? variant) => (super.noSuchMethod(
+  _i6.Future<void> setVariant(_i8.Variant? variant) => (super.noSuchMethod(
         Invocation.method(
           #setVariant,
           [variant],
@@ -1169,13 +1303,13 @@ class MockSubiquityClient extends _i1.Mock implements _i7.SubiquityClient {
 /// A class which mocks [SubiquityServer].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
+class MockSubiquityServer extends _i1.Mock implements _i9.SubiquityServer {
   MockSubiquityServer() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set process(_i9.SubiquityProcess? _process) => super.noSuchMethod(
+  set process(_i10.SubiquityProcess? _process) => super.noSuchMethod(
         Invocation.setter(
           #process,
           _process,
@@ -1231,7 +1365,7 @@ class MockSubiquityServer extends _i1.Mock implements _i8.SubiquityServer {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSubiquityStatusMonitor extends _i1.Mock
-    implements _i10.SubiquityStatusMonitor {
+    implements _i11.SubiquityStatusMonitor {
   MockSubiquityStatusMonitor() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-desktop-installer.git
       path: packages/subiquity_client
   ubuntu_localizations: ^0.0.5
+  ubuntu_session: ^0.0.4
   ubuntu_widgets:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git


### PR DESCRIPTION
Calls `org.gnome.session.Manager.Inhibit()`

There's potentially some overlap between what this method does and what the GSettings changes from #1554 do.

Fix #1543