### PR TITLE
postinst: don't apply default input source on the target

### DIFF
--- a/snap/local/postinst.d/10_override_desktop_settings
+++ b/snap/local/postinst.d/10_override_desktop_settings
@@ -22,7 +22,6 @@ dconf_dump() {
 
 dconf_dump a11y
 dconf_dump interface
-dconf_dump input-sources
 dconf_dump peripherals
 dconf_dump wm
 


### PR DESCRIPTION
Let it be picked from `/etc/default/keyboard` instead.