### PR TITLE
Apply application-wide minimum button size

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/theme.dart
+++ b/packages/ubuntu_desktop_installer/lib/theme.dart
@@ -3,13 +3,20 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 extension ThemeDataX on ThemeData {
   ThemeData customize() {
+    final buttonSize = MaterialStateProperty.all(const Size(136, 36));
     final mouseCursor = MaterialStateProperty.all(SystemMouseCursors.basic);
     return copyWith(
       elevatedButtonTheme: ElevatedButtonThemeData(
-        style: elevatedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+        style: elevatedButtonTheme.style!.copyWith(
+          minimumSize: buttonSize,
+          mouseCursor: mouseCursor,
+        ),
       ),
       filledButtonTheme: FilledButtonThemeData(
-        style: filledButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+        style: filledButtonTheme.style!.copyWith(
+          minimumSize: buttonSize,
+          mouseCursor: mouseCursor,
+        ),
       ),
       floatingActionButtonTheme:
           floatingActionButtonTheme.copyWith(mouseCursor: mouseCursor),
@@ -24,7 +31,10 @@ extension ThemeDataX on ThemeData {
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
-        style: outlinedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+        style: outlinedButtonTheme.style!.copyWith(
+          minimumSize: buttonSize,
+          mouseCursor: mouseCursor,
+        ),
       ),
       popupMenuTheme: popupMenuTheme.copyWith(mouseCursor: mouseCursor),
       sliderTheme: sliderTheme.copyWith(mouseCursor: mouseCursor),

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -162,14 +162,11 @@ class _WizardPageState extends State<WizardPage> {
 
     final child = Text(action.label!);
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minWidth: 136),
-      child: action.highlighted == true
-          ? ElevatedButton(onPressed: maybeActivate, child: child)
-          : action.flat == true
-              ? OutlinedButton(onPressed: maybeActivate, child: child)
-              : FilledButton(onPressed: maybeActivate, child: child),
-    );
+    return action.highlighted == true
+        ? ElevatedButton(onPressed: maybeActivate, child: child)
+        : action.flat == true
+            ? OutlinedButton(onPressed: maybeActivate, child: child)
+            : FilledButton(onPressed: maybeActivate, child: child);
   }
 }
 


### PR DESCRIPTION
Previously, we specified 136px as a minimum width for the wizard buttons. Some buttons, most notably the Ok and Cancel buttons in dialogs, are still awkwardly small. This PR promotes 136px as a minimum width for all push buttons (elevated, filled, and outlined) in the whole app.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-15 20-04-06](https://user-images.githubusercontent.com/140617/225416808-bc97ae3f-d8df-4c41-b937-1100557a83ca.png) | ![Screenshot from 2023-03-15 20-03-55](https://user-images.githubusercontent.com/140617/225416841-f6c474ea-c6fc-48db-b341-e6daaa1471d8.png) |

Close: #1631