### PR TITLE
CI: enable PR workflows on non-main branches

### DIFF
--- a/.github/workflows/flutter-build-win.yml
+++ b/.github/workflows/flutter-build-win.yml
@@ -10,8 +10,6 @@ on:
       - packages/ubuntu_wsl_setup/**
       - .github/workflows/**
   pull_request:
-    branches:
-      - main
     paths:
       - packages/subiquity_client/**
       - packages/ubuntu_wizard/**

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -2,8 +2,6 @@ name: snap
 
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
There will be `ubuntu/foo` branches in the future, and we might want to have some short-lived canary branches too. The CI should run whenever opening PRs against those branches.