### PR TITLE
Autoinstall error handling

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -251,6 +251,9 @@ class _UbuntuDesktopInstallerAppState extends State<UbuntuDesktopInstallerApp> {
         _subiquityStatus!.isWaitingAutoinstall) {
       return const _UbuntuDesktopInstallerLoadingPage();
     }
+    if (_subiquityStatus?.state == ApplicationState.ERROR) {
+      return const _UbuntuDesktopErrorWizard();
+    }
     return _subiquityStatus?.interactive == false
         ? _UbuntuDesktopAutoinstallWizard(status: _subiquityStatus)
         : _UbuntuDesktopInstallerWizard(
@@ -516,6 +519,21 @@ class _UbuntuDesktopAutoinstallWizard extends StatelessWidget {
         ),
         Routes.installationComplete: const WizardRoute(
           builder: InstallationCompletePage.create,
+        ),
+      },
+    );
+  }
+}
+
+class _UbuntuDesktopErrorWizard extends StatelessWidget {
+  const _UbuntuDesktopErrorWizard();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Wizard(
+      routes: <String, WizardRoute>{
+        Routes.installationSlides: WizardRoute(
+          builder: InstallationSlidesPage.create,
         ),
       },
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -131,7 +131,7 @@ class InstallationSlidesModel extends SafeChangeNotifier {
   /// Initializes and starts monitoring the status of the installation.
   Future<void> init() {
     return _client.status().then((status) {
-      _log = _journal.start(status.logSyslogId);
+      _log = _journal.start([status.logSyslogId, status.eventSyslogId]);
       _updateStatus(status);
       _monitorStatus(status.eventSyslogId);
     });
@@ -159,7 +159,7 @@ class InstallationSlidesModel extends SafeChangeNotifier {
   }
 
   Future<void> _monitorStatus(String syslogId) async {
-    final events = _journal.start(syslogId, output: JournalOutput.cat);
+    final events = _journal.start([syslogId], output: JournalOutput.cat);
     final subscription = events.listen(_processEvent);
     while (!isDone && !hasError) {
       await _client.status(current: state).then(_updateStatus);

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -15,8 +15,10 @@ class DiskStorageService {
   final SubiquityClient _client;
 
   /// Initializes the service.
-  Future<void> init() {
-    return Future.wait([
+  Future<void> init() async {
+    final status = await _client.status();
+    if (status.state == ApplicationState.ERROR) return;
+    await Future.wait([
       _client.getStorageV2().then(_updateStorage),
       _client.hasRst().then((value) => _hasRst = value),
       _client.hasBitLocker().then((value) => _hasBitLocker = value),

--- a/packages/ubuntu_desktop_installer/lib/services/journal_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/journal_service.dart
@@ -18,7 +18,7 @@ enum JournalOutput {
 class JournalService {
   /// Starts a `journalctl` process.
   Stream<String> start(
-    String id, {
+    List<String> ids, {
     JournalOutput output = JournalOutput.short,
   }) async* {
     final process = await Process.start(
@@ -27,7 +27,7 @@ class JournalService {
         '--follow',
         '--no-pager',
         '--no-tail',
-        '--identifier=$id',
+        for (final id in ids) '--identifier=$id',
         '--output=${output.name}'
       ],
       environment: {'SYSTEMD_COLORS': '0'},

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -17,9 +17,9 @@ void main() async {
   test('client status query loop', () async {
     final client = MockSubiquityClient();
     final journal = MockJournalService();
-    when(journal.start('log', output: JournalOutput.short))
+    when(journal.start(['log', 'event'], output: JournalOutput.short))
         .thenAnswer((_) => Stream.empty());
-    when(journal.start('event', output: JournalOutput.cat))
+    when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
     final model = InstallationSlidesModel(client, journal);
 
@@ -57,9 +57,9 @@ void main() async {
     }
 
     final journal = MockJournalService();
-    when(journal.start('log', output: JournalOutput.short))
+    when(journal.start(['log', 'event'], output: JournalOutput.short))
         .thenAnswer((_) => Stream.empty());
-    when(journal.start('event', output: JournalOutput.cat))
+    when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
 
     final model = InstallationSlidesModel(client, journal);
@@ -103,9 +103,9 @@ void main() async {
     );
 
     final journal = MockJournalService();
-    when(journal.start('log', output: JournalOutput.short))
+    when(journal.start(['log', 'event'], output: JournalOutput.short))
         .thenAnswer((_) => Stream.empty());
-    when(journal.start('event', output: JournalOutput.cat))
+    when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
 
     final model = InstallationSlidesModel(client, journal);
@@ -140,9 +140,9 @@ void main() async {
     final events = StreamController<String>(sync: true);
 
     final journal = MockJournalService();
-    when(journal.start('log', output: JournalOutput.short))
+    when(journal.start(['log', 'event'], output: JournalOutput.short))
         .thenAnswer((_) => Stream.empty());
-    when(journal.start('event', output: JournalOutput.cat))
+    when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => events.stream);
 
     final client = MockSubiquityClient();

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
@@ -29,13 +29,13 @@ class MockJournalService extends _i1.Mock implements _i2.JournalService {
 
   @override
   _i3.Stream<String> start(
-    String? id, {
+    List<String>? ids, {
     _i2.JournalOutput? output = _i2.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #start,
-          [id],
+          [ids],
           {#output: output},
         ),
         returnValue: _i3.Stream<String>.empty(),

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -157,13 +157,13 @@ class MockJournalService extends _i1.Mock implements _i6.JournalService {
 
   @override
   _i3.Stream<String> start(
-    String? id, {
+    List<String>? ids, {
     _i6.JournalOutput? output = _i6.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #start,
-          [id],
+          [ids],
           {#output: output},
         ),
         returnValue: _i3.Stream<String>.empty(),

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -24,6 +24,16 @@ void main() {
         .thenAnswer((_) async => testStorageResponse(disks: testDisks));
     when(client.hasRst()).thenAnswer((_) async => false);
     when(client.hasBitLocker()).thenAnswer((_) async => false);
+    when(client.status()).thenAnswer((_) async => ApplicationStatus(
+          cloudInitOk: null,
+          confirmingTty: '',
+          echoSyslogId: '',
+          error: null,
+          eventSyslogId: '',
+          interactive: null,
+          logSyslogId: '',
+          state: ApplicationState.RUNNING,
+        ));
   });
 
   test('get guided storage', () async {


### PR DESCRIPTION
- Allow `JournalService` to listen to multiple logs
- Show subiquity's 'event'+'log' entries on the installation slide page
- Immediately show installation slide page when the installation fails

For a broken autoinstall config with a missing hostname it looks like this:
![Screenshot from 2023-03-13 16-31-04](https://user-images.githubusercontent.com/113362648/224758668-dc8319a8-88a3-48e0-8c19-dd15546de5ec.png)

Close #1461 