### PR TITLE
Allow entering manual partitioning regardless of BitLocker

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -279,7 +279,7 @@ void main() {
     ]);
     await tester.pumpAndSettle();
 
-    await testInstallationTypePage(tester, type: InstallationType.manual);
+    await testInstallationTypePage(tester, type: InstallationType.bitlocker);
     await tester.pumpAndSettle();
 
     await testTurnOffBitLockerPage(tester);

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -464,9 +464,7 @@ class _UbuntuDesktopInstallerWizard extends StatelessWidget {
 
   String? _nextStorageRoute(DiskStorageService service, dynamic arguments) {
     if (arguments == InstallationType.manual) {
-      return service.hasBitLocker
-          ? Routes.turnOffBitlocker
-          : Routes.allocateDiskSpace;
+      return Routes.allocateDiskSpace;
     } else if (service.guidedTarget == null) {
       if (arguments == InstallationType.bitlocker) {
         return Routes.turnOffBitlocker;


### PR DESCRIPTION
We've made sure BitLocker partitions cannot be edited/resized and they're also visualized with a lock icon:

- https://github.com/canonical/ubuntu-desktop-installer/pull/1704
- https://github.com/canonical/ubuntu-desktop-installer/pull/1705
