### PR TITLE
Prevent editing partitions with BitLocker enabled

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -92,7 +92,7 @@ class AllocateDiskSpaceModel extends SafeChangeNotifier {
   bool get canRemovePartition => selectedPartition != null;
 
   /// Whether the currently selected partition can be edited.
-  bool get canEditPartition => selectedPartition != null;
+  bool get canEditPartition => selectedPartition?.canEdit == true;
 
   /// Whether the currently selected disk can be reformatted.
   bool get canReformatDisk => selectedDisk != null && selectedObject == null;

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -15,6 +15,7 @@ extension DiskExtension on Disk {
 
 extension PartitionExtension on Partition {
   bool get canWipe => PartitionFormat.fromPartition(this)?.canWipe == true;
+  bool get canEdit => format != 'BitLocker';
   bool get isWiped => wipe == 'superblock';
   String get prettySize => filesize(size ?? 0);
 }

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
@@ -188,6 +188,8 @@ void main() {
     final normalDisk = emptyDisk.copyWith(partitions: [Partition()]);
     final formattedPartition =
         emptyDisk.copyWith(partitions: [Partition(format: 'ext4')]);
+    final bitLockerPartition =
+        emptyDisk.copyWith(partitions: [Partition(format: 'BitLocker')]);
 
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer(
@@ -196,6 +198,7 @@ void main() {
         fullDisk,
         normalDisk,
         formattedPartition,
+        bitLockerPartition,
       ],
     );
 
@@ -262,6 +265,16 @@ void main() {
     expect(model.canAddPartition, isFalse);
     expect(model.canRemovePartition, isTrue);
     expect(model.canEditPartition, isTrue);
+    expect(model.canReformatDisk, isFalse);
+
+    model.selectStorage(4, 0);
+    expect(model.selectedDisk, equals(bitLockerPartition));
+    expect(model.selectedPartition, isNotNull);
+    expect(model.selectedPartition!.canWipe, isFalse);
+    expect(model.selectedGap, isNull);
+    expect(model.canAddPartition, isFalse);
+    expect(model.canRemovePartition, isTrue);
+    expect(model.canEditPartition, isFalse);
     expect(model.canReformatDisk, isFalse);
   });
 


### PR DESCRIPTION
BitLocker'd partitions cannot be resized or mounted. There's no reason to let the user open the partition edit dialog at all. Notice that deleting such a partition is allowed by pressing the "-" button, though.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-24 14-32-41](https://user-images.githubusercontent.com/140617/227537703-26d0e33c-670c-4cb8-96f6-18865e379195.png) | ![Screenshot from 2023-03-24 14-32-57](https://user-images.githubusercontent.com/140617/227537755-9a83c18a-9d2d-4608-9550-144cb43084f5.png) |
