### PR TITLE
DiskStorageService.setGuidedStorage(): remove unused return value

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -103,8 +103,8 @@ class DiskStorageService {
   }
 
   /// Sets the selected target for guided partitioning.
-  Future<GuidedStorageResponseV2> setGuidedStorage() async {
-    return _client.setGuidedStorageV2(
+  Future<void> setGuidedStorage() async {
+    await _client.setGuidedStorageV2(
       GuidedChoiceV2(
         target: guidedTarget!,
         useLvm: useLvm,

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -154,21 +154,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i4.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
@@ -154,21 +154,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i4.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -165,21 +165,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i5.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i5.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i5.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i5.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i5.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -167,21 +167,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i5.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i5.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i5.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i5.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i5.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
   _i5.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -154,21 +154,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i4.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -154,21 +154,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i4.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -154,21 +154,14 @@ class MockDiskStorageService extends _i1.Mock
         )),
       ) as _i4.Future<_i2.GuidedStorageResponseV2>);
   @override
-  _i4.Future<_i2.GuidedStorageResponseV2> setGuidedStorage() =>
-      (super.noSuchMethod(
+  _i4.Future<void> setGuidedStorage() => (super.noSuchMethod(
         Invocation.method(
           #setGuidedStorage,
           [],
         ),
-        returnValue: _i4.Future<_i2.GuidedStorageResponseV2>.value(
-            _FakeGuidedStorageResponseV2_0(
-          this,
-          Invocation.method(
-            #setGuidedStorage,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.GuidedStorageResponseV2>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<List<_i2.Disk>> getStorage() => (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
This is a noisy preparation step for applying the storage config from setGuidedStorage().