### PR TITLE
Where are you: use YaruAutocomplete

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -81,7 +81,7 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
             child: Row(
               children: <Widget>[
                 Expanded(
-                  child: Autocomplete<GeoLocation>(
+                  child: YaruAutocomplete<GeoLocation>(
                     initialValue: TextEditingValue(
                       text: formatLocation(controller.selectedLocation),
                     ),
@@ -109,7 +109,7 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
                 ),
                 const SizedBox(width: kContentSpacing),
                 Expanded(
-                  child: Autocomplete<GeoLocation>(
+                  child: YaruAutocomplete<GeoLocation>(
                     initialValue: TextEditingValue(
                       text: formatTimezone(controller.selectedLocation),
                     ),


### PR DESCRIPTION
YaruAutocomplete provides more appropriate looks and, unlike its Material counterpart, YaruAutocomplete allows customizing the mouse cursor in the popup (#1532).

| Before | After |
|---|---|
| ![Screenshot from 2023-03-13 09-59-23](https://user-images.githubusercontent.com/140617/224655881-00afceab-594c-454b-a6fb-e279939f5e30.png) | ![Screenshot from 2023-03-13 10-00-06](https://user-images.githubusercontent.com/140617/224655922-40b7bc57-9e76-4210-8bcd-e9c4ab9cb436.png) |
| ![Screenshot from 2023-03-13 10-05-46](https://user-images.githubusercontent.com/140617/224656148-2c502c72-772c-41c2-af14-7207b2e2319e.png) | ![Screenshot from 2023-03-13 10-04-34](https://user-images.githubusercontent.com/140617/224656117-851c35e0-a0b6-41da-ba0d-03b244f8a4f6.png) |

EDIT: The options popup width will be fixed to match the screenshots above by yaru_widgets 2.2.1:
- https://github.com/ubuntu/yaru_widgets.dart/pull/675