### PR TITLE
ubuntu_wizard: use package-syntax for barrel imports

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/password_strength_label.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru/yaru.dart';
-
-import '../../utils.dart';
 
 /// A widget that visualizes the strength of a password.
 class PasswordStrengthLabel extends StatelessWidget {

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
@@ -1,9 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:ubuntu_wizard/constants.dart';
 import 'package:wizard_router/wizard_router.dart';
 import 'package:yaru_widgets/widgets.dart';
 
-import '../../constants.dart';
 import 'wizard_action.dart';
 
 export 'package:wizard_router/wizard_router.dart';

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../../constants.dart';
+import 'package:ubuntu_wizard/constants.dart';
 
 export 'package:wizard_router/wizard_router.dart';
 export 'wizard_action.dart';


### PR DESCRIPTION
To get rid of the ugly "../../foo.dart" imports. Import them using the package syntax instead, as if they were standalone. Keep using local imports for local files in the same directory or in subdirectories.