### PR TITLE
Manual partitioning: fix initial GUI state update

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -218,11 +218,9 @@ class AllocateDiskSpaceModel extends SafeChangeNotifier {
         .map((p) => MapEntry(p.sysname, p)));
   }
 
-  Future<void> init() {
-    return Future.wait([
-      _service.getStorage().then(_updateDisks),
-      _service.getOriginalStorage().then(_updateOriginalConfigs),
-    ]);
+  Future<void> init() async {
+    await _service.getOriginalStorage().then(_updateOriginalConfigs);
+    return _service.getStorage().then(_updateDisks);
   }
 
   @override


### PR DESCRIPTION
Fixes a regression caused by yesterday's quick fix:
- #1823

`GET storage/v2` and `GET storage/v2/orig_config` requests were sent in parallel but only the former notified the GUI to update. Depending on the order of completion, the GUI could have left in a wrong initial state that confusingly stated that existing partitions would be formatted because it didn't see the original storage config. Reorder the calls and await for the `orig_config` to make sure both configs are available before notifying the GUI to update.

Fixes: #1828