### PR TITLE
Use YaruTestWindow for testing window close

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -22,6 +22,7 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test/test_utils.dart';
 
@@ -29,6 +30,8 @@ import '../test/test_utils.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
 
   setUp(() async {
     await cleanUpSubiquity();
@@ -550,9 +553,9 @@ Future<void> testTurnOffBitLockerPage(WidgetTester tester) async {
   await expectPage(
       tester, TurnOffBitLockerPage, (lang) => lang.turnOffBitlockerTitle);
 
-  final windowClosed = waitForWindowClosed();
+  final windowClosed = YaruTestWindow.waitForClosed();
   await tester.tapButton(tester.lang.restartIntoWindows);
-  await expectLater(windowClosed, completion(isTrue));
+  await expectLater(windowClosed, completes);
 }
 
 Future<void> testWhereAreYouPage(
@@ -656,9 +659,9 @@ Future<void> testInstallationCompletePage(WidgetTester tester) async {
   await expectPage(tester, InstallationCompletePage,
       (lang) => lang.installationCompleteTitle);
 
-  final windowClosed = waitForWindowClosed();
+  final windowClosed = YaruTestWindow.waitForClosed();
   await tester.tapButton(tester.lang.continueTesting);
-  await expectLater(windowClosed, completion(isTrue));
+  await expectLater(windowClosed, completes);
 }
 
 Future<void> expectPage(

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -75,6 +75,7 @@ dev_dependencies:
   ubuntu_test:
     path: ../ubuntu_test
   yaml: ^3.1.0
+  yaru_window_test: ^0.0.3
 
 flutter:
   uses-material-design: true

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_page_test.dart
@@ -1,6 +1,5 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -8,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/pages/not_enough_disk_space/not_enough_disk_space_model.dart';
 import 'package:ubuntu_desktop_installer/pages/not_enough_disk_space/not_enough_disk_space_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_utils.dart';
 import 'not_enough_disk_space_model_test.mocks.dart';
@@ -15,6 +15,8 @@ import 'not_enough_disk_space_page_test.mocks.dart';
 
 @GenerateMocks([NotEnoughDiskSpaceModel])
 void main() {
+  setUpAll(YaruTestWindow.ensureInitialized);
+
   NotEnoughDiskSpaceModel buildModel({
     bool hasMultipleDisks = false,
     int largestDiskSize = 0,
@@ -77,16 +79,11 @@ void main() {
         find.widgetWithText(FilledButton, tester.lang.quitButtonText);
     expect(button, findsOneWidget);
 
-    var windowClosed = false;
-    const methodChannel = MethodChannel('yaru_window');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
+    final windowClosed = YaruTestWindow.waitForClosed();
 
     await tester.tap(button);
 
-    expect(windowClosed, isTrue);
+    await expectLater(windowClosed, completes);
   });
 
   testWidgets('creates a model', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/try_or_install/try_or_install_page_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -14,6 +13,7 @@ import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_utils.dart';
 import 'try_or_install_page_test.mocks.dart';
@@ -22,6 +22,8 @@ import 'try_or_install_page_test.mocks.dart';
 
 @GenerateMocks([UrlLauncher])
 void main() {
+  setUpAll(YaruTestWindow.ensureInitialized);
+
   late MaterialApp app;
   late TryOrInstallModel model;
 
@@ -147,16 +149,11 @@ void main() {
 
     expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
 
-    var windowClosed = false;
-    final methodChannel = MethodChannel('yaru_window');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
+    final windowClosed = YaruTestWindow.waitForClosed();
 
     await tester.tap(continueButton);
     await tester.pump();
 
-    expect(windowClosed, isTrue);
+    await expectLater(windowClosed, completes);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_bitlocker/turn_off_bitlocker_page_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -9,6 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/turn_off_bitlocker/turn_off_bitlo
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_utils.dart';
 import 'turn_off_bitlocker_page_test.mocks.dart';
@@ -17,6 +17,8 @@ import 'turn_off_bitlocker_page_test.mocks.dart';
 
 @GenerateMocks([TurnOffBitLockerModel, UrlLauncher])
 void main() {
+  setUpAll(YaruTestWindow.ensureInitialized);
+
   testWidgets('restart', (tester) async {
     final model = MockTurnOffBitLockerModel();
     when(model.reboot()).thenAnswer((_) async {});
@@ -34,18 +36,13 @@ void main() {
     );
     expect(restartButton, findsOneWidget);
 
-    var windowClosed = false;
-    final methodChannel = MethodChannel('yaru_window');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
+    final windowClosed = YaruTestWindow.waitForClosed();
 
     await tester.tap(restartButton);
     await tester.pump();
     verify(model.reboot()).called(1);
 
-    expect(windowClosed, isTrue);
+    await expectLater(windowClosed, completes);
   });
 
   testWidgets('tap link', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/turn_off_rst/turn_off_rst_page_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -9,6 +8,7 @@ import 'package:ubuntu_desktop_installer/pages/turn_off_rst/turn_off_rst_page.da
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_utils.dart';
 import 'turn_off_rst_page_test.mocks.dart';
@@ -17,6 +17,8 @@ import 'turn_off_rst_page_test.mocks.dart';
 
 @GenerateMocks([TurnOffRSTModel, UrlLauncher])
 void main() {
+  setUpAll(YaruTestWindow.ensureInitialized);
+
   testWidgets('restart', (tester) async {
     final model = MockTurnOffRSTModel();
 
@@ -33,18 +35,13 @@ void main() {
     );
     expect(restartButton, findsOneWidget);
 
-    var windowClosed = false;
-    final methodChannel = MethodChannel('yaru_window');
-    methodChannel.setMockMethodCallHandler((call) async {
-      expect(call.method, equals('close'));
-      windowClosed = true;
-    });
+    final windowClosed = YaruTestWindow.waitForClosed();
 
     await tester.tap(restartButton);
     await tester.pump();
     verify(model.reboot()).called(1);
 
-    expect(windowClosed, isTrue);
+    await expectLater(windowClosed, completes);
   });
 
   testWidgets('tap link', (tester) async {

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_server.dart';
@@ -106,33 +104,6 @@ Future<void> cleanUpSubiquity() async {
   try {
     Directory(await subiquityPath).deleteSync(recursive: true);
   } on FileSystemException catch (_) {}
-}
-
-/// Waits for the application window to be closed, to allow an integration test
-/// to proceed to the next test case.
-Future<bool> waitForWindowClosed() {
-  final completer = Completer<bool>();
-  final methodChannel = MethodChannel('yaru_window');
-  methodChannel.setMockMethodCallHandler((call) async {
-    switch (call.method) {
-      case 'close':
-        await _testCloseWindow();
-        completer.complete(true);
-        break;
-    }
-  });
-  return completer.future;
-}
-
-// Sends a platform message to simulate the window being closed, to trigger the
-// application exit routine.
-Future<void> _testCloseWindow() async {
-  final call = MethodCall('onClose');
-  await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-    'yaru_window',
-    StandardMethodCodec().encodeMethodCall(call),
-    (_) {},
-  );
 }
 
 /// Helpers for interacting with widgets.

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/reconfigure_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/reconfigure_test.dart
@@ -3,11 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_pages.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
 
   // enter all WSLConfigurationAdvanced values
   testWidgets('reconfiguration', (tester) async {

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
@@ -3,11 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_pages.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
 
   testWidgets('basic setup', (tester) async {
     app.main(<String>['--no-dry-run']);

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
@@ -2,11 +2,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:ubuntu_wsl_setup/main_win.dart' as app;
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_pages.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
 
   testWidgets('basic setup with prefill info', (tester) async {
     const prefill = String.fromEnvironment('PREFILL', defaultValue: '');

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages.dart';
 import 'package:ubuntu_wsl_setup/splash_screen.dart';
 import 'package:ubuntu_wsl_setup/wizard.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test/test_utils.dart';
 
@@ -123,13 +124,13 @@ Future<void> testApplyingChangesPage(
   WidgetTester tester, {
   bool expectClose = false,
 }) async {
-  final windowClosed = expectClose ? waitForWindowClosed() : null;
+  final windowClosed = expectClose ? YaruTestWindow.waitForClosed() : null;
 
   await tester.pumpUntil(find.byType(ApplyingChangesPage));
   expectPage(tester, ApplyingChangesPage, (lang) => lang.setupCompleteTitle);
 
   if (windowClosed != null) {
-    expect(await windowClosed, isTrue);
+    await expectLater(windowClosed, completes);
   }
 }
 

--- a/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/ubuntu_wsl_setup_test.dart
@@ -5,11 +5,14 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wsl_setup/main.dart' as app;
 import 'package:ubuntu_wsl_setup/routes.dart';
+import 'package:yaru_window_test/yaru_window_test.dart';
 
 import 'test_pages.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
 
   setUp(() async => await cleanUpSubiquity());
   tearDown(() async => await resetAllServices());

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -47,6 +47,7 @@ dev_dependencies:
   mockito: 5.3.2
   ubuntu_test:
     path: ../ubuntu_test
+  yaru_window_test: ^0.0.3
 
 flutter:
   generate: true


### PR DESCRIPTION
Installing a mock call handler on the method channel is not only clumsy and ugly but also problematic in integration and screenshot tests (#1691) because it prevents any consequent tests from getting the appropriate window state as soon as the first test has mocked out the method channel just to prevent the window from closing.

`YaruTestWindow` was introduced to make it straightforward to test window closing. After calling `YaruTestWindow.ensureInitialized()`, it's always safe for the app to call `YaruWindow.close()` as it doesn't close the window for real _but_ it does execute the close handlers as expected. Furthermore, `YaruTestWindow.waitForClosed()` was added to make it easy to wait for the window to be closed without installing any problematic mock handlers.