### PR TITLE
(fix) WSL windows tests - `pumpAndSettle` no longer needed

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_test.dart
@@ -28,6 +28,5 @@ void main() {
       confirmedPassword: 'password123',
     );
     await testApplyingChangesPage(tester, expectClose: true);
-    await tester.pumpAndSettle();
   });
 }

--- a/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/e2e/setup_with_prefill_test.dart
@@ -24,6 +24,5 @@ void main() {
       confirmedPassword: 'password123',
     );
     await testApplyingChangesPage(tester, expectClose: true);
-    await tester.pumpAndSettle();
   });
 }


### PR DESCRIPTION
> This is test code fix. It shouldn't affect any other part of the apps.

It seems to be at least since we moved to YaruWindow. The test would hang forever waiting the circular progress indicator to finish, but it's infinite. Removing the `await tster.pumpAndSettle()` allows the window to close when the server exits, as it should.

