### PR TITLE
Update curtin, subiquitydeps, and probert parts to match subiquity snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,59 +39,44 @@ apps:
 
 parts:
   curtin:
+    plugin: nil
+    source: https://git.launchpad.net/curtin
+    source-type: git
+    source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
       sed -e "s,@@PACKAGED_VERSION@@,$PACKAGED_VERSION,g" -i curtin/version.py
-    plugin: python
-    source-type: git
-    source: https://git.launchpad.net/curtin
-    source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
+    override-build: &pyinstall |
+      # We install without dependencies because all dependencies come from
+      # archive packages.
+      # XXX: On core22, running `pip3 install --prefix xxx` does not do the
+      # right thing. The package ends up installed in xxx/local and the modules
+      # get installed to dist-packages instead of site-packages.
+      # See https://discuss.python.org/t/18240
+      # As a workaround, we use a fake user install to get the package
+      # installed in the expected place.
+      PYTHONUSERBASE="$CRAFT_PART_INSTALL" pip3 install --user --no-dependencies .
     build-packages:
-      - shared-mime-info
-      - zlib1g-dev
-    python-packages:
-      - pyyaml==5.3.1
-      - oauthlib
-      - jsonschema
-      - pyrsistent
-      - wheel
-      - setuptools
-      - pip
-      - bson
-      - urwid
-      - requests
-      - requests-unixsocket
+      - python3-pip
     organize:
       lib/python*/site-packages/usr/lib/curtin: usr/lib/
-    stage:
-      - '*'
-      - -lib/python*/site-packages/_yaml.*.so
-      - -lib/python*/site-packages/setuptools
-      - -lib/python*/site-packages/pip
-      - -lib/python*/site-packages/pkg_resources
-      - -lib/python*/site-packages/jsonschema
-      - -lib/python*/site-packages/wheel*
-      - -lib/python*/site-packages/probert
-      - -bin/activate*
-      - -bin/python3*
-      - -lib/python3.10/site-packages/__pycache__/six.cpython*
-      - -lib/python3.10/site-packages/pip-*.dist-info/RECORD
-      - -lib/python3.10/site-packages/wheel-*.dist-info/RECORD
-      - -lib/python3.10/site-packages/_distutils_hack
 
   probert:
-    plugin: python
+    plugin: nil
+    source: https://github.com/canonical/probert.git
+    source-type: git
+    source-commit: 40479d08fce0370a0c41a140e6d322d2846c2a8f
+    override-build: *pyinstall
     build-packages:
-      - python-setuptools
       - build-essential
       - libnl-3-dev
       - libnl-genl-3-dev
       - libnl-route-3-dev
-    source: https://github.com/canonical/probert.git
-    source-type: git
-    source-commit: 40479d08fce0370a0c41a140e6d322d2846c2a8f
-    python-requirements: [requirements.txt]
+      - pkg-config
+      - python3-dev
+      - python3-pip
+    build-attributes: [enable-patchelf]
     stage:
       - '*'
       - -bin/python3*
@@ -100,28 +85,36 @@ parts:
     plugin: nil
     build-attributes: [enable-patchelf]
     stage-packages:
+      # This list includes the dependencies for curtin and probert as well,
+      # there doesn't seem to be any real benefit to listing them separately.
       - cloud-init
-      - libsystemd0
       - iso-codes
-      - jq
+      - libpython3-stdlib
+      - libpython3.10-minimal
+      - libpython3.10-stdlib
+      - libsystemd0
       - lsb-release
-      - ssh-import-id
       - ntfs-3g
       - python3-aiohttp
-      - python3-bson
-      - python3-minimal
-      - python3.10-minimal
-      - libpython3-stdlib
-      - libpython3.10-stdlib
-      - libpython3.10-minimal
-      - libnetplan0
       - python3-apport
-      - python3-requests-unixsocket
+      - python3-attr
+      - python3-bson
+      - python3-jsonschema
+      - python3-minimal
+      - python3-oauthlib
+      - python3-pkg-resources
       - python3-pyroute2
+      - python3-pyrsistent
       - python3-pyudev
+      - python3-requests
+      - python3-requests-unixsocket
       - python3-systemd
       - python3-urwid
-      - util-linux
+      - python3-yaml
+      - python3-yarl
+      - python3.10-minimal
+      - ssh-import-id
+      - ubuntu-advantage-tools
       # WSL specifics:
       - language-selector-common
       - locales


### PR DESCRIPTION
Update curtin, subiquitydeps, and probert parts to match changes in upstream subiquity snap.  This should cleanup duplicated python libs. Fixes #1714