### PR TITLE
Allocate disk space: use YaruAutocomplete

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -297,7 +297,7 @@ class _PartitionMountField extends StatelessWidget {
     return ValueListenableBuilder<PartitionFormat?>(
       valueListenable: partitionFormat,
       builder: (context, format, child) {
-        return Autocomplete<String>(
+        return YaruAutocomplete<String>(
           initialValue: initialMount != null
               ? TextEditingValue(text: initialMount!)
               : null,

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -55,7 +55,7 @@ void main() {
         find.widgetWithText(MenuItemButton, tester.lang.partitionFormatBtrfs));
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(Autocomplete<String>), '/tst');
+    await tester.enterText(find.byType(YaruAutocomplete<String>), '/tst');
     await tester.pump();
 
     await tester
@@ -124,7 +124,7 @@ void main() {
     await tester.tap(find.byType(YaruCheckbox));
     await tester.pump();
 
-    await tester.enterText(find.byType(Autocomplete<String>), '/tst');
+    await tester.enterText(find.byType(YaruAutocomplete<String>), '/tst');
     await tester.pump();
 
     await tester


### PR DESCRIPTION
YaruAutocomplete provides more appropriate looks and, unlike its Material counterpart, YaruAutocomplete allows customizing the mouse cursor in the popup (https://github.com/canonical/ubuntu-desktop-installer/issues/1532).

| Before | After |
|---|---|
| ![Screenshot from 2023-03-13 12-54-51](https://user-images.githubusercontent.com/140617/224700745-27af60a9-573c-4484-aeb0-098ab07369af.png) | ![Screenshot from 2023-03-13 12-54-58](https://user-images.githubusercontent.com/140617/224700752-55d58dc2-dac3-4217-867a-bfe2a8ca2004.png) |