### PR TITLE
README.md: remove manual live-run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,14 @@ Install Subiquity dependencies:
 make -C packages/subiquity_client/subiquity install_deps
 ```
 
-### Run the installer
+### Dry-run the installer
 
-Run the installer either from within your IDE or by running the following command:
+Run the installer in dry-run mode either from within your IDE or by running the
+following command:
 
 ```sh
 cd packages/ubuntu_desktop_installer
 flutter run
-```
-
-### Run live installer
-
-In one terminal run:
-```sh
-cd /path/to/ubuntu-desktop-installer/packages/subiquity_client/subiquity
-sudo python3 -m subiquity.cmd.server
-```
-
-In another terminal run:
-```sh
-cd /path/to/ubuntu-desktop-installer/packages/ubuntu_desktop_installer
-LIVE_RUN=1 flutter run
 ```
 
 ## Contributing


### PR DESCRIPTION
There are (safe) instructions to test live images above. It's better not to give (dangerous) instructions to run the installer in live-mode on a normal desktop. Also, emphasize that `flutter run` is a dry run.