### PR TITLE
Move WizardBar out of WizardPage

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -314,10 +314,12 @@ class _UbuntuDesktopInstallerLoadingPage extends StatelessWidget {
           Text(lang.preparingUbuntu(flavor.name), style: style),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context, enabled: false),
-        WizardAction.next(context, enabled: false),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context, enabled: false),
+        trailing: [
+          WizardAction.next(context, enabled: false),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
@@ -65,24 +65,26 @@ class _ActiveDirectoryPageState extends State<ActiveDirectoryPage> {
           ],
         );
       }),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: context.select((ActiveDirectoryModel m) => m.isValid),
-          onNext: () async {
-            final model = context.read<ActiveDirectoryModel>();
-            await model.save();
-            model.getJoinResult().then((result) {
-              if (mounted &&
-                  (result == AdJoinResult.JOIN_ERROR ||
-                      result == AdJoinResult.PAM_ERROR)) {
-                showActiveDirectoryErrorDialog(context);
-              }
-            });
-          },
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: context.select((ActiveDirectoryModel m) => m.isValid),
+            onNext: () async {
+              final model = context.read<ActiveDirectoryModel>();
+              await model.save();
+              model.getJoinResult().then((result) {
+                if (mounted &&
+                    (result == AdJoinResult.JOIN_ERROR ||
+                        result == AdJoinResult.PAM_ERROR)) {
+                  showActiveDirectoryErrorDialog(context);
+                }
+              });
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -96,14 +96,16 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: model.isValid,
-          onNext: model.setStorage,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: model.isValid,
+            onNext: model.setStorage,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_security_key/choose_security_key_page.dart
@@ -83,16 +83,18 @@ class _ChooseSecurityKeyPageState extends State<ChooseSecurityKeyPage> {
           ],
         );
       }),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: context
-              .select<ChooseSecurityKeyModel, bool>((model) => model.isValid),
-          onNext: context.read<ChooseSecurityKeyModel>().saveSecurityKey,
-          onBack: context.read<ChooseSecurityKeyModel>().loadSecurityKey,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: context
+                .select<ChooseSecurityKeyModel, bool>((model) => model.isValid),
+            onNext: context.read<ChooseSecurityKeyModel>().saveSecurityKey,
+            onBack: context.read<ChooseSecurityKeyModel>().loadSecurityKey,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/choose_your_look_page.dart
@@ -17,10 +17,12 @@ class ChooseYourLookPage extends StatelessWidget {
     final desktop = getService<DesktopService>();
     return WizardPage(
       header: Text(lang.chooseYourLookPageHeader),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(context),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(context),
+        ],
+      ),
       title: YaruWindowTitleBar(
         title: Text(lang.chooseYourLookPageTitle),
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/configure_secure_boot/configure_secure_boot_page.dart
@@ -66,13 +66,15 @@ class _ConfigureSecureBootPageState extends State<ConfigureSecureBootPage> {
           );
         },
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: model.isFormValid,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: model.isFormValid,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/connect_to_internet/connect_to_internet_page.dart
@@ -94,27 +94,30 @@ class _ConnectToInternetPageState extends State<ConnectToInternetPage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction(
-          label: lang.connectButtonText,
-          enabled: !model.isConnecting,
-          visible: model.isEnabled && model.canConnect,
-          onActivated: model.connect,
-        ),
-        WizardAction.next(
-          context,
-          enabled: model.isEnabled && !model.isConnecting && model.isConnected,
-          visible: !model.isEnabled || !model.canConnect,
-          onNext: () => Future.wait([
-            // suspend network activity when proceeding on the next page
-            model.cleanup(),
-            model.markConfigured(),
-          ]),
-          // resume network activity if/when returning back to this page
-          onBack: model.init,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction(
+            label: lang.connectButtonText,
+            enabled: !model.isConnecting,
+            visible: model.isEnabled && model.canConnect,
+            onActivated: model.connect,
+          ),
+          WizardAction.next(
+            context,
+            enabled:
+                model.isEnabled && !model.isConnecting && model.isConnected,
+            visible: !model.isEnabled || !model.canConnect,
+            onNext: () => Future.wait([
+              // suspend network activity when proceeding on the next page
+              model.cleanup(),
+              model.markConfigured(),
+            ]),
+            // resume network activity if/when returning back to this page
+            onBack: model.init,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
@@ -110,15 +110,17 @@ class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          label: lang.selectGuidedStorageInstallNow,
-          onNext: model.selectedStorage != null ? model.save : null,
-          onBack: model.reset,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            label: lang.selectGuidedStorageInstallNow,
+            onNext: model.selectedStorage != null ? model.save : null,
+            onBack: model.reset,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -158,19 +158,21 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: model.hasStorage,
-          arguments: model.installationType,
-          onNext: model.save,
-          // If the user returns back to select another installation type, the
-          // previously configured storage must be reset to make all guided
-          // partitioning targets available.
-          onBack: model.resetStorage,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: model.hasStorage,
+            arguments: model.installationType,
+            onNext: model.save,
+            // If the user returns back to select another installation type, the
+            // previously configured storage must be reset to make all guided
+            // partitioning targets available.
+            onBack: model.resetStorage,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -173,14 +173,16 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
           ],
         ),
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: model.isValid,
-          onNext: model.save,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: model.isValid,
+            onNext: model.save,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -117,18 +117,20 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
             ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          label: lang.selectGuidedStorageInstallNow,
-          onNext: model.saveGuidedStorage,
-          // If the user returns back to select another disk, the previously
-          // configured guided storage must be reset to avoid multiple disks
-          // being configured for guided partitioning.
-          onBack: model.resetGuidedStorage,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            label: lang.selectGuidedStorageInstallNow,
+            onNext: model.saveGuidedStorage,
+            // If the user returns back to select another disk, the previously
+            // configured guided storage must be reset to avoid multiple disks
+            // being configured for guided partitioning.
+            onBack: model.resetGuidedStorage,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -98,21 +98,23 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.done(
-          context,
-          label: UbuntuLocalizations.of(context).nextLabel,
-          visible: model.option == Option.tryUbuntu,
-          onDone: YaruWindow.of(context).close,
-        ),
-        WizardAction.next(
-          context,
-          visible: model.option != Option.tryUbuntu,
-          enabled: model.option != Option.none,
-          arguments: model.option,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.done(
+            context,
+            label: UbuntuLocalizations.of(context).nextLabel,
+            visible: model.option == Option.tryUbuntu,
+            onDone: YaruWindow.of(context).close,
+          ),
+          WizardAction.next(
+            context,
+            visible: model.option != Option.tryUbuntu,
+            enabled: model.option != Option.none,
+            arguments: model.option,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_bitlocker/turn_off_bitlocker_page.dart
@@ -95,10 +95,9 @@ class TurnOffBitLockerPage extends StatelessWidget {
           ],
         ),
       ),
-      singleLeading: true,
-      actions: [
-        WizardAction.back(context),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/turn_off_rst/turn_off_rst_page.dart
@@ -96,10 +96,9 @@ class TurnOffRSTPage extends StatelessWidget {
             ],
           ),
         ),
-        singleLeading: true,
-        actions: <WizardAction>[
-          WizardAction.back(context),
-        ],
+        bottomBar: WizardBar(
+          leading: WizardAction.back(context),
+        ),
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -119,20 +119,22 @@ class _UpdatesOtherSoftwarePageState extends State<UpdatesOtherSoftwarePage> {
               showCloseIcon: true,
             )
           : null,
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          onNext: () async {
-            final telemetry = getService<TelemetryService>();
-            await telemetry.addMetrics({
-              'Minimal': model.installationMode == InstallationMode.minimal,
-              'RestrictedAddons': model.installCodecs,
-            });
-            await model.save();
-          },
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            onNext: () async {
+              final telemetry = getService<TelemetryService>();
+              await telemetry.addMetrics({
+                'Minimal': model.installationMode == InstallationMode.minimal,
+                'RestrictedAddons': model.installCodecs,
+              });
+              await model.save();
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -117,18 +117,20 @@ class _WelcomePageState extends State<WelcomePage> {
           ],
         ),
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          onNext: () {
-            final locale = model.locale(model.selectedLanguageIndex);
-            model.applyLocale(locale);
-            getService<TelemetryService>()
-                .addMetric('Language', locale.languageCode);
-          },
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            onNext: () {
+              final locale = model.locale(model.selectedLanguageIndex);
+              model.applyLocale(locale);
+              getService<TelemetryService>()
+                  .addMetric('Language', locale.languageCode);
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/where_are_you/where_are_you_page.dart
@@ -146,19 +146,22 @@ class WhereAreYouPageState extends State<WhereAreYouPage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(
+      bottomBar: WizardBar(
+        leading: WizardAction.back(
           context,
           enabled: false,
         ),
-        WizardAction.next(
-          context,
-          onNext: () {
-            final model = Provider.of<WhereAreYouModel>(context, listen: false);
-            return model.save(controller.selectedLocation?.timezone);
-          },
-        ),
-      ],
+        trailing: [
+          WizardAction.next(
+            context,
+            onNext: () {
+              final model =
+                  Provider.of<WhereAreYouModel>(context, listen: false);
+              return model.save(controller.selectedLocation?.timezone);
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/who_are_you/who_are_you_page.dart
@@ -96,16 +96,19 @@ class _WhoAreYouPageState extends State<WhoAreYouPage> {
           ],
         );
       }),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled:
-              context.select<WhoAreYouModel, bool>((model) => model.isValid),
-          arguments: context.select((WhoAreYouModel m) => m.useActiveDirectory),
-          onNext: context.read<WhoAreYouModel>().save,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled:
+                context.select<WhoAreYouModel, bool>((model) => model.isValid),
+            arguments:
+                context.select((WhoAreYouModel m) => m.useActiveDirectory),
+            onNext: context.read<WhoAreYouModel>().save,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -132,20 +132,22 @@ class _WriteChangesToDiskPageState extends State<WriteChangesToDiskPage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          highlighted: true,
-          label: lang.startInstallingButtonText,
-          onNext: () {
-            // start installation after the page transition (#1393)
-            Future.delayed(kThemeAnimationDuration).then((_) {
-              model.startInstallation();
-            });
-          },
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            highlighted: true,
+            label: lang.startInstallingButtonText,
+            onNext: () {
+              // start installation after the page transition (#1393)
+              Future.delayed(kThemeAnimationDuration).then((_) {
+                model.startInstallation();
+              });
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
@@ -1,0 +1,98 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/widgets.dart';
+
+import '../../constants.dart';
+import 'wizard_action.dart';
+
+export 'package:wizard_router/wizard_router.dart';
+export 'wizard_action.dart';
+
+class WizardBar extends StatefulWidget {
+  const WizardBar({
+    super.key,
+    this.leading,
+    this.trailing,
+    this.padding = kFooterPadding,
+  });
+
+  final WizardAction? leading;
+  final List<WizardAction>? trailing;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  State<WizardBar> createState() => _WizardBarState();
+}
+
+class _WizardBarState extends State<WizardBar> {
+  @override
+  Widget build(BuildContext context) {
+    final wizardScope = Wizard.maybeOf(context);
+    final totalSteps = (wizardScope?.wizardData as int?);
+    final currentStep = (wizardScope?.routeData as int?);
+
+    return Hero(
+      tag: 'wizard-bottom-bar', // keep in place during page transitions
+      child: Container(
+        margin: widget.padding,
+        constraints:
+            const BoxConstraints(maxHeight: 36), // TODO: kYaruButtonHeight
+        child: NavigationToolbar(
+          leading: _buildAction(context, widget.leading),
+          middle: currentStep != null && totalSteps != null
+              ? YaruPageIndicator.builder(
+                  page: currentStep,
+                  length: totalSteps,
+                  itemSizeBuilder: (index, selectedIndex, length) =>
+                      Size.square(index == selectedIndex ? 12.0 : 8.0),
+                  layoutDelegate:
+                      YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
+                )
+              : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: widget.trailing
+                    ?.map((action) => _buildAction(context, action))
+                    .whereNotNull()
+                    .withSpacing(kButtonBarSpacing) ??
+                [],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget? _buildAction(BuildContext context, WizardAction? action) {
+    if (action == null || action.visible == false) {
+      return null;
+    }
+
+    final maybeActivate = action.enabled ?? true
+        ? () async {
+            await action.onActivated?.call();
+            if (mounted) action.execute?.call();
+          }
+        : null;
+
+    final child = Text(action.label!);
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 136),
+      child: action.highlighted == true
+          ? ElevatedButton(onPressed: maybeActivate, child: child)
+          : action.flat == true
+              ? OutlinedButton(onPressed: maybeActivate, child: child)
+              : FilledButton(onPressed: maybeActivate, child: child),
+    );
+  }
+}
+
+extension on Iterable<Widget> {
+  List<Widget> withSpacing(double spacing) {
+    return expand((item) sync* {
+      yield SizedBox(width: spacing);
+      yield item;
+    }).skip(1).toList();
+  }
+}

--- a/packages/ubuntu_wizard/lib/widgets.dart
+++ b/packages/ubuntu_wizard/lib/widgets.dart
@@ -5,4 +5,5 @@ export 'src/widgets/option_card.dart';
 export 'src/widgets/override_mouse_cursor.dart';
 export 'src/widgets/password_strength_label.dart';
 export 'src/widgets/validated_form_field.dart';
+export 'src/widgets/wizard_bar.dart';
 export 'src/widgets/wizard_page.dart';

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -13,9 +13,10 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: <WizardAction>[
-            WizardAction(label: 'action', onActivated: () => activated = true),
-          ],
+          bottomBar: WizardBar(
+            leading: WizardAction(
+                label: 'action', onActivated: () => activated = true),
+          ),
         ),
       ),
     );
@@ -35,10 +36,12 @@ void main() {
           header: const Text('header'),
           content: const Text('content'),
           snackBar: const SnackBar(content: Text('snackbar')),
-          actions: const <WizardAction>[
-            WizardAction(label: 'back'),
-            WizardAction(label: 'next'),
-          ],
+          bottomBar: WizardBar(
+            leading: WizardAction(label: 'back'),
+            trailing: [
+              WizardAction(label: 'next'),
+            ],
+          ),
         ),
       ),
     );
@@ -76,11 +79,13 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: const <WizardAction>[
-            WizardAction(label: 'normal'),
-            WizardAction(label: 'flat', flat: true),
-            WizardAction(label: 'highlighted', highlighted: true),
-          ],
+          bottomBar: WizardBar(
+            trailing: [
+              WizardAction(label: 'normal'),
+              WizardAction(label: 'flat', flat: true),
+              WizardAction(label: 'highlighted', highlighted: true),
+            ],
+          ),
         ),
       ),
     );
@@ -95,13 +100,15 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: <WizardAction>[
-            WizardAction(
-              label: 'action',
-              enabled: false,
-              onActivated: () => activated = true,
-            ),
-          ],
+          bottomBar: WizardBar(
+            trailing: [
+              WizardAction(
+                label: 'action',
+                enabled: false,
+                onActivated: () => activated = true,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -117,9 +124,11 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: WizardPage(
-          actions: const <WizardAction>[
-            WizardAction(label: 'action', visible: false),
-          ],
+          bottomBar: WizardBar(
+            trailing: [
+              WizardAction(label: 'action', visible: false),
+            ],
+          ),
         ),
       ),
     );
@@ -141,10 +150,12 @@ void main() {
           '/': WizardRoute(builder: (_) {
             return Builder(builder: (context) {
               return WizardPage(
-                actions: <WizardAction>[
-                  WizardAction.back(context),
-                  WizardAction.next(context),
-                ],
+                bottomBar: WizardBar(
+                  leading: WizardAction.back(context),
+                  trailing: [
+                    WizardAction.next(context),
+                  ],
+                ),
               );
             });
           }),
@@ -177,6 +188,7 @@ void main() {
       '/foo': WizardRoute(
         builder: (context) => WizardPage(
           content: const Text('Page 4 of 7'),
+          bottomBar: WizardBar(),
         ),
         userData: 3,
       ),

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -77,16 +77,18 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
           ],
         );
       }),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          highlighted: true,
-          label: lang.setupButton,
-          enabled: model.isValid,
-          onNext: model.saveAdvancedSetup,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            highlighted: true,
+            label: lang.setupButton,
+            enabled: model.isValid,
+            onNext: model.saveAdvancedSetup,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/configuration_ui/configuration_ui_page.dart
@@ -94,16 +94,18 @@ class _ConfigurationUIPageState extends State<ConfigurationUIPage> {
           ),
         ],
       ),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          highlighted: true,
-          label: lang.saveButton,
-          enabled: model.isValid,
-          onNext: model.saveConfiguration,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            highlighted: true,
+            label: lang.saveButton,
+            enabled: model.isValid,
+            onNext: model.saveConfiguration,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -98,15 +98,17 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
           ],
         );
       }),
-      actions: <WizardAction>[
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          enabled: model.isValid,
-          arguments: model.showAdvancedOptions,
-          onNext: model.saveProfileSetup,
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            enabled: model.isValid,
+            arguments: model.showAdvancedOptions,
+            onNext: model.saveProfileSetup,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_page.dart
@@ -103,16 +103,18 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
           ),
         ],
       ),
-      actions: [
-        WizardAction.back(context),
-        WizardAction.next(
-          context,
-          onNext: () {
-            model.applyInstallLanguagePacks();
-            model.applyLocale(model.locale(model.selectedLanguageIndex));
-          },
-        ),
-      ],
+      bottomBar: WizardBar(
+        leading: WizardAction.back(context),
+        trailing: [
+          WizardAction.next(
+            context,
+            onNext: () {
+              model.applyInstallLanguagePacks();
+              model.applyLocale(model.locale(model.selectedLanguageIndex));
+            },
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
A single list of actions was convenient when they all used to be on the right. Since then, we've moved the back button to the other side, added a page indicator, and we might soon want to run animations too. This is a simple preparation step for giving individual pages more control over the bottom bar.