### PR TITLE
Remove animated auto-scrolling in language & keyboard layout lists

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard_layout/keyboard_layout_page.dart
@@ -1,8 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
@@ -13,8 +10,6 @@ import '../../l10n.dart';
 import '../../services.dart';
 import 'keyboard_layout_dialogs.dart';
 import 'keyboard_layout_model.dart';
-
-const _kScrollDuration = Duration(milliseconds: 1);
 
 class KeyboardLayoutPage extends StatefulWidget {
   const KeyboardLayoutPage({
@@ -33,38 +28,16 @@ class KeyboardLayoutPage extends StatefulWidget {
 }
 
 class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
-  final _layoutListFocusNode = FocusNode();
-  final _layoutListScrollController = AutoScrollController();
-
-  StreamSubscription<int>? _layoutChanged;
-
   @override
   void initState() {
     super.initState();
 
     final model = Provider.of<KeyboardLayoutModel>(context, listen: false);
-    model.init().then((_) {
-      _scrollToLayout(model.selectedLayoutIndex, AutoScrollPosition.middle);
-      model.updateInputSource();
-    });
-
-    _layoutChanged = model.onLayoutSelected.listen(_scrollToLayout);
-  }
-
-  void _scrollToLayout(int index, [AutoScrollPosition? position]) {
-    if (index == -1) return;
-    _layoutListScrollController.scrollToIndex(
-      index,
-      preferPosition: position,
-      duration: _kScrollDuration,
-    );
+    model.init().then((_) => model.updateInputSource());
   }
 
   @override
   void dispose() {
-    _layoutListFocusNode.dispose();
-    _layoutListScrollController.dispose();
-    _layoutChanged?.cancel();
     super.dispose();
   }
 
@@ -103,40 +76,21 @@ class _KeyboardLayoutPageState extends State<KeyboardLayoutPage> {
               child: Row(
                 children: <Widget>[
                   Expanded(
-                    child: KeySearch(
-                      autofocus: true,
-                      focusNode: _layoutListFocusNode,
-                      onSearch: (value) {
+                    child: ListWidget.builder(
+                      selectedIndex: model.selectedLayoutIndex,
+                      itemCount: model.layoutCount,
+                      itemBuilder: (context, index) => ListTile(
+                        key: ValueKey(index),
+                        title: Text(model.layoutName(index)),
+                        selected: index == model.selectedLayoutIndex,
+                        onTap: () => model.selectLayout(index),
+                      ),
+                      onKeySearch: (value) {
                         final index = model.searchLayout(value);
                         if (index != -1) {
                           model.selectLayout(index);
                         }
                       },
-                      child: FocusTraversalGroup(
-                        policy: WidgetOrderTraversalPolicy(),
-                        child: YaruBorderContainer(
-                          clipBehavior: Clip.antiAlias,
-                          child: ListView.builder(
-                            controller: _layoutListScrollController,
-                            itemCount: model.layoutCount,
-                            itemBuilder: (context, index) {
-                              return AutoScrollTag(
-                                index: index,
-                                key: ValueKey(index),
-                                controller: _layoutListScrollController,
-                                child: ListTile(
-                                  title: Text(model.layoutName(index)),
-                                  selected: index == model.selectedLayoutIndex,
-                                  onTap: () {
-                                    model.selectLayout(index);
-                                    _layoutListFocusNode.requestFocus();
-                                  },
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                      ),
                     ),
                   ),
                 ],

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/widgets/mascot_avatar.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -31,9 +29,6 @@ class WelcomePage extends StatefulWidget {
 }
 
 class _WelcomePageState extends State<WelcomePage> {
-  final _languageListFocusNode = FocusNode();
-  final _languageListScrollController = AutoScrollController();
-
   @override
   void initState() {
     super.initState();
@@ -41,30 +36,16 @@ class _WelcomePageState extends State<WelcomePage> {
     final model = Provider.of<WelcomeModel>(context, listen: false);
     model.loadLanguages().then((_) {
       model.selectLocale(InheritedLocale.of(context));
-
-      _selectAndScrollToLanguage(
-          model.selectedLanguageIndex, AutoScrollPosition.middle);
     });
   }
 
-  @override
-  void dispose() {
-    _languageListFocusNode.dispose();
-    _languageListScrollController.dispose();
-    super.dispose();
-  }
-
-  void _selectAndScrollToLanguage(int index, [AutoScrollPosition? position]) {
+  void _selectLanguage(int index) {
     if (index == -1) return;
 
     final model = context.read<WelcomeModel>();
     model.selectedLanguageIndex = index;
 
     InheritedLocale.apply(context, model.locale(index));
-
-    _languageListFocusNode.requestFocus();
-    _languageListScrollController.scrollToIndex(index,
-        preferPosition: position, duration: const Duration(milliseconds: 1));
   }
 
   @override
@@ -86,31 +67,21 @@ class _WelcomePageState extends State<WelcomePage> {
             Text(lang.welcomeHeader),
             const SizedBox(height: kContentSpacing / 2),
             Expanded(
-              child: KeySearch(
-                autofocus: true,
-                focusNode: _languageListFocusNode,
-                onSearch: (value) {
-                  _selectAndScrollToLanguage(model.searchLanguage(value));
-                },
-                child: YaruBorderContainer(
-                  clipBehavior: Clip.antiAlias,
-                  child: ListView.builder(
-                    controller: _languageListScrollController,
-                    itemCount: model.languageCount,
-                    itemBuilder: (context, index) {
-                      return AutoScrollTag(
-                        index: index,
-                        key: ValueKey(index),
-                        controller: _languageListScrollController,
-                        child: ListTile(
-                          title: Text(model.language(index)),
-                          selected: index == model.selectedLanguageIndex,
-                          onTap: () => _selectAndScrollToLanguage(index),
-                        ),
-                      );
-                    },
-                  ),
+              child: ListWidget.builder(
+                selectedIndex: model.selectedLanguageIndex,
+                itemCount: model.languageCount,
+                itemBuilder: (context, index) => ListTile(
+                  key: ValueKey(index),
+                  title: Text(model.language(index)),
+                  selected: index == model.selectedLanguageIndex,
+                  onTap: () => _selectLanguage(index),
                 ),
+                onKeySearch: (value) {
+                  final index = model.searchLanguage(value);
+                  if (index != -1) {
+                    _selectLanguage(index);
+                  }
+                },
               ),
             ),
             const SizedBox(height: kContentSpacing),

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -62,7 +62,7 @@ void main() {
   testWidgets('should display a list of languages', (tester) async {
     await setUpApp(tester);
 
-    final languageList = find.byType(ListView);
+    final languageList = find.byType(ListWidget);
     expect(languageList, findsOneWidget);
 
     expect(InheritedLocale.of(tester.element(languageList)).languageCode, 'en');
@@ -72,8 +72,8 @@ void main() {
     expect(listItems, findsWidgets);
     expect(listItems.evaluate().length, lessThan(app.supportedLocales.length));
     for (final language in ['English', 'Français', 'Galego', 'Italiano']) {
-      final listItem = find.descendant(
-          of: languageList, matching: find.text(language), skipOffstage: false);
+      final listItem =
+          find.widgetWithText(ListTile, language, skipOffstage: false);
       await tester.dragUntilVisible(listItem, languageList, Offset(0, -10));
       await tester.pumpAndSettle();
       expect(listItem, findsOneWidget);
@@ -119,7 +119,7 @@ void main() {
   testWidgets('key search', (tester) async {
     await setUpApp(tester);
 
-    final languageList = find.byType(ListView);
+    final languageList = find.byType(ListWidget);
     expect(languageList, findsOneWidget);
 
     final keySearch = find.byType(KeySearch);

--- a/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
@@ -1,0 +1,107 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class ListWidget extends StatefulWidget {
+  const ListWidget.builder({
+    super.key,
+    required this.itemCount,
+    required this.itemBuilder,
+    this.selectedIndex = -1,
+    this.onKeySearch,
+  });
+
+  final int selectedIndex;
+  final int itemCount;
+  final IndexedWidgetBuilder itemBuilder;
+  final ValueChanged<String>? onKeySearch;
+
+  @override
+  State<ListWidget> createState() => _ListWidgetState();
+}
+
+class _ListWidgetState extends State<ListWidget> {
+  final _focusNode = FocusNode();
+  final _scrollableKey = GlobalKey();
+  final _scrollController = ItemScrollController();
+  final _scrollListener = ItemPositionsListener.create();
+
+  @override
+  void didUpdateWidget(ListWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIndex != widget.selectedIndex) {
+      _scrollTo(widget.selectedIndex);
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _scrollTo(int index) {
+    if (index == -1) return;
+
+    final pos = _scrollListener.itemPositions.value
+        .firstWhereOrNull((item) => item.index == index);
+    if (pos == null) {
+      // the item does not exist in the viewport. jump and align the center.
+      final box =
+          _scrollableKey.currentContext?.findRenderObject() as RenderBox?;
+      if (box != null) {
+        _scrollController.jumpTo(
+          index: index,
+          alignment: _centerAlign(context, box.size.height),
+        );
+      }
+    } else if (pos.itemLeadingEdge < 0) {
+      // partly above the viewport, align the top edge
+      _scrollController.jumpTo(index: index, alignment: 0);
+    } else if (pos.itemTrailingEdge > 1) {
+      // partly below the viewport, align the bottom edge
+      _scrollController.jumpTo(
+        index: index,
+        alignment: 1 - pos.itemTrailingEdge + pos.itemLeadingEdge,
+      );
+    }
+
+    _focusNode.requestFocus();
+  }
+
+  static double _centerAlign(BuildContext context, double totalHeight) {
+    final theme = ListTileTheme.of(context);
+    final tileHeight = theme.dense == true ? kMinInteractiveDimension : 56;
+    return 0.5 - tileHeight / totalHeight / 2;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return YaruBorderContainer(
+      clipBehavior: Clip.antiAlias,
+      child: KeySearch(
+        autofocus: true,
+        focusNode: _focusNode,
+        onSearch: widget.onKeySearch ?? (_) => -1,
+        child: widget.itemCount > 0
+            ? LayoutBuilder(
+                builder: (context, constraints) {
+                  return ScrollablePositionedList.builder(
+                    key: _scrollableKey,
+                    initialAlignment:
+                        _centerAlign(context, constraints.maxHeight),
+                    initialScrollIndex: widget.selectedIndex,
+                    itemScrollController: _scrollController,
+                    itemPositionsListener: _scrollListener,
+                    itemCount: widget.itemCount,
+                    itemBuilder: widget.itemBuilder,
+                  );
+                },
+              )
+            : const SizedBox.expand(),
+      ),
+    );
+  }
+}

--- a/packages/ubuntu_wizard/lib/widgets.dart
+++ b/packages/ubuntu_wizard/lib/widgets.dart
@@ -1,6 +1,7 @@
 export 'src/widgets/animated_expanded.dart';
 export 'src/widgets/flavor.dart';
 export 'src/widgets/icons.dart';
+export 'src/widgets/list_widget.dart';
 export 'src/widgets/option_card.dart';
 export 'src/widgets/override_mouse_cursor.dart';
 export 'src/widgets/password_strength_label.dart';

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   password_strength: ^0.2.0
   path: ^1.8.0
   safe_change_notifier: ^0.2.0
+  scrollable_positioned_list: ^0.3.5
   subiquity_client:
     git:
       url: https://github.com/canonical/subiquity_client.dart.git

--- a/packages/ubuntu_wizard/test/list_widget_test.dart
+++ b/packages/ubuntu_wizard/test/list_widget_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+
+void main() {
+  testWidgets('center-align initial index', (tester) async {
+    final selectedIndex = ValueNotifier<int>(50);
+
+    await tester.pumpListWidget(selectedIndex);
+
+    final listWidget = find.byType(ListWidget);
+    expect(listWidget, findsOneWidget);
+
+    final listTile = find.widgetWithText(ListTile, '50');
+    expect(listTile, findsOneWidget);
+    expect(tester.getCenter(listTile), tester.getCenter(listWidget));
+  });
+
+  testWidgets('top-align first visible', (tester) async {
+    final selectedIndex = ValueNotifier<int>(50);
+
+    await tester.pumpListWidget(selectedIndex);
+
+    final listWidget = find.byType(ListWidget);
+    expect(listWidget, findsOneWidget);
+
+    var i = selectedIndex.value - 1;
+    while (tester.getRect(find.widgetWithText(ListTile, '$i')).top >=
+        tester.getRect(find.byType(ListWidget)).top) {
+      --i;
+    }
+    expect(i, lessThan(selectedIndex.value));
+
+    final listTile = find.widgetWithText(ListTile, '$i');
+    expect(tester.getRect(listTile).top,
+        lessThan(tester.getRect(find.byType(ListWidget)).top));
+
+    selectedIndex.value = i;
+    await tester.pumpAndSettle();
+
+    expect(tester.getRect(listTile).top,
+        equals(tester.getRect(find.byType(ListWidget)).top));
+  });
+
+  testWidgets('bottom-align last visible', (tester) async {
+    final selectedIndex = ValueNotifier<int>(50);
+
+    await tester.pumpListWidget(selectedIndex);
+
+    final listWidget = find.byType(ListWidget);
+    expect(listWidget, findsOneWidget);
+
+    var i = selectedIndex.value + 1;
+    while (tester.getRect(find.widgetWithText(ListTile, '$i')).bottom <=
+        tester.getRect(find.byType(ListWidget)).bottom) {
+      ++i;
+    }
+    expect(i, greaterThan(selectedIndex.value));
+
+    final listTile = find.widgetWithText(ListTile, '$i');
+    expect(tester.getRect(listTile).bottom,
+        greaterThan(tester.getRect(find.byType(ListWidget)).bottom));
+
+    selectedIndex.value = i;
+    await tester.pumpAndSettle();
+
+    expect(tester.getRect(listTile).bottom,
+        equals(tester.getRect(find.byType(ListWidget)).bottom));
+  });
+
+  testWidgets('center-align non-visible', (tester) async {
+    final selectedIndex = ValueNotifier<int>(0);
+
+    await tester.pumpListWidget(selectedIndex);
+
+    final listWidget = find.byType(ListWidget);
+    expect(listWidget, findsOneWidget);
+
+    final listTile = find.widgetWithText(ListTile, '50');
+    expect(listTile, findsNothing);
+
+    selectedIndex.value = 50;
+    await tester.pumpAndSettle();
+
+    expect(listTile, findsOneWidget);
+    expect(tester.getCenter(listTile), tester.getCenter(listWidget));
+  });
+}
+
+extension on WidgetTester {
+  Future<void> pumpListWidget(ValueNotifier<int> selectedIndex) {
+    return pumpWidget(MaterialApp(
+      theme: ThemeData(listTileTheme: const ListTileThemeData(dense: true)),
+      home: Scaffold(
+        body: ValueListenableBuilder<int>(
+          valueListenable: selectedIndex,
+          builder: (context, value, child) {
+            return ListWidget.builder(
+              selectedIndex: value,
+              itemCount: 100,
+              itemBuilder: (context, index) => ListTile(
+                title: Text('$index'),
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+  }
+}


### PR DESCRIPTION
### Before

[auto-scrolling-before.webm](https://user-images.githubusercontent.com/140617/229713925-f83ec2a8-5f89-4159-b2e5-74e2c90fa6ad.webm)

### After

[auto-scrolling-after.webm](https://user-images.githubusercontent.com/140617/229713938-b6740ae4-3579-4b8e-8ec6-85ac78bbd70c.webm)

P.S. I switched to the [scrollable_positioned_list](https://pub.dev/packages/scrollable_positioned_list) package because it supports an initial scroll position and unlike the previously used [scroll_to_index](https://pub.dev/packages/scroll_to_index), it's also able to jump [without a delay](https://github.com/quire-io/scroll-to-index/blob/be171b267f318e47436fdfb134e30fd5ce7b2efb/lib/scroll_to_index.dart#L216).

Close: #1499