### PR TITLE
CI: pin melos at 2.9.0

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -24,7 +24,7 @@ jobs:
         flutter-version: '3.7.x'
 
     - name: Install Melos
-      run: flutter pub global activate melos
+      run: flutter pub global activate melos 2.9.0
 
     - name: Install lcov
       run: sudo apt update && sudo apt install lcov
@@ -71,7 +71,7 @@ jobs:
         flutter-version: '3.7.x'
 
     - name: Install Melos
-      run: flutter pub global activate melos
+      run: flutter pub global activate melos 2.9.0
 
     - name: Bootstrap workspace
       run: melos pub get
@@ -96,7 +96,7 @@ jobs:
         flutter-version: '3.7.x'
 
     - name: Install Melos
-      run: flutter pub global activate melos
+      run: flutter pub global activate melos 2.9.0
 
     - name: Bootstrap workspace
       run: melos pub get


### PR DESCRIPTION
Pin for now, we can migrate to 3.x later.

> Found a melos.yaml file in "/home/runner/work/ubuntu-desktop-installer/ubuntu-desktop-installer" but no local installation of Melos.
>
> From version 3.0.0, the melos package must be installed in a pubspec.yaml file next to the melos.yaml file.
>
> For more information on migrating to version 3.0.0, see: https://melos.invertase.dev/guides/migrations#200-to-300
> 
> To migrate at a later time, ensure you have version 2.[9](https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4384799772/jobs/7676708919#step:9:10).0 or below installed: dart pub global activate melos 2.9.0

https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4384799772/jobs/7676708919