### PR TITLE
DiskStorageService.setStorage(): remove confusing unused arg

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -176,7 +176,7 @@ class AllocateDiskSpaceModel extends SafeChangeNotifier {
 
   /// Applies storage via the service.
   Future<void> setStorage() {
-    return _service.setStorage(_disks).then(_updateDisks);
+    return _service.setStorage().then(_updateDisks);
   }
 
   /// Resets the storage via the service.

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -43,7 +43,7 @@ class WriteChangesToDiskModel extends SafeChangeNotifier {
 
   /// Starts the installation process.
   Future<void> startInstallation() async {
-    await _service.setStorage(disks.toList());
+    await _service.setStorage();
     _service.securityKey = null; // no longer needed
     await _client.confirm('/dev/tty1');
   }

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -168,8 +168,8 @@ class DiskStorageService {
     return _client.deletePartitionV2(disk, partition).then(_updateStorage);
   }
 
-  /// Applies the given storage configuration on the system.
-  Future<List<Disk>> setStorage(List<Disk> disks) {
+  /// Applies the current storage configuration on the system.
+  Future<List<Disk>> setStorage() {
     return _client.setStorageV2().then(_updateStorage);
   }
 

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.dart
@@ -42,14 +42,14 @@ void main() {
   test('set storage', () async {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => testDisks);
-    when(service.setStorage(testDisks)).thenAnswer((_) async => changedDisks);
+    when(service.setStorage()).thenAnswer((_) async => changedDisks);
 
     final model = AllocateDiskSpaceModel(service);
     await model.getStorage();
 
     await model.setStorage();
     expect(model.disks, equals(changedDisks));
-    verify(service.setStorage(testDisks)).called(1);
+    verify(service.setStorage()).called(1);
   });
 
   test('reset storage', () async {

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -226,11 +226,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i4.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/choose_security_key/choose_security_key_model_test.mocks.dart
@@ -226,11 +226,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i4.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -237,11 +237,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i5.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i5.Future<List<_i2.Disk>>);
   @override
-  _i5.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i5.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i5.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i5.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -239,11 +239,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i5.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i5.Future<List<_i2.Disk>>);
   @override
-  _i5.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i5.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i5.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i5.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -226,11 +226,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i4.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -226,11 +226,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i4.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -114,7 +114,7 @@ void main() {
         .thenAnswer((_) async => testStorageResponse(disks: testDisks));
 
     final service = DiskStorageService(client);
-    expect(await service.setStorage(testDisks), equals(testDisks));
+    expect(await service.setStorage(), equals(testDisks));
     verify(client.setStorageV2()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -106,13 +106,13 @@ void main() {
     when(service.guidedTarget).thenReturn(null);
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
-    when(service.setStorage(any)).thenAnswer((_) async => nonPreservedDisks);
+    when(service.setStorage()).thenAnswer((_) async => nonPreservedDisks);
 
     final model = WriteChangesToDiskModel(client, service);
     await model.init();
     await model.startInstallation();
 
-    verify(service.setStorage(nonPreservedDisks)).called(1);
+    verify(service.setStorage()).called(1);
     verify(service.securityKey = null).called(1);
     verify(client.confirm('/dev/tty1')).called(1);
   });

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -226,11 +226,10 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);
   @override
-  _i4.Future<List<_i2.Disk>> setStorage(List<_i2.Disk>? disks) =>
-      (super.noSuchMethod(
+  _i4.Future<List<_i2.Disk>> setStorage() => (super.noSuchMethod(
         Invocation.method(
           #setStorage,
-          [disks],
+          [],
         ),
         returnValue: _i4.Future<List<_i2.Disk>>.value(<_i2.Disk>[]),
       ) as _i4.Future<List<_i2.Disk>>);


### PR DESCRIPTION
The argument is an old left-over which is no longer used. This method applies the current storage configuration, whatever has been requested using either the guided or manual partitioning APIs. Dropping the unused arg helps to eliminate some confusion in #1791.