### PR TITLE
Manual partitioning: ensure "format" selection when appropriate

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -42,7 +42,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
     _scrollSubscription = model.onSelectionChanged.listen((_) {
       _scrollToSelection();
     });
-    model.getStorage().then((_) => _scrollToSelection());
+    model.init().then((_) => _scrollToSelection());
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -244,6 +244,7 @@ class PartitionButtonRow extends StatelessWidget {
                           context,
                           model.selectedDisk!,
                           model.selectedPartition!,
+                          model.selectedConfig,
                           model.trailingGap)
                       : null,
                   child: Text(lang.changeButtonText),

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
@@ -1,10 +1,12 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import '../../services.dart';
+import 'allocate_disk_space_model.dart';
 import 'storage_types.dart';
 
 typedef DiskBuilder = Widget Function(BuildContext context, Disk disk);
@@ -186,9 +188,12 @@ class StorageWipeColumn extends StorageColumn {
             return const SizedBox.shrink();
           },
           partitionBuilder: (context, disk, partition) {
+            final model = context.read<AllocateDiskSpaceModel>();
+            final config = model.originalConfig(partition);
+            final forceWipe = config?.mustWipe(partition.format) != false;
             return YaruCheckbox(
-              value: partition.isWiped,
-              onChanged: partition.canWipe
+              value: partition.isWiped || forceWipe,
+              onChanged: partition.canWipe && !forceWipe
                   ? (wipe) => onWipe(disk, partition, wipe!)
                   : null,
             );

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_types.dart
@@ -19,6 +19,10 @@ extension PartitionExtension on Partition {
   bool get isEncrypted => format == 'BitLocker';
   bool get isWiped => wipe == 'superblock';
   String get prettySize => filesize(size ?? 0);
+  bool mustWipe(String? format) {
+    // a preserved partition must be wiped if its format changed
+    return preserve == true && format != null && this.format != format;
+  }
 }
 
 /// Available partition formats.

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -125,6 +125,7 @@ void main() {
       tester.element(find.byType(AllocateDiskSpacePage)),
       disk,
       disk.partitions.whereType<Partition>().first,
+      null,
       disk.partitions.whereType<Gap>().first,
     );
     await tester.pumpAndSettle();
@@ -159,7 +160,7 @@ void main() {
       disk.partitions.whereType<Partition>().first,
       size: 123,
       format: PartitionFormat.btrfs,
-      wipe: false,
+      wipe: true,
       mount: '/tst',
     )).called(1);
   });
@@ -194,6 +195,7 @@ void main() {
       tester.element(find.byType(AllocateDiskSpacePage)),
       disk,
       disk.partitions.whereType<Partition>().first,
+      null,
       disk.partitions.whereType<Gap>().first,
     );
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -80,6 +81,11 @@ AllocateDiskSpaceModel buildModel({
   final model = MockAllocateDiskSpaceModel();
   when(model.isValid).thenReturn(isValid ?? false);
   when(model.disks).thenReturn(disks ?? <Disk>[]);
+  when(model.originalConfig(any)).thenAnswer((i) {
+    return disks
+        ?.expand((d) => d.partitions.whereType<Partition>())
+        .firstWhereOrNull((p) => p.path == i.positionalArguments[0].path);
+  });
 
   when(model.selectedGap).thenReturn(selectedGap);
   when(model.selectedDisk).thenReturn(selectedDisk);
@@ -400,6 +406,7 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final storage = MockDiskStorageService();
     when(storage.getStorage()).thenAnswer((_) async => testDisks);
+    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
     when(storage.needRoot).thenReturn(false);
     when(storage.needBoot).thenReturn(false);
     registerMockService<DiskStorageService>(storage);

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.mocks.dart
@@ -255,6 +255,15 @@ class MockAllocateDiskSpaceModel extends _i1.Mock
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
+  _i5.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
           #dispose,


### PR DESCRIPTION
Force-select the "Format partition" -checkbox if the FS type is changed. For example, if you take an existing EXT4 partition and change it to BTRFS, the format checkbox must be selected or else Subiquity will throw an exception. Notice that we must fetch the _original_ storage config to be able to compare the FS type of preserved partitions.

| Before | After |
|---|---|
| ![Screenshot from 2023-04-17 15-59-45](https://user-images.githubusercontent.com/140617/232525587-61fb2579-c8c8-41ba-a159-8ee5f282684a.png) | ![Screenshot from 2023-04-17 15-59-24](https://user-images.githubusercontent.com/140617/232525562-c07aec6a-33a3-439a-af8e-70c4c11fd03a.png) |

Fixes: #1817