### PR TITLE
Installation slides: add repaint boundary to limit updates

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -131,8 +131,11 @@ class _InstallationSlidesPageState extends State<InstallationSlidesPage> {
                       ? Theme.of(context).colorScheme.error
                       : null),
             ),
-            subtitle:
-                LinearProgressIndicator(value: model.isInstalling ? null : 0),
+            subtitle: RepaintBoundary(
+              child: LinearProgressIndicator(
+                value: model.isInstalling ? null : 0,
+              ),
+            ),
             trailing: IconButton(
               icon: Icon(YaruIcons.terminal,
                   color: model.isLogVisible


### PR DESCRIPTION
With [repaints highlighted](https://docs.flutter.dev/development/tools/devtools/inspector#highlight-repaints):

## Before

[Screencast from 2023-04-24 13-24-21.webm](https://user-images.githubusercontent.com/140617/233983383-c5382f90-de89-4d1c-8ac8-a1fac7138211.webm)

## After

[Screencast from 2023-04-24 13-25-35.webm](https://user-images.githubusercontent.com/140617/233983397-e89d4c96-607b-4d3e-83b4-aced783edf4a.webm)
