### PR TITLE
Installation type: remove initial default selection

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -47,14 +47,14 @@ class InstallationTypeModel extends SafeChangeNotifier {
   final TelemetryService _telemetryService;
   final ProductService _productService;
 
-  var _installationType = InstallationType.erase;
+  InstallationType? _installationType;
   var _advancedFeature = AdvancedFeature.none;
   var _encryption = false;
   List<GuidedStorageTarget>? _storages;
 
   /// The selected installation type.
-  InstallationType get installationType => _installationType;
-  set installationType(InstallationType type) {
+  InstallationType? get installationType => _installationType;
+  set installationType(InstallationType? type) {
     if (_installationType == type) return;
     _installationType = type;
     notifyListeners();
@@ -110,7 +110,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
   /// Initializes the model.
   Future<void> init() async {
     await _diskService.getGuidedStorage().then((r) => _storages = r.possible);
-    _installationType = canInstallAlongside
+    _installationType ??= canInstallAlongside
         ? InstallationType.alongside
         : InstallationType.erase;
     _advancedFeature =
@@ -147,7 +147,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
   /// if appropriate (single guided storage).
   Future<void> save() async {
     // automatically pre-select a guided storage target if possible
-    _diskService.guidedTarget = preselectTarget(installationType);
+    _diskService.guidedTarget = preselectTarget(installationType!);
 
     final partitionMethod = _resolvePartitionMethod();
     if (partitionMethod != null) {

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -68,7 +68,7 @@ void main() {
     model.addListener(() => wasNotified = true);
 
     wasNotified = false;
-    expect(model.installationType, equals(InstallationType.erase));
+    expect(model.installationType, isNull);
     model.installationType = InstallationType.manual;
     expect(wasNotified, isTrue);
 

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -43,11 +43,6 @@ class MockInstallationTypeModel extends _i1.Mock
   }
 
   @override
-  _i3.InstallationType get installationType => (super.noSuchMethod(
-        Invocation.getter(#installationType),
-        returnValue: _i3.InstallationType.erase,
-      ) as _i3.InstallationType);
-  @override
   set installationType(_i3.InstallationType? type) => super.noSuchMethod(
         Invocation.setter(
           #installationType,


### PR DESCRIPTION
Don't hard-code the initial selection to "Erase" (and then potentially switch to "Alongside") but leave it unselected until available guided partitioning options have been received from Subiquity. This is not the final solution but makes the GUI feel slightly less awkward in such cases where the pre-selected "Alongside" option appears with a slight delay.

Show-case recorded with an extra 500ms delay injected:

## Before

[installation-type-before.webm](https://user-images.githubusercontent.com/140617/232820354-9439f836-4eb7-4a5d-8708-0ba8456986f0.webm)

## After

[installation-type-after.webm](https://user-images.githubusercontent.com/140617/232820312-245dac8b-0709-4186-adba-f5f134bf9636.webm)