### PR TITLE
Partition dialog size constraints

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -10,6 +10,8 @@ import '../../widgets.dart';
 import 'allocate_disk_space_model.dart';
 import 'storage_types.dart';
 
+const _kInputFieldWidth = 400.0;
+
 /// Shows a confirmation dialog with the given title and message.
 Future<bool> showConfirmationDialog(
   BuildContext context, {
@@ -294,28 +296,31 @@ class _PartitionMountField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<PartitionFormat?>(
-      valueListenable: partitionFormat,
-      builder: (context, format, child) {
-        return YaruAutocomplete<String>(
-          initialValue: initialMount != null
-              ? TextEditingValue(text: initialMount!)
-              : null,
-          optionsBuilder: (value) => kDefaultMountPoints
-              .where((option) => option.startsWith(value.text)),
-          onSelected: (option) => partitionMount.value = option,
-          fieldViewBuilder:
-              (context, textEditingController, focusNode, onFieldSubmitted) {
-            return TextFormField(
-              enabled: format != PartitionFormat.swap,
-              controller: textEditingController,
-              focusNode: focusNode,
-              onChanged: (value) => partitionMount.value = value,
-              onFieldSubmitted: (_) => onFieldSubmitted(),
-            );
-          },
-        );
-      },
+    return SizedBox(
+      width: _kInputFieldWidth,
+      child: ValueListenableBuilder<PartitionFormat?>(
+        valueListenable: partitionFormat,
+        builder: (context, format, child) {
+          return YaruAutocomplete<String>(
+            initialValue: initialMount != null
+                ? TextEditingValue(text: initialMount!)
+                : null,
+            optionsBuilder: (value) => kDefaultMountPoints
+                .where((option) => option.startsWith(value.text)),
+            onSelected: (option) => partitionMount.value = option,
+            fieldViewBuilder:
+                (context, textEditingController, focusNode, onFieldSubmitted) {
+              return TextFormField(
+                enabled: format != PartitionFormat.swap,
+                controller: textEditingController,
+                focusNode: focusNode,
+                onChanged: (value) => partitionMount.value = value,
+                onFieldSubmitted: (_) => onFieldSubmitted(),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }
@@ -357,21 +362,24 @@ class _PartitionFormatSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
-    return ValueListenableBuilder<PartitionFormat?>(
-      valueListenable: partitionFormat,
-      builder: (context, type, child) {
-        return MenuButtonBuilder<PartitionFormat?>(
-          selected: type,
-          values: partitionFormats,
-          itemBuilder: (context, format, _) {
-            return Text(
-              format?.localize(lang) ?? lang.partitionFormatNone,
-              key: ValueKey(format?.type),
-            );
-          },
-          onSelected: (value) => partitionFormat.value = value,
-        );
-      },
+    return SizedBox(
+      width: _kInputFieldWidth,
+      child: ValueListenableBuilder<PartitionFormat?>(
+        valueListenable: partitionFormat,
+        builder: (context, type, child) {
+          return MenuButtonBuilder<PartitionFormat?>(
+            selected: type,
+            values: partitionFormats,
+            itemBuilder: (context, format, _) {
+              return Text(
+                format?.localize(lang) ?? lang.partitionFormatNone,
+                key: ValueKey(format?.type),
+              );
+            },
+            onSelected: (value) => partitionFormat.value = value,
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -52,12 +52,16 @@ class StorageSizeBox extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Expanded(
-          child: SpinBox(
-            value: fromBytes(size, unit),
-            min: fromBytes(minimum, unit),
-            max: fromBytes(maximum, unit),
-            onChanged: (value) => onSizeChanged(toBytes(value, unit)),
-            autofocus: autofocus,
+          flex: 3,
+          child: SizedBox(
+            width: 240,
+            child: SpinBox(
+              value: fromBytes(size, unit),
+              min: fromBytes(minimum, unit),
+              max: fromBytes(maximum, unit),
+              onChanged: (value) => onSizeChanged(toBytes(value, unit)),
+              autofocus: autofocus,
+            ),
           ),
         ),
         SizedBox(width: spacing),
@@ -69,8 +73,15 @@ class StorageSizeBox extends StatelessWidget {
             itemBuilder: (context, unit, _) {
               return Text(unit.l10n(context), key: ValueKey(unit));
             },
+            child: IndexedStack(
+              index: unit.index,
+              children: DataUnit.values
+                  .map((unit) => Text(unit.l10n(context)))
+                  .toList(),
+            ),
           ),
         ),
+        const Spacer(),
       ],
     );
   }


### PR DESCRIPTION
The storage size spinbox is not expanded to full width as proposed in https://github.com/canonical/ubuntu-desktop-installer/issues/1502#issuecomment-1457737146.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/224755339-dd85ea4c-8b51-4ed1-82a9-11b5c200ffaf.png) | ![image](https://user-images.githubusercontent.com/140617/224755205-19de8a96-e019-4478-a200-0081baf00bc3.png) |

Close: #1502