### PR TITLE
Fetch source catalogs from Subiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -136,14 +136,14 @@ Future<void> testConnectToInternetPage(
 
 Future<void> testUpdatesOtherSoftwarePage(
   WidgetTester tester, {
-  InstallationMode? mode,
+  String? sourceId,
   String? screenshot,
 }) async {
   await expectPage(tester, UpdatesOtherSoftwarePage,
       (lang) => lang.updatesOtherSoftwarePageTitle);
 
-  if (mode != null) {
-    await tester.tapRadioButton<InstallationMode>(mode);
+  if (sourceId != null) {
+    await tester.tapRadioButton<String>(sourceId);
   }
   await tester.pumpAndSettle();
 

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -57,7 +57,7 @@ void main() {
     await testConnectToInternetPage(tester, mode: ConnectMode.none);
     await tester.pumpAndSettle();
 
-    await testUpdatesOtherSoftwarePage(tester, mode: InstallationMode.minimal);
+    await testUpdatesOtherSoftwarePage(tester, sourceId: kMinimalSourceId);
     await tester.pumpAndSettle();
 
     await testInstallationTypePage(tester, type: InstallationType.erase);
@@ -178,7 +178,7 @@ void main() {
     await testConnectToInternetPage(tester, mode: ConnectMode.none);
     await tester.pumpAndSettle();
 
-    await testUpdatesOtherSoftwarePage(tester, mode: InstallationMode.normal);
+    await testUpdatesOtherSoftwarePage(tester, sourceId: kNormalSourceId);
     await tester.pumpAndSettle();
 
     await testInstallationTypePage(tester, type: InstallationType.manual);
@@ -229,7 +229,7 @@ void main() {
     await testConnectToInternetPage(tester, mode: ConnectMode.none);
     await tester.pumpAndSettle();
 
-    await testUpdatesOtherSoftwarePage(tester, mode: InstallationMode.normal);
+    await testUpdatesOtherSoftwarePage(tester, sourceId: kNormalSourceId);
     await tester.pumpAndSettle();
 
     await testInstallationTypePage(tester, type: InstallationType.alongside);

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -50,7 +51,7 @@ Future<void> runInstallerApp(
         help: 'Path of the machine config (dry-run only)');
     parser.addOption('source-catalog',
         valueHelp: 'path',
-        defaultsTo: 'examples/mixed-sources.yaml',
+        defaultsTo: 'examples/desktop-sources.yaml',
         help: 'Path of the source catalog (dry-run only)');
     parser.addFlag('try-or-install', hide: true);
   })!;
@@ -336,7 +337,12 @@ class _UbuntuDesktopInstallerWizardState
     super.initState();
 
     final client = getService<SubiquityClient>();
-    client.setSource(InstallationMode.normal.source).then((_) {
+    client.source().then((value) async {
+      final source = value.sources.firstWhereOrNull((s) => s.isDefault);
+      if (source != null) {
+        await client.setSource(source.id);
+      }
+
       // Use the default values for a number of endpoints
       // for which a UI page isn't implemented yet.
       client.markConfigured([

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -83,6 +83,9 @@ extension on WidgetTester {
     when(client.getOriginalStorageV2())
         .thenAnswer((_) async => testStorageResponse());
     registerMockService<SubiquityClient>(client);
+    when(client.source()).thenAnswer((_) async =>
+        const SourceSelectionAndSetting(
+            sources: [], currentId: kNormalSourceId, searchDrivers: false));
 
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.status).thenReturn(status);

--- a/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/updates_other_software/updates_other_software_page_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
-import 'dart:ui' as _i4;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/updates_other_software/updates_other_software_model.dart'
     as _i2;
-import 'package:ubuntu_desktop_installer/services.dart' as _i5;
+import 'package:ubuntu_desktop_installer/services.dart' as _i6;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -32,10 +33,10 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
   }
 
   @override
-  _i2.InstallationMode get installationMode => (super.noSuchMethod(
-        Invocation.getter(#installationMode),
-        returnValue: _i2.InstallationMode.normal,
-      ) as _i2.InstallationMode);
+  List<_i3.SourceSelection> get sources => (super.noSuchMethod(
+        Invocation.getter(#sources),
+        returnValue: <_i3.SourceSelection>[],
+      ) as List<_i3.SourceSelection>);
   @override
   bool get installDrivers => (super.noSuchMethod(
         Invocation.getter(#installDrivers),
@@ -67,10 +68,10 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  void setInstallationMode(_i2.InstallationMode? mode) => super.noSuchMethod(
+  void setSourceId(String? sourceId) => super.noSuchMethod(
         Invocation.method(
-          #setInstallationMode,
-          [mode],
+          #setSourceId,
+          [sourceId],
         ),
         returnValueForMissingStub: null,
       );
@@ -91,25 +92,25 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  _i3.Future<void> save() => (super.noSuchMethod(
+  _i4.Future<void> save() => (super.noSuchMethod(
         Invocation.method(
           #save,
           [],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(
+  _i4.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  void setProperties(_i3.Stream<List<String>>? properties) =>
+  void setProperties(_i4.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #setProperties,
@@ -120,7 +121,7 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
   @override
   void addPropertyListener(
     String? property,
-    _i4.VoidCallback? onChanged,
+    _i5.VoidCallback? onChanged,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -157,7 +158,7 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -165,7 +166,7 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -185,32 +186,32 @@ class MockUpdateOtherSoftwareModel extends _i1.Mock
 /// A class which mocks [TelemetryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
+class MockTelemetryService extends _i1.Mock implements _i6.TelemetryService {
   MockTelemetryService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
+  _i4.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
       (super.noSuchMethod(
         Invocation.method(
           #init,
           [metrics],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<void> addStage(String? name) => (super.noSuchMethod(
+  _i4.Future<void> addStage(String? name) => (super.noSuchMethod(
         Invocation.method(
           #addStage,
           [name],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<void> addMetric(
+  _i4.Future<void> addMetric(
     String? key,
     dynamic value,
   ) =>
@@ -222,17 +223,17 @@ class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
             value,
           ],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i3.Future<void> addMetrics(Map<String, dynamic>? entries) =>
+  _i4.Future<void> addMetrics(Map<String, dynamic>? entries) =>
       (super.noSuchMethod(
         Invocation.method(
           #addMetrics,
           [entries],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }


### PR DESCRIPTION
Remove the hardcoded "normal" vs. "minimal" enum, declare known "ubuntu-desktop" and "ubuntu-desktop-minimal" source IDs, fetch the effective list of sources from Subiquity, present them in the desired order, and use localized descriptions if available.

There's no visual difference by default when the sources are defined as they are in [`livecd-rootfs`](https://git.launchpad.net/livecd-rootfs/tree/live-build/auto/config#n766) (and [`desktop-sources.yaml`](https://github.com/canonical/subiquity/blob/main/examples/desktop-sources.yaml) for dry-run) but this does allow the GUI to run with any source catalogs e.g. the previously used `mixed-sources.yaml` would present a server source.

| Before | After |
|---|---|
| ![Screenshot from 2023-04-24 11-55-07](https://user-images.githubusercontent.com/140617/233963662-54606562-f24f-4dae-8165-9e4ed9defe58.png) | ![Screenshot from 2023-04-24 11-54-50](https://user-images.githubusercontent.com/140617/233963726-f10b90cd-2ebe-4f47-b638-5bbaadb0403b.png) |

Ref: #1841