### PR TITLE
Select guide storage: use simplified disk and partion names

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -44,7 +44,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
     return '${disk.sysname}${partition.number}';
   }
 
-  /// Formats a disk in a pretty way e.g. "/dev/sda ATA Maxtor (123 GB)"
+  /// Formats a disk in a pretty way e.g. "sda ATA Maxtor (123 GB)"
   String prettyFormatDisk(Disk disk) {
     final fullName = <String?>[
       disk.model,
@@ -52,7 +52,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
     ].where((p) => p?.isNotEmpty == true).join(' ');
 
     final size = filesize(disk.size);
-    return '${disk.path} - $size $fullName';
+    return '${disk.sysname} - $size $fullName';
   }
 
   @override
@@ -106,7 +106,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: kContentSpacing / 2),
-                  Text(model.selectedDisk?.path ?? ''),
+                  Text(model.selectedDisk?.sysname ?? ''),
                   const SizedBox(height: kContentSpacing / 2),
                   Text(
                     filesize(model.selectedDisk?.size ?? 0),

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -65,7 +65,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(MenuItemButton),
-          matching: find.textContaining(disk.path!),
+          matching: find.textContaining(disk.sysname),
         ),
         findsOneWidget,
       );
@@ -99,7 +99,7 @@ void main() {
       selectedStorage: selectedStorage,
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
-    expect(find.text(selectedDisk.path!), findsOneWidget);
+    expect(find.text(selectedDisk.sysname), findsOneWidget);
     expect(find.text(filesize(selectedDisk.size)), findsOneWidget);
   });
 


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/225744137-0fc5af64-4fd4-4371-96b2-d05c99f6bcd1.png) | ![Screenshot from 2023-03-16 21-21-51](https://user-images.githubusercontent.com/140617/225744151-560ed1c9-2697-4472-9fad-c7bb02ae0a9f.png) |

Ref: #1577