### PR TITLE
Allow installing alongside BitLocker if there's free space

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -463,9 +463,7 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
       if (arguments == InstallationType.erase) {
         return Routes.selectGuidedStorage;
       } else if (arguments == InstallationType.alongside) {
-        return service.hasBitLocker
-            ? Routes.turnOffBitlocker
-            : Routes.installAlongside;
+        return Routes.installAlongside;
       }
     } else if (service.useEncryption && service.securityKey == null) {
       return Routes.chooseSecurityKey;


### PR DESCRIPTION
Subiquity handles BitLocker partitions fine for guided partitioning. It correctly leaves out the "resize" option and only offers a "use gap" option when there's enough free space. There is no reason to force users to turn off BitLocker when installing into an unused area alongside a partition with BitLocker enabled.