### PR TITLE
snapcraft: update curtin to pickup ventoy fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: b1f4da3bec92356e8ef389c1c581cfdcd1b36c42
+    source-commit: 650a5af561fed5be811e7e2d5c101334c05257ba
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
Multiple users reported a crash early in the install on the desktop installer. It turned out they all were running the installer through ventoy.

A fix was done in curtin. Let's pick it up for the desktop installer so installs stop crashing.

Launchpad bug: https://bugs.launchpad.net/subiquity/+bug/2012722 (15+ duplicates)

(I don't know if `main` is the only branch that needs to be updated to fix the daily build)