### PR TITLE
Installation summary: fix NVME partition formatting

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -163,35 +163,35 @@ class _PartitionLabel extends StatelessWidget {
   String formatPartition(AppLocalizations lang) {
     if (partition.resize == true) {
       return lang.writeChangesPartitionResized(
-        sysname,
-        partition.number ?? 0,
+        '', // TODO: remove unused {disk} argument
+        partition.sysname,
         filesize(original?.size ?? 0),
         filesize(partition.size ?? 0),
       );
     } else if (partition.wipe != null && partition.mount?.isNotEmpty == true) {
       return lang.writeChangesPartitionFormattedMounted(
-        sysname,
-        partition.number ?? 0,
+        '', // TODO: remove unused {disk} argument
+        partition.sysname,
         partition.format ?? '',
         partition.mount ?? '',
       );
     } else if (partition.wipe != null && partition.format?.isNotEmpty == true) {
       return lang.writeChangesPartitionFormatted(
-        sysname,
-        partition.number ?? 0,
+        '', // TODO: remove unused {disk} argument
+        partition.sysname,
         partition.format ?? '',
       );
     } else if (partition.mount?.isNotEmpty == true) {
       return lang.writeChangesPartitionMounted(
-        sysname,
-        partition.number ?? 0,
+        '', // TODO: remove unused {disk} argument
+        partition.sysname,
         partition.mount ?? '',
       );
     } else {
       assert(partition.preserve == false);
       return lang.writeChangesPartitionCreated(
-        sysname,
-        partition.number ?? 0,
+        '', // TODO: remove unused {disk} argument
+        partition.sysname,
       );
     }
   }

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -24,6 +24,7 @@ final testDisks = <Disk>[
     preserve: false,
     partitions: [
       Partition(
+        path: '/dev/sda1',
         number: 1,
         size: 11,
         mount: '/mnt/1',
@@ -31,6 +32,7 @@ final testDisks = <Disk>[
         preserve: false,
       ),
       Partition(
+        path: '/dev/sda2',
         number: 2,
         size: 22,
         mount: '/mnt/2',
@@ -45,6 +47,7 @@ final testDisks = <Disk>[
     preserve: false,
     partitions: [
       Partition(
+        path: '/dev/sdb3',
         number: 3,
         size: 33,
         wipe: 'superblock',
@@ -52,22 +55,26 @@ final testDisks = <Disk>[
         format: 'ext3',
       ),
       Partition(
+        path: '/dev/sdb4',
         number: 4,
         size: 44,
         wipe: 'superblock',
         format: 'ext4',
       ),
       Partition(
+        path: '/dev/sdb5',
         number: 5,
         size: 55,
         mount: '/mnt/5',
       ),
       Partition(
+        path: '/dev/sdb6',
         number: 6,
         size: 66,
         resize: true,
       ),
       Partition(
+        path: '/dev/sdb7',
         number: 7,
         preserve: false,
         wipe: 'superblock',
@@ -136,8 +143,8 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     expect(
-        find.html(tester.lang
-            .writeChangesPartitionFormattedMounted('sdb', 3, 'ext3', '/mnt/3')),
+        find.html(tester.lang.writeChangesPartitionFormattedMounted(
+            '', 'sdb3', 'ext3', '/mnt/3')),
         findsOneWidget);
     expect(
         find.html(tester.lang.writeChangesPartitionFormatted('sdb', 4, 'ext4')),


### PR DESCRIPTION
"nvme0n11" vs. "nvme0n1p1"

For historical reasons, we used "{disk}{partition}" because it used to be something like "{disk} #{partition}". However, this does not result in the correct formatting with NVME disks where there needs to be an extra "p". It's not possible to change the translations on the release week but luckily all existing translations have kept it as "{disk}{partition}" so we can safely pass an empty disk argument for the time being, and remove the unused argument later. The "Partition.path" property from subiquity provides the correct value, and we have a "sysname" convenience wrapper for that to take the filename part of the path.

| Before | After |
|---|---|
| ![Screenshot from 2023-04-17 14-26-37](https://user-images.githubusercontent.com/140617/232504683-f793c2c7-6823-40fd-907b-86b16d17c65f.png) | ![Screenshot from 2023-04-17 14-25-27](https://user-images.githubusercontent.com/140617/232504715-57b770be-54e8-432e-b08f-be1c3b19be38.png) |

Fixes: #1819