### PR TITLE
Override wifi list & storage table mouse cursor

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_table.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
+import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'storage_columns.dart';
@@ -141,31 +142,34 @@ class StorageTable extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: LayoutBuilder(builder: (context, constraints) {
         final theme = Theme.of(context);
-        return OverflowBox(
-          maxWidth: double.infinity,
-          alignment: Alignment.topLeft,
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minWidth: constraints.minWidth),
-            child: SingleChildScrollView(
-              controller: controller,
-              child: DataTable(
-                dataRowHeight: kMinInteractiveDimension +
-                    theme.visualDensity.baseSizeAdjustment.dy,
-                headingRowHeight: kMinInteractiveDimension +
-                    theme.visualDensity.baseSizeAdjustment.dy,
-                showCheckboxColumn: false,
-                headingTextStyle: theme.textTheme.titleSmall,
-                dataTextStyle: theme.textTheme.bodyMedium,
-                columns: columns
-                    .map((column) =>
-                        DataColumn(label: column.titleBuilder(context)))
-                    .toList(),
-                rows: List.generate(storages.length, (index) {
-                  return _buildDataRows(context, diskIndex: index);
-                }).fold<List<DataRow>>([], (allRows, diskRows) {
-                  allRows.addAll(diskRows);
-                  return allRows;
-                }).toList(),
+        return OverrideMouseCursor(
+          cursor: SystemMouseCursors.basic,
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            alignment: Alignment.topLeft,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minWidth: constraints.minWidth),
+              child: SingleChildScrollView(
+                controller: controller,
+                child: DataTable(
+                  dataRowHeight: kMinInteractiveDimension +
+                      theme.visualDensity.baseSizeAdjustment.dy,
+                  headingRowHeight: kMinInteractiveDimension +
+                      theme.visualDensity.baseSizeAdjustment.dy,
+                  showCheckboxColumn: false,
+                  headingTextStyle: theme.textTheme.titleSmall,
+                  dataTextStyle: theme.textTheme.bodyMedium,
+                  columns: columns
+                      .map((column) =>
+                          DataColumn(label: column.titleBuilder(context)))
+                      .toList(),
+                  rows: List.generate(storages.length, (index) {
+                    return _buildDataRows(context, diskIndex: index);
+                  }).fold<List<DataRow>>([], (allRows, diskRows) {
+                    allRows.addAll(diskRows);
+                    return allRows;
+                  }).toList(),
+                ),
               ),
             ),
           ),

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/wifi_view.dart
@@ -123,22 +123,25 @@ class WifiListView extends StatelessWidget {
     final model = Provider.of<WifiModel>(context);
     return YaruBorderContainer(
       clipBehavior: Clip.antiAlias,
-      child: ListView.builder(
-        shrinkWrap: true,
-        itemCount: model.devices.length,
-        itemBuilder: (context, index) {
-          return ChangeNotifierProvider.value(
-            value: model.devices[index],
-            child: WifiListTile(
-              key: ValueKey(index),
-              selected: model.isSelectedDevice(model.devices[index]),
-              onSelected: (device, accessPoint) {
-                model.selectDevice(device);
-                onSelected(device, accessPoint);
-              },
-            ),
-          );
-        },
+      child: OverrideMouseCursor(
+        cursor: SystemMouseCursors.basic,
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: model.devices.length,
+          itemBuilder: (context, index) {
+            return ChangeNotifierProvider.value(
+              value: model.devices[index],
+              child: WifiListTile(
+                key: ValueKey(index),
+                selected: model.isSelectedDevice(model.devices[index]),
+                onSelected: (device, accessPoint) {
+                  model.selectDevice(device);
+                  onSelected(device, accessPoint);
+                },
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/packages/ubuntu_wizard/lib/src/widgets/override_mouse_cursor.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/override_mouse_cursor.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+
+// Overrides the mouse cursor for a subtree of widgets by stacking a mouse
+// region on top of the child.
+//
+// Note: This is intended as a workaround for widgets that do not support
+// themeable mouse cursors. Prefer using FooThemeData.mouseCursor instead
+// whenever possible.
+class OverrideMouseCursor extends StatelessWidget {
+  const OverrideMouseCursor({
+    super.key,
+    required this.child,
+    required this.cursor,
+  });
+
+  final Widget child;
+  final MouseCursor cursor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        Positioned.fill(
+          child: MouseRegion(cursor: cursor, opaque: false),
+        )
+      ],
+    );
+  }
+}

--- a/packages/ubuntu_wizard/lib/widgets.dart
+++ b/packages/ubuntu_wizard/lib/widgets.dart
@@ -2,6 +2,7 @@ export 'src/widgets/animated_expanded.dart';
 export 'src/widgets/flavor.dart';
 export 'src/widgets/icons.dart';
 export 'src/widgets/option_card.dart';
+export 'src/widgets/override_mouse_cursor.dart';
 export 'src/widgets/password_strength_label.dart';
 export 'src/widgets/validated_form_field.dart';
 export 'src/widgets/wizard_page.dart';

--- a/packages/ubuntu_wizard/test/override_mouse_cursor_test.dart
+++ b/packages/ubuntu_wizard/test/override_mouse_cursor_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+
+void main() {
+  testWidgets('override mouse cursor', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              ListTile(title: const Text('normal'), onTap: () {}),
+              const ListTile(title: Text('disabled')),
+              OverrideMouseCursor(
+                cursor: SystemMouseCursors.basic,
+                child: ListTile(title: const Text('basic'), onTap: () {}),
+              ),
+              const OverrideMouseCursor(
+                cursor: SystemMouseCursors.alias,
+                child: ListTile(title: Text('alias')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final gesture =
+        await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+
+    MouseCursor? debugDeviceActiveCursor() {
+      return WidgetsBinding.instance.mouseTracker.debugDeviceActiveCursor(1);
+    }
+
+    await gesture.moveTo(tester.getCenter(find.text('normal')));
+    await tester.pump();
+    expect(debugDeviceActiveCursor(), SystemMouseCursors.click);
+
+    await gesture.moveTo(tester.getCenter(find.text('disabled')));
+    await tester.pump();
+    expect(debugDeviceActiveCursor(), SystemMouseCursors.basic);
+
+    await gesture.moveTo(tester.getCenter(find.text('basic')));
+    await tester.pump();
+    expect(debugDeviceActiveCursor(), SystemMouseCursors.basic);
+
+    await gesture.moveTo(tester.getCenter(find.text('alias')));
+    await tester.pump();
+    expect(debugDeviceActiveCursor(), SystemMouseCursors.alias);
+  });
+}


### PR DESCRIPTION
These are the last two remaining areas in the installer where it was not possible to customize the mouse cursor via Flutter's theming APIs (#1601). As a workaround, we're overriding the mouse cursor by stacking a `MouseRegion` on top of the wifi list and storage table.

Close: #1532