### PR TITLE
Installation slides: remove bogus spacing in the cinematic layout

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/slides/slide_layouts.dart
+++ b/packages/ubuntu_desktop_installer/lib/slides/slide_layouts.dart
@@ -343,7 +343,6 @@ class CinematicSlideLayout extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  const SizedBox(height: 16),
                   DefaultTextStyle(
                     style: _bodyStyle(context),
                     child: body,


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/231372279-8485ea64-c5b5-4807-a334-fafa8ae7f92a.png) | ![Screenshot from 2023-04-12 08-29-08](https://user-images.githubusercontent.com/140617/231370772-d816d20b-9dcb-4624-9119-d7caf8714e95.png) |
| ![Screenshot from 2023-04-12 08-28-33](https://user-images.githubusercontent.com/140617/231370724-bf7f074f-873f-4b71-968c-194271001f3f.png) | ![Screenshot from 2023-04-12 08-29-01](https://user-images.githubusercontent.com/140617/231370800-25e74a8a-b9cb-4011-9cc4-996af2af27e1.png) |

Spec:
![image](https://user-images.githubusercontent.com/140617/231371424-deb84a70-ceaf-4e75-8285-4c2d1cb78dd4.png)