### PR TITLE
Present a fake "install alongside" option that leads to BitLocker instructions

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -468,7 +468,9 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
           ? Routes.turnOffBitlocker
           : Routes.allocateDiskSpace;
     } else if (service.guidedTarget == null) {
-      if (arguments == InstallationType.erase) {
+      if (arguments == InstallationType.bitlocker) {
+        return Routes.turnOffBitlocker;
+      } else if (arguments == InstallationType.erase) {
         return Routes.selectGuidedStorage;
       } else if (arguments == InstallationType.alongside) {
         return Routes.installAlongside;

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -17,6 +17,9 @@ enum InstallationType {
 
   /// Manual partitioning.
   manual,
+
+  /// BitLocker must be manually resized or disabled.
+  bitlocker,
 }
 
 /// Available advanced features.
@@ -89,6 +92,9 @@ class InstallationTypeModel extends SafeChangeNotifier {
 
   /// Whether storage information has been queried and installation can proceed.
   bool get hasStorage => _storages != null;
+
+  /// Whether BitLocker is detected.
+  bool get hasBitLocker => _diskService.hasBitLocker;
 
   /// Whether installation alongside an existing OS is possible.
   ///

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -106,14 +106,16 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
           //     onChanged: (v) => model.installationType = v!,
           //   ),
           // if (model.existingOS != null) const SizedBox(height: kContentSpacing),
-          if (model.canInstallAlongside)
+          if (model.canInstallAlongside || model.hasBitLocker)
             Padding(
               padding: const EdgeInsets.only(bottom: kContentSpacing),
               child: YaruRadioButton<InstallationType>(
                 title: Text(_formatAlongside(
                     lang, model.productInfo, model.existingOS ?? [])),
                 subtitle: Text(lang.installationTypeAlongsideInfo),
-                value: InstallationType.alongside,
+                value: model.canInstallAlongside
+                    ? InstallationType.alongside
+                    : InstallationType.bitlocker, // for instructions
                 groupValue: model.installationType,
                 onChanged: (v) => model.installationType = v!,
               ),

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -18,8 +18,8 @@ class DiskStorageService {
   Future<void> init() async {
     final status = await _client.status();
     if (status.state == ApplicationState.ERROR) return;
+    await _client.getStorageV2().then(_updateStorage);
     await Future.wait([
-      _client.getStorageV2().then(_updateStorage),
       _client.hasRst().then((value) => _hasRst = value),
       _client.hasBitLocker().then((value) => _hasBitLocker = value),
     ]);

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
@@ -57,6 +57,7 @@ void main() {
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
     when(model.hasStorage).thenReturn(true);
+    when(model.hasBitLocker).thenReturn(false);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
@@ -88,6 +89,7 @@ void main() {
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
     when(model.hasStorage).thenReturn(true);
+    when(model.hasBitLocker).thenReturn(false);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -16,6 +16,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.useLvm).thenReturn(true);
     when(service.useEncryption).thenReturn(true);
+    when(service.hasBitLocker).thenReturn(true);
     when(service.getGuidedStorage())
         .thenAnswer((_) async => testGuidedStorageResponse());
 
@@ -28,6 +29,7 @@ void main() {
 
     expect(model.advancedFeature, AdvancedFeature.lvm);
     expect(model.encryption, isTrue);
+    expect(model.hasBitLocker, isTrue);
   });
 
   test('existing OS', () async {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -25,6 +25,7 @@ void main() {
     List<OsProber>? existingOS,
     bool? canInstallAlongside,
     bool? hasStorage,
+    bool? hasBitLocker,
   }) {
     final model = MockInstallationTypeModel();
     when(model.installationType)
@@ -36,6 +37,7 @@ void main() {
     when(model.existingOS).thenReturn(existingOS);
     when(model.canInstallAlongside).thenReturn(canInstallAlongside ?? false);
     when(model.hasStorage).thenReturn(hasStorage ?? true);
+    when(model.hasBitLocker).thenReturn(hasBitLocker ?? false);
     return model;
   }
 
@@ -146,6 +148,30 @@ void main() {
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.installationType = InstallationType.alongside).called(1);
+  });
+
+  testWidgets('alongside bitlocker', (tester) async {
+    final model = buildModel(
+      productInfo: ProductInfo(name: 'Ubuntu 22.10'),
+      existingOS: [
+        OsProber(
+          long: 'Windows 11',
+          label: 'WIN11',
+          version: '11',
+          type: 'BitLocker',
+        ),
+      ],
+      canInstallAlongside: false,
+      hasBitLocker: true,
+    );
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+        tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 11'));
+    expect(radio, findsOneWidget);
+
+    await tester.tap(radio);
+    verify(model.installationType = InstallationType.bitlocker).called(1);
   });
 
   testWidgets('alongside ubuntu', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -95,6 +95,11 @@ class MockInstallationTypeModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
+  bool get hasBitLocker => (super.noSuchMethod(
+        Invocation.getter(#hasBitLocker),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get canInstallAlongside => (super.noSuchMethod(
         Invocation.getter(#canInstallAlongside),
         returnValue: false,


### PR DESCRIPTION
If Subiquity doesn't offer any "install alongside" option and we detect BitLocker on the system, assume that the option got filtered out due to BitLocker. At this point, we're already past the minimum installation size check so we can safely assume that there's enough disk space in total. In this case, we want to present a fake "install alongside" option that leads to BitLocker instructions.

NOTE: The BitLocker instructions will be updated separately. This PR is only about the flow change.

The following "before" and "after" screenshot and recording are taken with a machine configuration that has one large partition with BitLocker enabled.

## Before

Subiquity does not offer any "alongside" option because there's no free space and the BitLocker partition cannot be resized.

![Screenshot from 2023-03-24 12-38-51](https://user-images.githubusercontent.com/140617/227518272-cd295e4e-9534-4c0c-be91-3884fa5b86cf.png)

## After

We insert a fake "alongside" option that leads to BitLocker instructions.

[Screencast from 2023-03-24 12-56-24.webm](https://user-images.githubusercontent.com/140617/227518333-f6445a3f-6dde-4c9a-ab65-839f96b49708.webm)
