### PR TITLE
scripts/update-subiquity: remove git submodule calls

### DIFF
--- a/scripts/update-subiquity-deps
+++ b/scripts/update-subiquity-deps
@@ -1,15 +1,6 @@
 #!/usr/bin/env python3
 
-import subprocess
 from ruamel.yaml import YAML
-
-# update subiquity_client to remote HEAD
-submodule = 'packages/subiquity_client'
-cmd = 'git submodule update --init --remote ' + submodule
-subprocess.check_call(cmd.split(' '))
-# update subiquity_client's submodules
-cmd = 'git submodule update --init --recursive ' + submodule
-subprocess.check_call(cmd.split(' '))
 
 yaml = YAML()
 yaml.default_flow_style = False


### PR DESCRIPTION
Dedicate this script for updating the sha1's of subiquity dependencies and let the user decide which subiquity_client revision is checked out.

The git submodule calls are not only unnecessary whenever checking out dependabot branches that have already bumped the submodule but can also create problems because `git submodule update --remote` defaults to the `origin` remote which may point to a personal fork when following GitHub's recommended workflows. In that case, it would have to use the `upstream` remote instead but we cannot assume that either because it's just a recommendation.