### PR TITLE
ProxyAssetBundle: use synchronous IO lookups

### DIFF
--- a/packages/ubuntu_wizard/lib/src/utils/proxy_asset_bundle.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/proxy_asset_bundle.dart
@@ -18,30 +18,30 @@ class ProxyAssetBundle extends AssetBundle {
 
   @override
   Future<ByteData> load(String key) {
-    return _findAsset(key, package: package).then(source.load);
+    final asset = _findAsset(key, package: package);
+    return source.load(asset);
   }
 
   @override
   Future<T> loadStructuredData<T>(String key, StructuredDataParser<T> parser) {
-    return _findAsset(key, package: package).then((asset) {
-      return source.loadStructuredData<T>(asset, parser);
-    });
+    final asset = _findAsset(key, package: package);
+    return source.loadStructuredData<T>(asset, parser);
   }
 
-  Future<String> _findAsset(String assetName, {required String package}) async {
+  String _findAsset(String assetName, {required String package}) {
     // <app>/data/flutter_assets/
     final exePath = Platform.resolvedExecutable;
     final bundlePath = p.join(p.dirname(exePath), 'data', 'flutter_assets');
 
     // <bundle>/assets/foo.png
     final appAsset = File(p.join(bundlePath, assetName));
-    if (await appAsset.exists()) {
+    if (appAsset.existsSync()) {
       return appAsset.path;
     }
 
     // <bundle>/packages/<package>/assets/foo.png
     final pkgAsset = File(p.join(bundlePath, 'packages', package, assetName));
-    if (await pkgAsset.exists()) {
+    if (pkgAsset.existsSync()) {
       return pkgAsset.path;
     }
 

--- a/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
+++ b/packages/ubuntu_wizard/test/proxy_asset_bundle_test.dart
@@ -133,7 +133,7 @@ class MockFileCreator {
   final Set<String> paths;
   File call(String path) {
     final file = MockFile(path);
-    when(file.exists()).thenAnswer((_) async => paths.contains(path));
+    when(file.existsSync()).thenReturn(paths.contains(path));
     return file;
   }
 }
@@ -145,18 +145,10 @@ class MockFile extends Mock implements File {
   final String path;
 
   @override
-  Future<bool> exists() {
+  bool existsSync() {
     return super.noSuchMethod(
-      Invocation.method(#exists, []),
-      returnValue: Future.value(false),
-    );
-  }
-
-  @override
-  Future<String> resolveSymbolicLinks() {
-    return super.noSuchMethod(
-      Invocation.method(#resolveSymbolicLinks, []),
-      returnValue: Future.value(''),
+      Invocation.method(#existsSync, []),
+      returnValue: false,
     );
   }
 }


### PR DESCRIPTION
`ProxyAssetBundle` (#713) takes care of looking up image assets so that flavors can optionally override them. For example, `ubuntu-flavor-installer/assets/mascot.png` would override `packages/ubuntu-desktop-installer/assets/mascot.png` but it would fall back to the U-D-I asset if the flavor did not provide its own mascot image.

While resolving each asset, `ProxyAssetBundle` was doing up to two asynchronous `File.exists()` calls. While it's generally a good idea to use asynchronous APIs to avoid blocking the GUI, these asynchronous lookups would cause us to miss frames whenever looking up assets because the result would never be available within the same frame that requested the asset.

See also:
- #1743
- #1746
- #1749