### PR TITLE
Disable storage auto-mounting

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -40,4 +40,11 @@ fi
 
 [ "$needs_update" = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > "$SNAP_USER_DATA/.last_revision"
 
+# Disable storage automounting (/usr/lib/udisks2/udisks2-inhibit)
+sudo mkdir -p /run/udev/rules.d
+sudo sh -c 'echo "SUBSYSTEM==\"block\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/90-udisks-inhibit.rules'
+trap "sudo rm -f /run/udev/rules.d/90-udisks-inhibit.rules; sudo udevadm control --reload; sudo udevadm trigger --subsystem-match=block" EXIT HUP INT QUIT ILL ABRT FPE KILL SEGV PIPE ALRM TERM BUS
+sudo udevadm control --reload
+sudo udevadm trigger --subsystem-match=block
+
 exec "$@"


### PR DESCRIPTION
Unlike Ubiquity, the new GUI is not running as root so we cannot use udisks2-inhibit as a wrapper so we ended up copying the commands.