### PR TITLE
ubuntu_wizard: remove `ignore_for_file: type=lint` & run `dart fix`

### DIFF
--- a/packages/ubuntu_wizard/test/color_test.dart
+++ b/packages/ubuntu_wizard/test/color_test.dart
@@ -3,12 +3,11 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('hex string', () {
-    expect(Color(0x01020304).toHex(), equals('#01020304'));
-    expect(Color(0xffabcdef).toHex(), equals('#ffabcdef'));
-    expect(Color.fromARGB(0x11, 0x22, 0x33, 0x44).toHex(), equals('#11223344'));
+    expect(const Color(0x01020304).toHex(), equals('#01020304'));
+    expect(const Color(0xffabcdef).toHex(), equals('#ffabcdef'));
+    expect(const Color.fromARGB(0x11, 0x22, 0x33, 0x44).toHex(),
+        equals('#11223344'));
   });
 }

--- a/packages/ubuntu_wizard/test/flavor_test.dart
+++ b/packages/ubuntu_wizard/test/flavor_test.dart
@@ -4,8 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('data class', (tester) async {
     final flavor1 = FlavorData(
@@ -36,7 +34,7 @@ void main() {
           darkTheme: ThemeData.dark(),
           localizationsDelegates: GlobalUbuntuLocalizations.delegates,
         ),
-        child: Builder(builder: (_) => MaterialApp()),
+        child: Builder(builder: (_) => const MaterialApp()),
       ),
     );
 

--- a/packages/ubuntu_wizard/test/l10n_test.dart
+++ b/packages/ubuntu_wizard/test/l10n_test.dart
@@ -3,8 +3,6 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('load localized languages', () async {
     const testLocales = [
@@ -17,10 +15,10 @@ void main() {
     expect(
       await loadLocalizedLanguages(testLocales),
       equals([
-        LocalizedLanguage('English', Locale('en', 'US')),
-        LocalizedLanguage('Español', Locale('es', 'ES')),
-        LocalizedLanguage('Français', Locale('fr', 'FR')),
-        LocalizedLanguage('Русский', Locale('ru', 'RU')),
+        const LocalizedLanguage('English', Locale('en', 'US')),
+        const LocalizedLanguage('Español', Locale('es', 'ES')),
+        const LocalizedLanguage('Français', Locale('fr', 'FR')),
+        const LocalizedLanguage('Русский', Locale('ru', 'RU')),
       ]),
     );
   });
@@ -41,11 +39,11 @@ void main() {
     // full match
     expect(
       <LocalizedLanguage>[
-        LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEnUS),
-        LocalizedLanguage('', localeFrFReuro),
-        LocalizedLanguage('', localeFrCA),
-        LocalizedLanguage('', localeFrFR),
+        const LocalizedLanguage('', localeFr),
+        const LocalizedLanguage('', localeEnUS),
+        const LocalizedLanguage('', localeFrFReuro),
+        const LocalizedLanguage('', localeFrCA),
+        const LocalizedLanguage('', localeFrFR),
       ].findBestMatch(localeFrFReuro),
       equals(2),
     );
@@ -53,10 +51,10 @@ void main() {
     // matching language and country
     expect(
       <LocalizedLanguage>[
-        LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEnUS),
-        LocalizedLanguage('', localeFrCA),
-        LocalizedLanguage('', localeFrFR),
+        const LocalizedLanguage('', localeFr),
+        const LocalizedLanguage('', localeEnUS),
+        const LocalizedLanguage('', localeFrCA),
+        const LocalizedLanguage('', localeFrFR),
       ].findBestMatch(localeFrFReuro),
       equals(3),
     );
@@ -64,9 +62,9 @@ void main() {
     // matching language
     expect(
       <LocalizedLanguage>[
-        LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEnUS),
-        LocalizedLanguage('', localeFrCA),
+        const LocalizedLanguage('', localeFr),
+        const LocalizedLanguage('', localeEnUS),
+        const LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeFrFReuro),
       equals(0),
     );
@@ -74,9 +72,9 @@ void main() {
     // no match -> en
     expect(
       <LocalizedLanguage>[
-        LocalizedLanguage('', localeFr),
-        LocalizedLanguage('', localeEnUS),
-        LocalizedLanguage('', localeFrCA),
+        const LocalizedLanguage('', localeFr),
+        const LocalizedLanguage('', localeEnUS),
+        const LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeEs),
       equals(1),
     );
@@ -84,9 +82,9 @@ void main() {
     // country mismatch -> en
     expect(
       <LocalizedLanguage>[
-        LocalizedLanguage('', localeFrFR),
-        LocalizedLanguage('', localeEnUS),
-        LocalizedLanguage('', localeFrCA),
+        const LocalizedLanguage('', localeFrFR),
+        const LocalizedLanguage('', localeEnUS),
+        const LocalizedLanguage('', localeFrCA),
       ].findBestMatch(localeFrBE),
       equals(1),
     );

--- a/packages/ubuntu_wizard/test/locale_test.dart
+++ b/packages/ubuntu_wizard/test/locale_test.dart
@@ -3,50 +3,48 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   group('parseLocale', () {
     test('empty and C locales', () {
-      expect(parseLocale(''), Locale('C'));
-      expect(parseLocale('C'), Locale('C'));
+      expect(parseLocale(''), const Locale('C'));
+      expect(parseLocale('C'), const Locale('C'));
     });
 
     test('basic locales', () {
-      expect(parseLocale('en'), Locale('en'));
-      expect(parseLocale('fr'), Locale('fr'));
-      expect(parseLocale('en_US'), Locale('en', 'US'));
-      expect(parseLocale('en_GB'), Locale('en', 'GB'));
+      expect(parseLocale('en'), const Locale('en'));
+      expect(parseLocale('fr'), const Locale('fr'));
+      expect(parseLocale('en_US'), const Locale('en', 'US'));
+      expect(parseLocale('en_GB'), const Locale('en', 'GB'));
     });
 
     test('three letter locales', () {
-      expect(parseLocale('agr_PE.UTF-8'), Locale('agr', 'PE'));
-      expect(parseLocale('bhb_IN.UTF-8'), Locale('bhb', 'IN'));
+      expect(parseLocale('agr_PE.UTF-8'), const Locale('agr', 'PE'));
+      expect(parseLocale('bhb_IN.UTF-8'), const Locale('bhb', 'IN'));
     });
 
     test('codeset', () {
-      expect(parseLocale('zh_CN.UTF-8'), Locale('zh', 'CN'));
-      expect(parseLocale('zh_SG.GBK'), Locale('zh', 'SG'));
-      expect(parseLocale('zh_HK.BIG5'), Locale('zh', 'HK'));
-      expect(parseLocale('zh_TW.EUC-TW'), Locale('zh', 'TW'));
-      expect(parseLocale('hy_AM.ARMSCII-8'), Locale('hy', 'AM'));
+      expect(parseLocale('zh_CN.UTF-8'), const Locale('zh', 'CN'));
+      expect(parseLocale('zh_SG.GBK'), const Locale('zh', 'SG'));
+      expect(parseLocale('zh_HK.BIG5'), const Locale('zh', 'HK'));
+      expect(parseLocale('zh_TW.EUC-TW'), const Locale('zh', 'TW'));
+      expect(parseLocale('hy_AM.ARMSCII-8'), const Locale('hy', 'AM'));
     });
 
     test('modifier', () {
-      expect(parseLocale('fr@euro'), Locale('fr'));
-      expect(parseLocale('fr_FR@euro'), Locale('fr', 'FR'));
-      expect(parseLocale('fr_BE.UTF-8@euro'), Locale('fr', 'BE'));
+      expect(parseLocale('fr@euro'), const Locale('fr'));
+      expect(parseLocale('fr_FR@euro'), const Locale('fr', 'FR'));
+      expect(parseLocale('fr_BE.UTF-8@euro'), const Locale('fr', 'BE'));
     });
 
     test('unexpected order', () {
-      expect(parseLocale('fr.UTF-8_FR'), Locale('fr', 'FR'));
-      expect(parseLocale('fr.UTF-8_FR@euro'), Locale('fr', 'FR'));
+      expect(parseLocale('fr.UTF-8_FR'), const Locale('fr', 'FR'));
+      expect(parseLocale('fr.UTF-8_FR@euro'), const Locale('fr', 'FR'));
     });
 
     test('unexpected format', () {
-      expect(parseLocale('fr_UTF-8'), Locale('fr'));
-      expect(parseLocale('fr_UTF-8_FR'), Locale('fr', 'FR'));
-      expect(parseLocale('fr_UTF-8_FR_euro'), Locale('fr', 'FR'));
+      expect(parseLocale('fr_UTF-8'), const Locale('fr'));
+      expect(parseLocale('fr_UTF-8_FR'), const Locale('fr', 'FR'));
+      expect(parseLocale('fr_UTF-8_FR_euro'), const Locale('fr', 'FR'));
     });
   });
 }

--- a/packages/ubuntu_wizard/test/option_card_test.dart
+++ b/packages/ubuntu_wizard/test/option_card_test.dart
@@ -3,8 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ubuntu_wizard/widgets.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -30,7 +28,7 @@ void main() {
       MaterialApp(
         home: Material(
           child: OptionCard(
-            title: Text('title'),
+            title: const Text('title'),
             selected: false,
             onSelected: () {},
           ),

--- a/packages/ubuntu_wizard/test/password_strength_label_test.dart
+++ b/packages/ubuntu_wizard/test/password_strength_label_test.dart
@@ -5,14 +5,12 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru/yaru.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('weak password', (tester) async {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       home: Builder(builder: (context) {
-        return PasswordStrengthLabel(strength: PasswordStrength.weak);
+        return const PasswordStrengthLabel(strength: PasswordStrength.weak);
       }),
     ));
 
@@ -30,7 +28,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       home: Builder(builder: (context) {
-        return PasswordStrengthLabel(strength: PasswordStrength.fair);
+        return const PasswordStrengthLabel(strength: PasswordStrength.fair);
       }),
     ));
 
@@ -46,7 +44,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       home: Builder(builder: (context) {
-        return PasswordStrengthLabel(strength: PasswordStrength.good);
+        return const PasswordStrengthLabel(strength: PasswordStrength.good);
       }),
     ));
 
@@ -62,7 +60,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       home: Builder(builder: (context) {
-        return PasswordStrengthLabel(strength: PasswordStrength.strong);
+        return const PasswordStrengthLabel(strength: PasswordStrength.strong);
       }),
     ));
 

--- a/packages/ubuntu_wizard/test/validated_form_field_test.dart
+++ b/packages/ubuntu_wizard/test/validated_form_field_test.dart
@@ -4,8 +4,6 @@ import 'package:form_field_validator/form_field_validator.dart';
 
 import 'package:ubuntu_wizard/widgets.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('input validation', (tester) async {
     await tester.pumpWidget(
@@ -161,7 +159,7 @@ void main() {
         home: Material(
           child: Center(
             child: ValidatedFormField(
-              successWidget: SuccessIcon(),
+              successWidget: const SuccessIcon(),
               helperText: helperText,
             ),
           ),
@@ -343,7 +341,7 @@ void main() {
         ),
       ),
     );
-    await tester.pumpWidget(MaterialApp());
+    await tester.pumpWidget(const MaterialApp());
     await tester.pumpAndSettle();
 
     await expectLater(

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -13,14 +13,12 @@ import 'package:ubuntu_wizard/app.dart';
 
 import 'wizard_app_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([IOSink])
 void main() {
   final endpoint = Endpoint.unix('socket path');
 
   setUpAll(() {
-    final methodChannel = MethodChannel('yaru_window');
+    const methodChannel = MethodChannel('yaru_window');
     methodChannel.setMockMethodCallHandler((call) async {});
   });
 
@@ -55,7 +53,7 @@ void main() {
     when(monitor.start(any)).thenAnswer((_) async => true);
 
     await runWizardApp(
-      SizedBox(),
+      const SizedBox(),
       subiquityClient: client,
       subiquityServer: server,
       subiquityMonitor: monitor,
@@ -133,7 +131,7 @@ void main() {
         .thenAnswer((_) async => endpoint);
 
     await runWizardApp(
-      SizedBox(),
+      const SizedBox(),
       subiquityServer: server,
       subiquityMonitor: monitor,
       subiquityClient: MockSubiquityClient(),
@@ -152,7 +150,7 @@ void main() {
     );
 
     await runWizardApp(
-      SizedBox(),
+      const SizedBox(),
       subiquityClient: client,
       subiquityServer: server,
     );
@@ -162,7 +160,7 @@ void main() {
 
   testWidgets('ensure initialized', (tester) async {
     var windowInit = false;
-    final methodChannel = MethodChannel('yaru_window');
+    const methodChannel = MethodChannel('yaru_window');
     methodChannel.setMockMethodCallHandler((call) async {
       if (call.method == 'init') {
         windowInit = true;
@@ -178,7 +176,7 @@ void main() {
     );
 
     await runWizardApp(
-      SizedBox(),
+      const SizedBox(),
       subiquityClient: client,
       subiquityServer: server,
     );

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -4,8 +4,6 @@ import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/widgets.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('activation', (tester) async {
     var activated = false;
@@ -36,7 +34,7 @@ void main() {
           header: const Text('header'),
           content: const Text('content'),
           snackBar: const SnackBar(content: Text('snackbar')),
-          bottomBar: WizardBar(
+          bottomBar: const WizardBar(
             leading: WizardAction(label: 'back'),
             trailing: [
               WizardAction(label: 'next'),
@@ -77,7 +75,7 @@ void main() {
 
   testWidgets('normal/flat/highlighted action', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      const MaterialApp(
         home: WizardPage(
           bottomBar: WizardBar(
             trailing: [
@@ -122,7 +120,7 @@ void main() {
 
   testWidgets('hidden action', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      const MaterialApp(
         home: WizardPage(
           bottomBar: WizardBar(
             trailing: [
@@ -186,8 +184,8 @@ void main() {
   testWidgets('page indicator', (tester) async {
     final routes = <String, WizardRoute>{
       '/foo': WizardRoute(
-        builder: (context) => WizardPage(
-          content: const Text('Page 4 of 7'),
+        builder: (context) => const WizardPage(
+          content: Text('Page 4 of 7'),
           bottomBar: WizardBar(),
         ),
         userData: 3,


### PR DESCRIPTION
```
Computing fixes in ubuntu_wizard... 14.7s
Applying fixes...                      0.0s

test/color_test.dart
  prefer_const_constructors • 3 fixes

test/flavor_test.dart
  prefer_const_constructors • 1 fix

test/l10n_test.dart
  prefer_const_constructors • 22 fixes

test/locale_test.dart
  prefer_const_constructors • 21 fixes

test/option_card_test.dart
  prefer_const_constructors • 1 fix

test/password_strength_label_test.dart
  prefer_const_constructors • 4 fixes

test/validated_form_field_test.dart
  prefer_const_constructors • 2 fixes

test/wizard_app_test.dart
  prefer_const_constructors • 6 fixes
  prefer_const_declarations • 2 fixes

test/wizard_page_test.dart
  prefer_const_constructors • 4 fixes

66 fixes made in 9 files.
```