### PR TITLE
WSL: adapt language sorting to loadLocalizedLanguages() changes

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/select_language/select_language_model.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:diacritic/diacritic.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -55,8 +56,7 @@ class SelectLanguageModel extends SafeChangeNotifier {
   /// Loads available languages.
   Future<void> loadLanguages() async {
     return loadLocalizedLanguages(supportedLocales).then((languages) {
-      _languages = languages;
-      _languages.sort((a, b) =>
+      _languages = languages.sorted((a, b) =>
           removeDiacritics(_languageFallback.displayNameFor(a)).compareTo(
               removeDiacritics(_languageFallback.displayNameFor(b))));
     }).then((_) => notifyListeners());

--- a/packages/ubuntu_wsl_setup/pubspec.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   args: ^2.2.0
+  collection: ^1.17.0
   diacritic: ^0.1.3
   flutter:
     sdk: flutter


### PR DESCRIPTION
It no longer returns a list but a lazy iterable. Don't try to assign it directly into a variable of List type:

```
ERROR: lib/pages/select_language/select_language_model.dart:58:20: Error: A value of type 'Iterable<LocalizedLanguage>' can't be assigned to a variable of type 'List<LocalizedLanguage>'.
ERROR:  - 'Iterable' is from 'dart:core'.
ERROR:  - 'LocalizedLanguage' is from 'package:ubuntu_localizations/src/localizations.dart' ('/opt/hostedtoolcache/flutter/stable-3.7.10-x64/.pub-cache/hosted/pub.dev/ubuntu_localizations-0.1.3/lib/src/localizations.dart').
ERROR:  - 'List' is from 'dart:core'.
ERROR:       _languages = languages;
ERROR:                    ^
```

Note: Flutter itself depends on the collection package. It's not a new dependency even if the diff suggests so.

See also:
- https://github.com/canonical/ubuntu-flutter-plugins/pull/174
- #1765