### PR TITLE
Enable dependabot for Git submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+        interval: "daily"
+    target-branch: "main"


### PR DESCRIPTION
We disabled Renovate's Git submodule updates for `subiquity_client` in #1615 because it didn't like our `ubuntu/foo` branch naming convention. This PR is the promised replacement to provide similar Git submodule updates with help of GitHub's own [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot).

Dependabot doesn't mind our branch naming and has already been test-driven in the [subiquity_client.dart](https://github.com/canonical/subiquity_client.dart/blob/main/.github/dependabot.yml) repo to update subiquity's `main` and `ubuntu/lunar` branches.