### PR TITLE
Allow passing arbitrary CLI args to subiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -215,6 +215,7 @@ void main() {
   testWidgets('alongside windows', (tester) async {
     await app.main(<String>[
       '--machine-config=examples/win10-along-ubuntu.json',
+      '--',
       '--bootloader=uefi',
     ]);
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -52,7 +52,6 @@ Future<void> runInstallerApp(
         valueHelp: 'path',
         defaultsTo: 'examples/mixed-sources.yaml',
         help: 'Path of the source catalog (dry-run only)');
-    parser.addOption('bootloader', hide: true);
     parser.addFlag('try-or-install', hide: true);
   })!;
 
@@ -111,9 +110,8 @@ Future<void> runInstallerApp(
         '--machine-config=${options['machine-config']}',
       if (options['source-catalog'] != null)
         '--source-catalog=${options['source-catalog']}',
-      if (options['bootloader'] != null)
-        '--bootloader=${options['bootloader']}',
       '--storage-version=2',
+      ...options.rest,
     ],
     dispose: () => getService<DesktopService>().close(),
   );

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -138,12 +138,6 @@ Can also be specified in a LOG_LEVEL environment variable.
   if (options?['help'] == true) {
     _printUsage(parser.usage, out: out, exit: exit);
   }
-  if (options?.rest.isNotEmpty == true) {
-    _printUsage(parser.usage,
-        error: 'Unknown positional arguments "${options!.rest.join(' ')}"',
-        out: out,
-        exit: exit);
-  }
   return options;
 }
 

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -108,12 +108,13 @@ void main() {
     expect(didExit, equals(1));
 
     didExit = null;
-    parseCommandLine(
-      ['unknown rest arguments'],
+    final rest = parseCommandLine(
+      ['--', 'subiquity', 'arguments'],
       out: out,
       exit: (exitCode) => didExit = exitCode,
-    );
-    expect(didExit, equals(1));
+    )?.rest;
+    expect(didExit, isNull);
+    expect(rest, ['subiquity', 'arguments']);
   });
 
   testWidgets('starts and registers the monitor', (tester) async {


### PR DESCRIPTION
Separated by `--`, the rest are forwarded to subiquity. For example, `--foo` goes to UDI whereas `--bar --baz` goes to subiquity:

```
./ubuntu-desktop-installer --foo -- --bar --baz
```

This way, we don't need to duplicate subiquity's arguments in the GUI but one can pass arguments straight to subiquity and that way test more exotic use cases with help of dry-run mode, custom machine config, and socket path even in a live session. We might still need to tweak the socket path lookup on the GUI side to avoid arbitrary paths but that comes separately if even necessary.