### PR TITLE
Apply storage config after sending the guided choice

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -43,7 +43,6 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
 
   /// Starts the installation process.
   Future<void> startInstallation() async {
-    await _service.setStorage();
     _service.securityKey = null; // no longer needed
     await _client.confirm('/dev/tty1');
   }

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -112,6 +112,7 @@ class DiskStorageService {
         sizingPolicy: SizingPolicy.ALL,
       ),
     );
+    await _client.setStorageV2();
   }
 
   List<Disk> _updateStorage(StorageResponseV2 response) {

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -52,11 +52,13 @@ void main() {
     );
     when(client.setGuidedStorageV2(choice))
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
+    when(client.setStorageV2()).thenAnswer((_) async => testStorageResponse());
 
     final service = DiskStorageService(client);
     service.guidedTarget = target;
     await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
+    verify(client.setStorageV2()).called(1);
   });
 
   test('use LVM', () async {
@@ -68,6 +70,7 @@ void main() {
     );
     when(client.setGuidedStorageV2(choice))
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
+    when(client.setStorageV2()).thenAnswer((_) async => testStorageResponse());
 
     final service = DiskStorageService(client);
     service.useLvm = true;
@@ -75,6 +78,7 @@ void main() {
     service.guidedTarget = target;
     await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
+    verify(client.setStorageV2()).called(1);
   });
 
   test('reset guided storage', () async {
@@ -275,6 +279,7 @@ void main() {
     );
     when(client.setGuidedStorageV2(choice))
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
+    when(client.setStorageV2()).thenAnswer((_) async => testStorageResponse());
     when(client.resetStorageV2())
         .thenAnswer((_) async => testStorageResponse());
 
@@ -298,6 +303,7 @@ void main() {
     );
     when(client.setGuidedStorageV2(choice))
         .thenAnswer((_) async => testGuidedStorageResponse(configured: choice));
+    when(client.setStorageV2()).thenAnswer((_) async => testStorageResponse());
 
     final service = DiskStorageService(client);
     await service.init();
@@ -308,6 +314,7 @@ void main() {
     service.guidedTarget = target;
     await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
+    verify(client.setStorageV2()).called(1);
   });
 
   test('has enough disk space', () async {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -112,7 +112,7 @@ void main() {
     await model.init();
     await model.startInstallation();
 
-    verify(service.setStorage()).called(1);
+    verifyNever(service.setStorage());
     verify(service.securityKey = null).called(1);
     verify(client.confirm('/dev/tty1')).called(1);
   });


### PR DESCRIPTION
For guided partitioning, the GUI collects input across several screens:

- Installation type: whether to use LVM or encryption
- Select disk: which disk to erase
- Install alongside: how much space to free up
- Choose security key: encryption password

These bits and pieces of information cannot be sent to Subiquity from each screen but must be collectively sent as a "guided choice". This is done when entering the confirmation screen because at that point all the necessary input has been collected.

When the guided storage target had been chosen, the user was presented with the resulting storage config which was then applied when the user pressed "Install". The problem was that udev events could invalidate the storage config while sitting at the confirmation screen, before pressing "Install".

Therefore, we have to change the flow so that in case of guided partitioning, the storage config is already applied when entering the confirmation screen, right after choosing the guided storage target.

## Before

#### Guided

- Choose a guided storage target when entering the confirmation screen
- Apply the storage config after pressing "Install"

#### Manual

- Apply the storage config when done with manual partitioning, before entering the confirmation screen

## After

#### Guided

- Choose a guided storage target _and_ apply the storage config when entering the confirmation screen

#### Manual

- No changes

Fixes: [LP#2012077](https://bugs.launchpad.net/subiquity/+bug/2012077)