### PR TITLE
ubuntu_desktop_installer: use package-syntax for barrel imports

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
-
-import '../../l10n.dart';
-import '../../widgets.dart';
 
 Future<void> showActiveDirectoryErrorDialog(BuildContext context) {
   return showDialog(

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_l10n.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_l10n.dart
@@ -1,6 +1,5 @@
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../l10n.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 
 extension AdDomainNameValidationL10n on AdDomainNameValidation {
   String localize(AppLocalizations lang) {

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'active_directory_dialogs.dart';
 import 'active_directory_model.dart';
 import 'active_directory_widgets.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
@@ -2,9 +2,9 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../../l10n.dart';
 import 'active_directory_l10n.dart';
 import 'active_directory_model.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_dialogs.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../widgets.dart';
 import 'allocate_disk_space_model.dart';
 import 'storage_types.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_model.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:dartx/dartx.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../../services.dart';
 import 'storage_types.dart';
 
 /// The default mount points for auto-completion.

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_page.dart
@@ -3,12 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'allocate_disk_space_model.dart';
 import 'allocate_disk_space_widgets.dart';
 import 'storage_selector.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -3,11 +3,11 @@ import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
-import '../../widgets.dart';
 import 'allocate_disk_space_dialogs.dart';
 import 'allocate_disk_space_model.dart';
 import 'storage_columns.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_columns.dart
@@ -1,11 +1,11 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'allocate_disk_space_model.dart';
 import 'storage_types.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/allocate_disk_space/storage_selector.dart
@@ -1,9 +1,8 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-
-import '../../services.dart';
 
 class StorageSelector extends StatelessWidget {
   const StorageSelector({

--- a/packages/ubuntu_desktop_installer/lib/pages/bitlocker/bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/bitlocker/bitlocker_page.dart
@@ -3,14 +3,14 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
-import '../../widgets.dart';
 import 'bitlocker_model.dart';
 
 class BitLockerPage extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -2,10 +2,9 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
-
-import '../../services.dart';
 
 export 'package:ubuntu_wizard/utils.dart' show PasswordStrength;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'identity_model.dart';
 
 part 'identity_widgets.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_model.dart
@@ -2,8 +2,7 @@ import 'package:collection/collection.dart' hide ListExtensions;
 import 'package:dartx/dartx.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/install_alongside_page.dart
@@ -2,15 +2,15 @@ import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/pages.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../pages.dart';
-import '../../services.dart';
 import 'install_alongside_model.dart';
 import 'storage_split_view.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_size_dialog.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
-
-import '../../l10n.dart';
-import '../../widgets.dart';
 
 Future<int?> showStorageSizeDialog(
   BuildContext context, {

--- a/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_split_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install_alongside/storage_split_view.dart
@@ -2,10 +2,10 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:split_view/split_view.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'storage_button.dart';
 import 'storage_size_dialog.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_model.dart
@@ -1,6 +1,5 @@
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 /// View model for [InstallationCompletePage].
 class InstallationCompleteModel {

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
-import '../../widgets.dart';
 import 'installation_complete_model.dart';
 
 class InstallationCompletePage extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_model.dart
@@ -4,8 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p;
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show ApplicationState;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_slides/installation_slides_page.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/slides.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
-import '../../slides.dart';
 import 'bottom_bar.dart';
 import 'installation_slides_model.dart';
 import 'slide_view.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_dialogs.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../widgets.dart';
 import 'installation_type_model.dart';
 
 /// Shows a dialog to select advanced installation features.

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_model.dart
@@ -1,8 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 /// Available installation types.
 enum InstallationType {

--- a/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_type/installation_type_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'installation_type_dialogs.dart';
 import 'installation_type_model.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_dialogs.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
-import '../../widgets.dart';
 import 'keyboard_detector.dart';
 import 'keyboard_widgets.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'keyboard_dialogs.dart';
 import 'keyboard_model.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_widgets.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
-
-import '../../l10n.dart';
 
 /// Asks the user to press one of keys.
 class PressKeyView extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
@@ -2,11 +2,10 @@ import 'dart:ui';
 
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart' show KeySearchX;
-
-import '../../l10n.dart';
-import '../../services.dart';
 
 /// @internal
 final log = Logger('locale');

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_desktop_installer/widgets/mascot_avatar.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'locale_model.dart';
 
 class LocalePage extends StatefulWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/network/connect_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/connect_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'connect_model.dart';
 import 'ethernet_model.dart';
 import 'wifi_model.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_model.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../../services.dart';
 import 'connect_model.dart';
 import 'network_device.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_view.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'connect_model.dart';
 import 'ethernet_model.dart';
 import 'network_tile.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_model.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../../services.dart';
 import 'connect_model.dart';
 import 'network_device.dart';
 import 'wifi_model.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_view.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'connect_model.dart';
 import 'hidden_wifi_model.dart';
 import 'wifi_model.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_device.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_device.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../../services.dart';
 import 'connect_model.dart';
 
 abstract class NetworkDeviceModel<T extends NetworkDevice>

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_model.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
-import '../../services.dart';
 import 'connect_model.dart';
 
 /// A proxy model for the currently selected [ConnectModel] (eth, wifi, none).

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'connect_model.dart';
 import 'connect_view.dart';
 import 'ethernet_model.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
@@ -4,9 +4,9 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-import '../../services.dart';
 import 'connect_model.dart';
 import 'network_device.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/network/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/wifi_view.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'connect_model.dart';
 import 'network_tile.dart';
 import 'wifi_model.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -3,13 +3,13 @@ import 'dart:math';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'not_enough_disk_space_model.dart';
 
 class NotEnoughDiskSpacePage extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/rst/rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/rst/rst_page.dart
@@ -3,14 +3,14 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'rst_model.dart';
 
 class RstPage extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'secure_boot_model.dart';
 import 'secure_boot_widgets.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_widgets.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../../l10n.dart';
 import 'secure_boot_model.dart';
 
 class SecurityKeyFormField extends StatelessWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/security_key/security_key_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/security_key/security_key_model.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 /// View model for [ChooseSecurityKeyPage].
 class SecurityKeyModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/security_key/security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/security_key/security_key_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'security_key_model.dart';
 
 part 'security_key_widgets.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_model.dart
@@ -1,8 +1,7 @@
 import 'package:dartx/dartx.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/select_guided_storage/select_guided_storage_page.dart
@@ -2,13 +2,13 @@ import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'select_guided_storage_model.dart';
 
 /// Select a storage for guided partitioning.

--- a/packages/ubuntu_desktop_installer/lib/pages/theme_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/theme_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
-
-import '../../l10n.dart';
-import '../../services.dart';
 
 class ThemePage extends StatelessWidget {
   const ThemePage({super.key});

--- a/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_page.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:timezone_map/timezone_map.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'timezone_model.dart';
 
 /// https://github.com/canonical/ubuntu-desktop-installer/issues/38

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_model.dart
@@ -1,10 +1,9 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
-
-import '../../services.dart';
 
 /// @internal
 final log = Logger('try_or_install');

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
 import 'try_or_install_model.dart';
 import 'try_or_install_widgets.dart';
 

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_model.dart
@@ -1,9 +1,8 @@
 import 'package:async/async.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
-
-import '../../services.dart';
 
 /// @internal
 final log = Logger('updates_other_software');

--- a/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/updates_other_software/updates_other_software_page.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'updates_other_software_model.dart';
 
 export 'updates_other_software_model.dart'

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_model.dart
@@ -1,8 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-
-import '../../services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/write_changes_to_disk/write_changes_to_disk_page.dart
@@ -3,13 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../../l10n.dart';
-import '../../services.dart';
 import 'write_changes_to_disk_model.dart';
 
 /// @internal

--- a/packages/ubuntu_desktop_installer/lib/slides/default_slides.dart
+++ b/packages/ubuntu_desktop_installer/lib/slides/default_slides.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../l10n.dart';
-import '../services.dart';
-import '../widgets.dart';
 import 'slide_layouts.dart';
 
 String _slideAsset(String name) => 'assets/installation_slides/$name';

--- a/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/storage_size_box.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
-
-import '../l10n.dart';
 
 /// Storage size entry with a spinbox and a data size unit dropdown.
 class StorageSizeBox extends StatelessWidget {


### PR DESCRIPTION
To get rid of the ugly "../../foo.dart" imports. Import them using the package syntax instead, as if they were standalone. Keep using local imports for local files in the same directory or in subdirectories.

As a bonus, this will help to reduce the noise when restructuring half a dozen pages into filesystem/ in #1850 where the relative imports would become one level deeper...