### PR TITLE
launcher: fix udev cleanup

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -47,4 +47,4 @@ trap "sudo rm -f /run/udev/rules.d/90-udisks-inhibit.rules; sudo udevadm control
 sudo udevadm control --reload
 sudo udevadm trigger --subsystem-match=block
 
-exec "$@"
+"$@"


### PR DESCRIPTION
With the exec call, the previous trap will not run.  Leave the process around so that we can run the trap on exit.