### PR TITLE
Tweak error colors and text field borders

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/theme.dart
+++ b/packages/ubuntu_desktop_installer/lib/theme.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 extension ThemeDataX on ThemeData {
   ThemeData customize() {
+    final errorColor = brightness == Brightness.light
+        ? YaruColors.red[700]!
+        : YaruColors.red[300]!;
     final mouseCursor = MaterialStateProperty.all(SystemMouseCursors.basic);
     return copyWith(
+      colorScheme: colorScheme.copyWith(error: errorColor),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: elevatedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
       ),
@@ -15,6 +20,30 @@ extension ThemeDataX on ThemeData {
           floatingActionButtonTheme.copyWith(mouseCursor: mouseCursor),
       iconButtonTheme: IconButtonThemeData(
         style: iconButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+      ),
+      inputDecorationTheme: inputDecorationTheme.copyWith(
+        floatingLabelStyle: MaterialStateTextStyle.resolveWith((states) {
+          final textStyle = textTheme.bodyLarge ?? const TextStyle();
+          if (states.contains(MaterialState.error)) {
+            return textStyle.copyWith(color: errorColor);
+          }
+          if (states.contains(MaterialState.focused)) {
+            return textStyle.copyWith(color: colorScheme.onSurface);
+          }
+          if (states.contains(MaterialState.disabled)) {
+            return textStyle.copyWith(
+                color: colorScheme.onSurface.withOpacity(0.38));
+          }
+          return textStyle.copyWith(color: colorScheme.onSurfaceVariant);
+        }),
+        focusedBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: colorScheme.onSurface),
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: errorColor),
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+        ),
       ),
       listTileTheme: listTileTheme.copyWith(mouseCursor: mouseCursor),
       menuButtonTheme: MenuButtonThemeData(

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   udev: ^0.0.2
   upower: ^0.7.0
   yaru: ^0.5.0
+  yaru_colors: ^0.1.6
   yaru_icons: ^1.0.0
   yaru_widgets: ^2.2.0
 


### PR DESCRIPTION
- Remove accent color from focused text field border (orange accent vs. red error are too close)
- Use a lighter red shade for errors in the dark theme to increase contrast and make error labels readable

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/225607226-88e9c450-44e0-4df5-9e94-4aeada327c90.png) | ![image](https://user-images.githubusercontent.com/140617/225607151-1c8502c0-f233-4d2c-bf08-1f68d7e06d7b.png) |
| ![image](https://user-images.githubusercontent.com/140617/225607273-89f4f9ea-7db0-49f4-b566-12ea0974cd93.png) | ![image](https://user-images.githubusercontent.com/140617/225607116-2d884ea6-c74c-4fa5-9102-498f8588e478.png) |
| ![image](https://user-images.githubusercontent.com/140617/225608056-219475e1-ad38-4944-a487-704f546a8cd2.png) | ![image](https://user-images.githubusercontent.com/140617/225607991-20a18bc8-f7d0-4422-a0f5-984261dcf0df.png) |
| ![image](https://user-images.githubusercontent.com/140617/225608095-4d1f29d8-d599-4309-bd4c-851d978fe9f8.png) | ![image](https://user-images.githubusercontent.com/140617/225607965-4defab83-42b0-463c-90e6-05caa9441e67.png) |

Close: #1405