### PR TITLE
Optimize timezone map

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -49,11 +49,6 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
         controller.selectTimezone(timezones.firstOrNull);
       });
     });
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      TimezoneMap.precacheAssets(context);
-    });
   }
 
   String formatLocation(GeoLocation? location) {
@@ -141,6 +136,7 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
           const SizedBox(height: kContentSpacing),
           Expanded(
             child: TimezoneMap(
+              size: TimezoneMapSize.medium,
               offset: controller.selectedLocation?.offset,
               marker: controller.selectedLocation?.coordinates,
               onPressed: (coordinates) => controller

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -138,7 +138,12 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
           context,
           highlighted: true,
           label: lang.startInstallingButtonText,
-          onNext: model.startInstallation,
+          onNext: () {
+            // start installation after the page transition (#1393)
+            Future.delayed(kThemeAnimationDuration).then((_) {
+              model.startInstallation();
+            });
+          },
         ),
       ],
     );

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
       path: packages/timezone_map
   ubuntu_localizations: ^0.1.0
   ubuntu_logger: ^0.0.1
-  ubuntu_service: ^0.2.1
+  ubuntu_service: ^0.2.2
   ubuntu_session: ^0.0.4
   ubuntu_widgets:
     git:

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -164,6 +164,9 @@ void main() {
     expect(continueButton, findsOneWidget);
 
     await tester.tap(continueButton);
+    verifyNever(model.startInstallation());
+
+    await tester.pumpAndSettle(kThemeAnimationDuration);
     verify(model.startInstallation()).called(1);
   });
 


### PR DESCRIPTION
- Use a PNG-based timezone map
- Pre-cache the map assets on startup
- Initialize local geodata on startup
- Postpone installation start until after the page transitions

See also:
- https://github.com/canonical/ubuntu-flutter-plugins/pull/163
- https://github.com/canonical/ubuntu-flutter-plugins/pull/168

## Before

[timezone-map-before.webm](https://user-images.githubusercontent.com/140617/226132740-d6ff6dbb-86ab-4ab4-8376-f3cac190c2ab.webm)

## After

[timezone-map-after.webm](https://user-images.githubusercontent.com/140617/226132746-ec44a2b2-c627-4b2f-95c4-f7332db7c287.webm)

Close: #1393