### PR TITLE
Installation slides: use product name as page title

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -49,18 +49,18 @@ class InstallationEvent {
 /// View model for [InstallationSlidesPage].
 class InstallationSlidesModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
-  InstallationSlidesModel(this._client, this._journal, this._service);
+  InstallationSlidesModel(this._client, this._journal, this._product);
 
   final SubiquityClient _client;
   final JournalService _journal;
-  final ProductService _service;
+  final ProductService _product;
 
   Stream<String>? _log;
   ApplicationStatus? _status;
   InstallationEvent _event = const InstallationEvent(InstallationAction.none);
 
   /// Detailed info of the product being installed.
-  ProductInfo get productInfo => _service.getProductInfo();
+  ProductInfo get productInfo => _product.getProductInfo();
 
   /// The current installation state.
   ApplicationState? get state => _status?.state;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -49,14 +49,18 @@ class InstallationEvent {
 /// View model for [InstallationSlidesPage].
 class InstallationSlidesModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
-  InstallationSlidesModel(this._client, this._journal);
+  InstallationSlidesModel(this._client, this._journal, this._service);
 
   final SubiquityClient _client;
   final JournalService _journal;
+  final ProductService _service;
 
   Stream<String>? _log;
   ApplicationStatus? _status;
   InstallationEvent _event = const InstallationEvent(InstallationAction.none);
+
+  /// Detailed info of the product being installed.
+  ProductInfo get productInfo => _service.getProductInfo();
 
   /// The current installation state.
   ApplicationState? get state => _status?.state;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -41,8 +42,9 @@ class InstallationSlidesPage extends StatefulWidget {
   static Widget create(BuildContext context) {
     final client = getService<SubiquityClient>();
     final journal = getService<JournalService>();
+    final product = getService<ProductService>();
     return ChangeNotifierProvider(
-      create: (_) => InstallationSlidesModel(client, journal),
+      create: (_) => InstallationSlidesModel(client, journal, product),
       child: const InstallationSlidesPage(),
     );
   }
@@ -80,13 +82,12 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
 
   @override
   Widget build(BuildContext context) {
-    final flavor = Flavor.of(context);
     final lang = AppLocalizations.of(context);
     final model = Provider.of<InstallationSlidesModel>(context);
     final slides = SlidesContext.of(context);
     return Scaffold(
       appBar: YaruWindowTitleBar(
-        title: Text(lang.installationSlidesTitle(flavor.name)),
+        title: Text(model.productInfo.toString()),
       ),
       body: Stack(
         children: [

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
-import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -12,8 +12,22 @@ import 'installation_slides_model_test.mocks.dart';
 
 // ignore_for_file: type=lint
 
-@GenerateMocks([JournalService])
+@GenerateMocks([JournalService, ProductService])
 void main() async {
+  test('product info', () {
+    final product = MockProductService();
+    when(product.getProductInfo())
+        .thenReturn(ProductInfo(name: 'Ubuntu', version: '24.04 LTS'));
+
+    final model = InstallationSlidesModel(
+      MockSubiquityClient(),
+      MockJournalService(),
+      product,
+    );
+    expect(model.productInfo.name, 'Ubuntu');
+    expect(model.productInfo.version, '24.04 LTS');
+  });
+
   test('client status query loop', () async {
     final client = MockSubiquityClient();
     final journal = MockJournalService();
@@ -21,7 +35,8 @@ void main() async {
         .thenAnswer((_) => Stream.empty());
     when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
-    final model = InstallationSlidesModel(client, journal);
+    final product = MockProductService();
+    final model = InstallationSlidesModel(client, journal, product);
 
     ApplicationState? currentState;
     for (final nextState in ApplicationState.values) {
@@ -62,7 +77,9 @@ void main() async {
     when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
 
-    final model = InstallationSlidesModel(client, journal);
+    final product = MockProductService();
+
+    final model = InstallationSlidesModel(client, journal, product);
 
     expect(model.state, isNull);
     expect(model.isInstalling, isFalse);
@@ -108,7 +125,9 @@ void main() async {
     when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => Stream.empty());
 
-    final model = InstallationSlidesModel(client, journal);
+    final product = MockProductService();
+
+    final model = InstallationSlidesModel(client, journal, product);
 
     expect(model.hasError, isFalse);
 
@@ -121,6 +140,7 @@ void main() async {
     final model = InstallationSlidesModel(
       MockSubiquityClient(),
       MockJournalService(),
+      MockProductService(),
     );
     expect(model.isLogVisible, isFalse);
 
@@ -153,7 +173,9 @@ void main() async {
       (_) async => testStatus(ApplicationState.RUNNING),
     );
 
-    final model = InstallationSlidesModel(client, journal);
+    final product = MockProductService();
+
+    final model = InstallationSlidesModel(client, journal, product);
 
     expect(model.event.action, InstallationAction.none);
 

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.mocks.dart
@@ -3,10 +3,11 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services/journal_service.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services/journal_service.dart' as _i3;
+import 'package:ubuntu_desktop_installer/services/product_service.dart' as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -19,18 +20,28 @@ import 'package:ubuntu_desktop_installer/services/journal_service.dart' as _i2;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakeProductInfo_0 extends _i1.SmartFake implements _i2.ProductInfo {
+  _FakeProductInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [JournalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i2.JournalService {
+class MockJournalService extends _i1.Mock implements _i3.JournalService {
   MockJournalService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Stream<String> start(
+  _i4.Stream<String> start(
     List<String>? ids, {
-    _i2.JournalOutput? output = _i2.JournalOutput.short,
+    _i3.JournalOutput? output = _i3.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -38,6 +49,30 @@ class MockJournalService extends _i1.Mock implements _i2.JournalService {
           [ids],
           {#output: output},
         ),
-        returnValue: _i3.Stream<String>.empty(),
-      ) as _i3.Stream<String>);
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
+}
+
+/// A class which mocks [ProductService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockProductService extends _i1.Mock implements _i2.ProductService {
+  MockProductService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i2.ProductInfo getProductInfo() => (super.noSuchMethod(
+        Invocation.method(
+          #getProductInfo,
+          [],
+        ),
+        returnValue: _FakeProductInfo_0(
+          this,
+          Invocation.method(
+            #getProductInfo,
+            [],
+          ),
+        ),
+      ) as _i2.ProductInfo);
 }

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -15,11 +15,12 @@ import 'package:ubuntu_test/mocks.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 import '../test_utils.dart';
+import 'installation_slides_model_test.mocks.dart';
 import 'installation_slides_page_test.mocks.dart';
 
 // ignore_for_file: type=lint
 
-@GenerateMocks([InstallationSlidesModel, JournalService])
+@GenerateMocks([InstallationSlidesModel])
 void main() {
   UbuntuTester.context = InstallationSlidesPage;
 
@@ -32,6 +33,7 @@ void main() {
     InstallationEvent? event,
     bool? isLogVisible,
     bool? isPlaying,
+    ProductInfo? productInfo,
   }) {
     final model = MockInstallationSlidesModel();
     when(model.state).thenReturn(state);
@@ -42,6 +44,8 @@ void main() {
     when(model.event).thenReturn(event ?? InstallationEvent.fromString(''));
     when(model.isLogVisible).thenReturn(isLogVisible ?? false);
     when(model.isPlaying).thenReturn(isPlaying ?? false);
+    when(model.productInfo)
+        .thenReturn(productInfo ?? ProductInfo(name: 'Ubuntu'));
     return model;
   }
 
@@ -197,8 +201,11 @@ void main() {
         .thenAnswer((_) => never.future);
     registerMockService<SubiquityClient>(client);
 
-    final service = MockJournalService();
-    registerMockService<JournalService>(service);
+    registerMockService<JournalService>(MockJournalService());
+
+    final product = MockProductService();
+    when(product.getProductInfo()).thenReturn(ProductInfo(name: 'Ubuntu'));
+    registerMockService<ProductService>(product);
 
     await tester.pumpWidget(
       SlidesContext(

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.mocks.dart
@@ -3,14 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
-import 'dart:ui' as _i5;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i6;
 
-import 'package:flutter/widgets.dart' as _i4;
+import 'package:flutter/widgets.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_desktop_installer/pages/installation_slides/installation_slides_model.dart'
-    as _i2;
-import 'package:ubuntu_desktop_installer/services.dart' as _i6;
+    as _i3;
+import 'package:ubuntu_desktop_installer/services.dart' as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -23,9 +23,19 @@ import 'package:ubuntu_desktop_installer/services.dart' as _i6;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeInstallationEvent_0 extends _i1.SmartFake
-    implements _i2.InstallationEvent {
-  _FakeInstallationEvent_0(
+class _FakeProductInfo_0 extends _i1.SmartFake implements _i2.ProductInfo {
+  _FakeProductInfo_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeInstallationEvent_1 extends _i1.SmartFake
+    implements _i3.InstallationEvent {
+  _FakeInstallationEvent_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -38,19 +48,27 @@ class _FakeInstallationEvent_0 extends _i1.SmartFake
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockInstallationSlidesModel extends _i1.Mock
-    implements _i2.InstallationSlidesModel {
+    implements _i3.InstallationSlidesModel {
   MockInstallationSlidesModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.InstallationEvent get event => (super.noSuchMethod(
+  _i2.ProductInfo get productInfo => (super.noSuchMethod(
+        Invocation.getter(#productInfo),
+        returnValue: _FakeProductInfo_0(
+          this,
+          Invocation.getter(#productInfo),
+        ),
+      ) as _i2.ProductInfo);
+  @override
+  _i3.InstallationEvent get event => (super.noSuchMethod(
         Invocation.getter(#event),
-        returnValue: _FakeInstallationEvent_0(
+        returnValue: _FakeInstallationEvent_1(
           this,
           Invocation.getter(#event),
         ),
-      ) as _i2.InstallationEvent);
+      ) as _i3.InstallationEvent);
   @override
   bool get isDone => (super.noSuchMethod(
         Invocation.getter(#isDone),
@@ -67,10 +85,10 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  _i3.Stream<String> get log => (super.noSuchMethod(
+  _i4.Stream<String> get log => (super.noSuchMethod(
         Invocation.getter(#log),
-        returnValue: _i3.Stream<String>.empty(),
-      ) as _i3.Stream<String>);
+        returnValue: _i4.Stream<String>.empty(),
+      ) as _i4.Stream<String>);
   @override
   bool get isLogVisible => (super.noSuchMethod(
         Invocation.getter(#isLogVisible),
@@ -108,26 +126,26 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(
+  _i4.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<void> precacheSlideImages(_i4.BuildContext? context) =>
+  _i4.Future<void> precacheSlideImages(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #precacheSlideImages,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -135,7 +153,7 @@ class MockInstallationSlidesModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -158,27 +176,4 @@ class MockInstallationSlidesModel extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
-}
-
-/// A class which mocks [JournalService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i6.JournalService {
-  MockJournalService() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i3.Stream<String> start(
-    List<String>? ids, {
-    _i6.JournalOutput? output = _i6.JournalOutput.short,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #start,
-          [ids],
-          {#output: output},
-        ),
-        returnValue: _i3.Stream<String>.empty(),
-      ) as _i3.Stream<String>);
 }


### PR DESCRIPTION
NOTE: It says "Ubuntu Lunar Lobster (development branch)" in the screenshot because I'm in a development environment but the title would be "Ubuntu 23.04" or "Ubuntu 24.04 LTS" in the live environment.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-15 22-01-18](https://user-images.githubusercontent.com/140617/225441723-303b6b53-3d65-40be-9f44-3e7ce32b8e2e.png) | ![Screenshot from 2023-03-15 22-00-59](https://user-images.githubusercontent.com/140617/225441750-780a6846-2dc3-43b1-8660-10f89c4e165a.png) |

Ref: #1591