### PR TITLE
Installation summary: present all disks with any partition modifications

### DIFF
--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -45,9 +45,21 @@ void main() {
         Partition(number: 4, resize: true),
       ],
     ),
+    testDisk(
+      path: '/dev/sde',
+      preserve: true,
+      partitions: [
+        Partition(number: 1, preserve: true),
+      ],
+    ),
   ];
 
-  final nonPreservedDisks = <Disk>[testDisks[0], testDisks[1], testDisks[2]];
+  final modifiedDisks = <Disk>[
+    testDisks[0],
+    testDisks[1],
+    testDisks[2],
+    testDisks[3],
+  ];
 
   test('get storage', () async {
     final client = MockSubiquityClient();
@@ -64,7 +76,7 @@ void main() {
     ]);
     verifyNever(service.setGuidedStorage());
 
-    expect(model.disks, equals(nonPreservedDisks));
+    expect(model.disks, equals(modifiedDisks));
     expect(
       model.partitions,
       equals({
@@ -106,7 +118,7 @@ void main() {
     when(service.guidedTarget).thenReturn(null);
     when(service.getStorage()).thenAnswer((_) async => testDisks);
     when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
-    when(service.setStorage()).thenAnswer((_) async => nonPreservedDisks);
+    when(service.setStorage()).thenAnswer((_) async => modifiedDisks);
 
     final model = WriteChangesToDiskModel(client, service);
     await model.init();


### PR DESCRIPTION
The installation summary aims to present all file system changes. Make sure to include all disks that have any sort of partition modifications to avoid confusing and mismatching lists of disks vs. partitions. In other words, use the same filter condition for finding disks with modified partitions and the flattened list of modified partitions.

| Before | After |
|--------|--------|
| ![Screenshot from 2023-04-17 14-08-30](https://user-images.githubusercontent.com/140617/232493547-260e8dc5-2d0a-40e6-905d-73209cb33f87.png) | ![Screenshot from 2023-04-17 14-08-55](https://user-images.githubusercontent.com/140617/232493565-41749031-5af5-4718-9749-c8d3e4312775.png) | 

Ref: #1817
