### PR TITLE
Turn off XXX: remove page indicators

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -375,9 +375,8 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
             }
           },
         ),
-        Routes.turnOffRST: WizardRoute(
+        Routes.turnOffRST: const WizardRoute(
           builder: TurnOffRSTPage.create,
-          userData: InstallationStep.welcome.index,
         ),
         Routes.keyboardLayout: WizardRoute(
           builder: KeyboardLayoutPage.create,
@@ -407,9 +406,8 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
           userData: InstallationStep.type.index,
           onNext: (settings) => _nextStorageRoute(service, settings.arguments),
         ),
-        Routes.turnOffBitlocker: WizardRoute(
+        Routes.turnOffBitlocker: const WizardRoute(
           builder: TurnOffBitLockerPage.create,
-          userData: InstallationStep.storage.index,
         ),
         Routes.installAlongside: WizardRoute(
           builder: InstallAlongsidePage.create,


### PR DESCRIPTION
When the user is taken to the page with instructions to turn off RST or BitLocker, there's nowhere to progress but the only available action is to restart the computer.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-15 07-43-40](https://user-images.githubusercontent.com/140617/225236471-ac3a5f3a-128d-405d-a02b-c0bac68b26ff.png) | ![Screenshot from 2023-03-15 08-20-39](https://user-images.githubusercontent.com/140617/225236525-7e003041-a54d-41ae-9c61-2f2492584c0c.png) |
| ![Screenshot from 2023-03-15 07-45-54](https://user-images.githubusercontent.com/140617/225236551-7967dcea-c0f7-440c-a253-8c2376f39b40.png) | ![Screenshot from 2023-03-15 08-20-59](https://user-images.githubusercontent.com/140617/225236572-ffcdbb8c-87b1-4e5e-a6f4-8102e28f44a4.png) |