### PR TITLE
Update dependency yaru_widgets to ^2.2.0

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   upower: ^0.7.0
   yaru: ^0.5.0
   yaru_icons: ^1.0.0
-  yaru_widgets: ^2.1.1
+  yaru_widgets: ^2.2.0
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -29,4 +29,4 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-desktop-installer.git
       path: packages/ubuntu_wizard
-  yaru_widgets: ^2.1.0
+  yaru_widgets: ^2.2.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   wizard_router: ^0.9.4
   yaru: ^0.5.0
   yaru_colors: ^0.1.6
-  yaru_widgets: ^2.1.0
+  yaru_widgets: ^2.2.0
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
       path: packages/ubuntu_wizard
   yaru: ^0.5.0
   yaru_icons: ^1.0.0
-  yaru_widgets: ^2.1.0
+  yaru_widgets: ^2.2.0
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
Among other things, [yaru_widgets 2.2.0](https://github.com/ubuntu/yaru_widgets.dart/releases/tag/2.2.0) comes with:
- improved YaruPageIndicator theming capabilities, and
- themeable mouse cursors for YaruCheckbox, YaruRadio, YaruSwitch, and friends.

See also:
- https://github.com/canonical/ubuntu-desktop-installer/issues/1348
- https://github.com/canonical/ubuntu-desktop-installer/pull/1601
