### PR TITLE
KeyboardLayoutDetector: remove subiquity_client export

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_detector.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_detector.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_detector.dart
@@ -2,8 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
-export 'package:subiquity_client/subiquity_client.dart';
-
 /// @internal
 final log = Logger('keyboard_layout');
 

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_dialogs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 

--- a/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard_layout/keyboard_layout_detector_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_detector.dart';
 import 'package:ubuntu_test/mocks.dart';
 

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:ubuntu_desktop_installer/pages/keyboard_layout/keyboard_layout_detector.dart';
+import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/write_changes_to_disk/write_changes_to_disk_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/mocks.dart';


### PR DESCRIPTION
Exporting all of `subiquity_client.dart` from `keyboard_layout_detector.dart` makes VS Code automatically offer `keyboard_layout_detector.dart` import whenever using types from `subiquity_client.dart` so it accidentally ended up being imported in completely unrelated places such as AD & confirmation.