### PR TITLE
Use a fake desktop service to speed up integration testing in the CI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
-          sudo apt install -y dbus-x11 network-manager ubuntu-desktop-minimal upower
+          sudo apt install -y dbus-x11 network-manager upower
           make install_deps
 
       - name: Install Flutter

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
@@ -16,8 +15,6 @@ import 'package:ubuntu_desktop_installer/pages/connect_to_internet/connect_model
 import 'package:ubuntu_desktop_installer/pages/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
-import 'package:ubuntu_session/ubuntu_session.dart';
-import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaml/yaml.dart';
@@ -32,14 +29,7 @@ void main() {
 
   setUp(() async {
     await cleanUpSubiquity();
-    final mockGnomeSessionManager = MockGnomeSessionManager();
-    when(mockGnomeSessionManager.inhibit(
-            appId: anyNamed('appId'),
-            topLevelXId: anyNamed('topLevelXId'),
-            reason: anyNamed('reason'),
-            flags: anyNamed('flags')))
-        .thenAnswer((_) async => 42);
-    registerMockService<GnomeSessionManager>(mockGnomeSessionManager);
+    registerMockService<DesktopService>(FakeDesktopService());
   });
   tearDown(() async => await resetAllServices());
 
@@ -756,4 +746,15 @@ Future<void> verifyConfig({
             .isNotEmpty,
         useEncryption);
   }
+}
+
+class FakeDesktopService implements DesktopService {
+  @override
+  Future<void> inhibit() async {}
+
+  @override
+  Future<void> setTheme(Brightness brightness) async {}
+
+  @override
+  Future<void> close() async {}
 }

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -8,7 +8,6 @@ import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:timezone_map/timezone_map.dart';
-import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -90,7 +89,6 @@ Future<void> runInstallerApp(
   tryRegisterService(TelemetryService.new);
   tryRegisterService(UdevService.new);
   tryRegisterService(UrlLauncher.new);
-  tryRegisterService(GnomeSessionManager.new);
 
   WidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/desktop_service.dart
@@ -1,7 +1,6 @@
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:gsettings/gsettings.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 
@@ -42,8 +41,7 @@ class GnomeService implements DesktopService {
             screensaverSettings ?? GSettings('org.gnome.desktop.screensaver'),
         _sessionSettings =
             sessionSettings ?? GSettings('org.gnome.desktop.session'),
-        _gnomeSessionManager =
-            gnomeSessionManager ?? getService<GnomeSessionManager>();
+        _gnomeSessionManager = gnomeSessionManager ?? GnomeSessionManager();
 
   final GSettings _dingSettings;
   final GSettings _interfaceSettings;

--- a/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_your_look/choose_your_look_page_test.mocks.dart
@@ -7,7 +7,7 @@ import 'dart:async' as _i3;
 import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services/desktop_service.dart' as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values


### PR DESCRIPTION
This way, we don't need to install `ubuntu-desktop-minimal` which can sometimes take several minutes.