### PR TITLE
ListWidget: guard against empty size constraints

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
@@ -85,22 +85,24 @@ class _ListWidgetState extends State<ListWidget> {
         autofocus: true,
         focusNode: _focusNode,
         onSearch: widget.onKeySearch ?? (_) => -1,
-        child: widget.itemCount > 0
-            ? LayoutBuilder(
-                builder: (context, constraints) {
-                  return ScrollablePositionedList.builder(
-                    key: _scrollableKey,
-                    initialAlignment:
-                        _centerAlign(context, constraints.maxHeight),
-                    initialScrollIndex: widget.selectedIndex,
-                    itemScrollController: _scrollController,
-                    itemPositionsListener: _scrollListener,
-                    itemCount: widget.itemCount,
-                    itemBuilder: widget.itemBuilder,
-                  );
-                },
-              )
-            : const SizedBox.expand(),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            if (widget.itemCount <= 0 ||
+                constraints.maxWidth <= 0 ||
+                constraints.maxHeight <= 0) {
+              return const SizedBox.expand();
+            }
+            return ScrollablePositionedList.builder(
+              key: _scrollableKey,
+              initialAlignment: _centerAlign(context, constraints.maxHeight),
+              initialScrollIndex: widget.selectedIndex,
+              itemScrollController: _scrollController,
+              itemPositionsListener: _scrollListener,
+              itemCount: widget.itemCount,
+              itemBuilder: widget.itemBuilder,
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
I'm not sure why this only happens in snap+live but the entire app gets briefly built with 0x0 size which breaks the initial offset calculation of `ScrollablePositionedList`.

Close: #1782
Close: #1783