### PR TITLE
Replace ScrollablePositionedList with a plain ListView

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
@@ -53,6 +53,7 @@ class _ListWidgetState extends State<ListWidget> {
     final tileOffset = index * _kTileHeight;
     final viewHeight = box!.size.height;
 
+    // jump and center align the selected item is fully outside the viewport
     if (tileOffset < scrollOffset - _kTileHeight ||
         tileOffset > scrollOffset + viewHeight) {
       final center = tileOffset - viewHeight / 2 + _kTileHeight / 2;
@@ -77,6 +78,7 @@ class _ListWidgetState extends State<ListWidget> {
                 constraints.maxHeight <= 0) {
               return const SizedBox.expand();
             }
+            // calculate initial center-alignment
             _scrollController ??= ScrollController(
                 initialScrollOffset: widget.selectedIndex * _kTileHeight -
                     constraints.maxHeight / 2 +
@@ -88,6 +90,7 @@ class _ListWidgetState extends State<ListWidget> {
               itemBuilder: (context, index) => Builder(
                 builder: (context) {
                   if (index == widget.selectedIndex) {
+                    // bring a half-visible selected item into the viewport
                     context.findRenderObject()?.showOnScreen();
                   }
                   return widget.itemBuilder(context, index);

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   password_strength: ^0.2.0
   path: ^1.8.0
   safe_change_notifier: ^0.2.0
-  scrollable_positioned_list: ^0.3.5
   subiquity_client:
     git:
       url: https://github.com/canonical/subiquity_client.dart.git


### PR DESCRIPTION
ScrollablePositionedList creates problems with focus traversal and is probably overkill for what we need, anyway. Using a plain ListView and calculating the offsets ourselves helps to make arrow key navigation work sensibly in list views again. All alignment tests added in #1773 are passing.