### PR TITLE
snapcraft: set non-snap environment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,10 @@ apps:
     command: bin/subiquity-server
     daemon: simple
     restart-condition: always
+    environment:
+      PATH_ORIG: $PATH
+      PYTHONPATH_ORIG: $PYTHONPATH
+      LD_LIBRARY_PATH_ORIG: $LD_LIBRARY_PATH
 
   subiquity-loadkeys:
     command: bin/subiquity/bin/subiquity-loadkeys


### PR DESCRIPTION
`netplan apply` wants to run without this environment setup. Lay the groudwork for a subiquity patch that will run netplan without these environment changes.