### PR TITLE
Revert "Renovate: enable Git submodule updates (for subiquity_client.…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>ubuntu-flutter-community/renovate-config"
-  ],
-  "enabledManagers": [
-    "git-submodules",
-    "github-actions",
-    "pub"
-  ],
-  "git-submodules": {
-    "enabled": true
-  }
+  ]
 }


### PR DESCRIPTION
…dart) (#1406)"

This reverts commit c8aa2a5dbcdd7b8ac0fae5d5b6f87201e70737d7 because Renovate doesn't like the `ubuntu/xxx` branch naming convention:

> Dependency packages/subiquity_client has unsupported value ubuntu/lunar

https://app.renovatebot.com/dashboard#github/canonical/ubuntu-desktop-installer/1021012551

We can either bump manually as we did before or switch to Dependabot which has been tested to work.