### PR TITLE
Replace hard-coded SubiquityXxx instances with conditional services

### DIFF
--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -9,7 +9,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 /// @internal
@@ -49,11 +48,6 @@ Future<bool?> runWizardApp(
     subiquityClient.open(endpoint);
     return subiquityMonitor?.start(endpoint);
   });
-
-  registerServiceInstance(subiquityClient);
-  if (subiquityMonitor != null) {
-    registerServiceInstance(subiquityMonitor);
-  }
 
   WidgetsFlutterBinding.ensureInitialized();
   await setupAppLocalizations();

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
       url: https://github.com/canonical/subiquity_client.dart.git
   ubuntu_localizations: ^0.1.0
   ubuntu_logger: ^0.0.1
-  ubuntu_service: ^0.2.0
+  ubuntu_service: ^0.2.2
   ubuntu_widgets:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/mocks.dart';
 import 'package:ubuntu_wizard/app.dart';
@@ -17,7 +18,6 @@ import 'wizard_app_test.mocks.dart';
 @GenerateMocks([IOSink])
 void main() {
   final endpoint = Endpoint.unix('socket path');
-  tearDown(() => unregisterMockService<SubiquityClient>());
 
   setUpAll(() {
     final methodChannel = MethodChannel('yaru_window');
@@ -43,7 +43,7 @@ void main() {
     verify(client.open(endpoint)).called(1);
   });
 
-  testWidgets('registers the client', (tester) async {
+  testWidgets('does not register services', (tester) async {
     final client = MockSubiquityClient();
     final server = MockSubiquityServer();
     when(server.start(
@@ -51,14 +51,19 @@ void main() {
         .thenAnswer(
       (_) async => Endpoint.unix(''),
     );
+    final monitor = MockSubiquityStatusMonitor();
+    when(monitor.start(any)).thenAnswer((_) async => true);
 
     await runWizardApp(
       SizedBox(),
       subiquityClient: client,
       subiquityServer: server,
+      subiquityMonitor: monitor,
     );
 
-    expect(getService<SubiquityClient>(), equals(client));
+    expect(tryGetService<SubiquityClient>(), isNull);
+    expect(tryGetService<SubiquityServer>(), isNull);
+    expect(tryGetService<SubiquityStatusMonitor>(), isNull);
   });
 
   testWidgets('parse command-line arguments', (tester) async {
@@ -116,7 +121,7 @@ void main() {
     expect(didExit, equals(1));
   });
 
-  testWidgets('starts and registers the monitor', (tester) async {
+  testWidgets('starts the monitor', (tester) async {
     final endpoint = Endpoint.unix('/tmp/subiquity.sock');
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.start(endpoint)).thenAnswer((_) async => true);
@@ -133,7 +138,6 @@ void main() {
       subiquityClient: MockSubiquityClient(),
     );
 
-    expect(getService<SubiquityStatusMonitor>(), equals(monitor));
     verify(monitor.start(endpoint)).called(1);
   });
 

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -36,8 +36,9 @@ Future<void> main(List<String> args) async {
   );
   final serverArgs = serverArgsFromOptions(options);
 
-  final subiquityClient = SubiquityClient();
-  final subiquityMonitor = SubiquityStatusMonitor();
+  registerService(SubiquityClient.new);
+  registerService(() => SubiquityServer(process: process, endpoint: endpoint));
+  registerService(SubiquityStatusMonitor.new);
   registerService(UrlLauncher.new);
   registerService(LanguageFallbackService.linux);
   await runWizardApp(
@@ -46,20 +47,22 @@ Future<void> main(List<String> args) async {
       child: const UbuntuWslSetupApp(),
     ),
     options: options,
-    subiquityClient: subiquityClient,
-    subiquityServer: SubiquityServer(process: process, endpoint: endpoint),
-    subiquityMonitor: subiquityMonitor,
+    subiquityClient: getService<SubiquityClient>(),
+    subiquityServer: getService<SubiquityServer>(),
+    subiquityMonitor: getService<SubiquityStatusMonitor>(),
     serverArgs: serverArgs,
     serverEnvironment: {
       if (!liveRun && options['reconfigure'] == true) 'DRYRUN_RECONFIG': 'true',
     },
   );
+  final subiquityClient = getService<SubiquityClient>();
   await subiquityClient.variant().then((value) {
     if (value == Variant.WSL_SETUP) {
       isLocaleSet(subiquityClient).then(
         (isSet) => appModel.value =
             appModel.value.copyWith(variant: value, languageAlreadySet: isSet),
       );
+      final subiquityMonitor = getService<SubiquityStatusMonitor>();
       subiquityMonitor.onStatusChanged.listen((status) {
         window.setClosable(status?.state.isInstalling != true);
       });


### PR DESCRIPTION
To allow calling `runInstallerApp()` with pre-registered fake services for testing and screenshotting purposes.