### PR TITLE
Nested filesystem wizard

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -276,7 +276,7 @@ void main() {
       '--machine-config',
       'examples/win10.json',
       '--initial-route',
-      Routes.installationType,
+      Routes.filesystem,
     ]);
     await tester.pumpAndSettle();
 

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -313,7 +313,7 @@ enum InstallationStep {
   network,
   software,
   type,
-  storage,
+  filesystem,
   location,
   user,
   look,
@@ -408,9 +408,9 @@ class _UbuntuDesktopInstallerWizardState
           userData: InstallationStep.software.index,
           onNext: (_) => !service.hasEnoughDiskSpace
               ? Routes.notEnoughDiskSpace
-              : !service.hasSecureBoot
-                  ? Routes.installationType
-                  : null,
+              : service.hasSecureBoot
+                  ? Routes.secureBoot
+                  : Routes.filesystem,
         ),
         Routes.notEnoughDiskSpace: const WizardRoute(
           builder: NotEnoughDiskSpacePage.create,
@@ -419,37 +419,13 @@ class _UbuntuDesktopInstallerWizardState
           builder: SecureBootPage.create,
           userData: InstallationStep.type.index,
         ),
-        Routes.installationType: WizardRoute(
-          builder: InstallationTypePage.create,
-          userData: InstallationStep.type.index,
-          onNext: (settings) => _nextStorageRoute(service, settings.arguments),
-        ),
-        Routes.bitlocker: const WizardRoute(
-          builder: BitLockerPage.create,
-        ),
-        Routes.installAlongside: WizardRoute(
-          builder: InstallAlongsidePage.create,
-          userData: InstallationStep.storage.index,
-          onReplace: (_) => Routes.allocateDiskSpace,
-          onNext: (settings) => _nextStorageRoute(service, settings.arguments),
-        ),
-        Routes.selectGuidedStorage: WizardRoute(
-          builder: SelectGuidedStoragePage.create,
-          userData: InstallationStep.storage.index,
-          onNext: (settings) => _nextStorageRoute(service, settings.arguments),
-        ),
-        Routes.securityKey: WizardRoute(
-          builder: SecurityKeyPage.create,
-          userData: InstallationStep.storage.index,
-          onNext: (settings) => _nextStorageRoute(service, settings.arguments),
-        ),
-        Routes.allocateDiskSpace: WizardRoute(
-          builder: AllocateDiskSpacePage.create,
-          userData: InstallationStep.storage.index,
+        Routes.filesystem: WizardRoute(
+          builder: FilesystemPage.create,
+          userData: InstallationStep.filesystem.index,
         ),
         Routes.writeChangesToDisk: WizardRoute(
           builder: WriteChangesToDiskPage.create,
-          userData: InstallationStep.storage.index,
+          userData: InstallationStep.filesystem.index,
         ),
         Routes.timezone: WizardRoute(
           builder: TimezonePage.create,
@@ -481,23 +457,6 @@ class _UbuntuDesktopInstallerWizardState
         _UbuntuDesktopInstallerWizardObserver(getService<TelemetryService>())
       ],
     );
-  }
-
-  String? _nextStorageRoute(DiskStorageService service, dynamic arguments) {
-    if (arguments == InstallationType.manual) {
-      return Routes.allocateDiskSpace;
-    } else if (service.guidedTarget == null) {
-      if (arguments == InstallationType.bitlocker) {
-        return Routes.bitlocker;
-      } else if (arguments == InstallationType.erase) {
-        return Routes.selectGuidedStorage;
-      } else if (arguments == InstallationType.alongside) {
-        return Routes.installAlongside;
-      }
-    } else if (service.useEncryption && service.securityKey == null) {
-      return Routes.securityKey;
-    }
-    return Routes.writeChangesToDisk;
   }
 }
 

--- a/packages/ubuntu_desktop_installer/lib/pages.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages.dart
@@ -1,6 +1,7 @@
 export 'pages/active_directory/active_directory_page.dart';
 export 'pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart';
 export 'pages/filesystem/bitlocker/bitlocker_page.dart';
+export 'pages/filesystem/filesystem_page.dart';
 export 'pages/filesystem/install_alongside/install_alongside_page.dart';
 export 'pages/filesystem/installation_type/installation_type_page.dart';
 export 'pages/filesystem/security_key/security_key_page.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart
@@ -102,6 +102,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
         trailing: [
           WizardAction.next(
             context,
+            root: true,
             enabled: model.isValid,
             onNext: model.setStorage,
           ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+
+import '../../installer.dart';
+import '../../routes.dart';
+import '../../services.dart';
+import 'allocate_disk_space/allocate_disk_space_page.dart';
+import 'bitlocker/bitlocker_page.dart';
+import 'install_alongside/install_alongside_page.dart';
+import 'installation_type/installation_type_page.dart';
+import 'security_key/security_key_page.dart';
+import 'select_guided_storage/select_guided_storage_page.dart';
+
+export 'allocate_disk_space/allocate_disk_space_page.dart';
+export 'bitlocker/bitlocker_page.dart';
+export 'install_alongside/install_alongside_page.dart';
+export 'installation_type/installation_type_page.dart';
+export 'security_key/security_key_page.dart';
+export 'select_guided_storage/select_guided_storage_page.dart';
+
+class FilesystemPage extends StatelessWidget {
+  const FilesystemPage({super.key});
+
+  static Widget create(BuildContext context) => const FilesystemPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Wizard(
+      userData: InstallationStep.values.length,
+      routes: {
+        Routes.installationType: WizardRoute(
+          builder: InstallationTypePage.create,
+          userData: InstallationStep.type.index,
+          onNext: (settings) => _nextRoute(settings.arguments),
+        ),
+        Routes.bitlocker: const WizardRoute(
+          builder: BitLockerPage.create,
+        ),
+        Routes.installAlongside: WizardRoute(
+          builder: InstallAlongsidePage.create,
+          userData: InstallationStep.filesystem.index,
+          onReplace: (_) => Routes.allocateDiskSpace,
+          onNext: (settings) => _nextRoute(settings.arguments),
+        ),
+        Routes.selectGuidedStorage: WizardRoute(
+          builder: SelectGuidedStoragePage.create,
+          userData: InstallationStep.filesystem.index,
+          onNext: (settings) => _nextRoute(settings.arguments),
+        ),
+        Routes.securityKey: WizardRoute(
+          builder: SecurityKeyPage.create,
+          userData: InstallationStep.filesystem.index,
+          onNext: (settings) => _nextRoute(settings.arguments),
+        ),
+        Routes.allocateDiskSpace: WizardRoute(
+          builder: AllocateDiskSpacePage.create,
+          userData: InstallationStep.filesystem.index,
+        ),
+      },
+    );
+  }
+
+  String? _nextRoute(dynamic arguments) {
+    final service = getService<DiskStorageService>();
+    if (arguments == InstallationType.manual) {
+      return Routes.allocateDiskSpace;
+    } else if (service.guidedTarget == null) {
+      if (arguments == InstallationType.bitlocker) {
+        return Routes.bitlocker;
+      } else if (arguments == InstallationType.erase) {
+        return Routes.selectGuidedStorage;
+      } else if (arguments == InstallationType.alongside) {
+        return Routes.installAlongside;
+      }
+    } else if (service.useEncryption && service.securityKey == null) {
+      return Routes.securityKey;
+    }
+    return Routes.writeChangesToDisk;
+  }
+}

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_model.dart
@@ -18,6 +18,9 @@ class InstallAlongsideModel extends SafeChangeNotifier {
   int? _selectedIndex;
   int? _currentSize;
 
+  /// Whether the filesystem wizard is at the end.
+  bool get isDone => !_service.useEncryption;
+
   /// Detailed info of the product being installed.
   ProductInfo get productInfo => _product.getProductInfo();
 

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
@@ -115,6 +115,7 @@ class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
         trailing: [
           WizardAction.next(
             context,
+            root: model.isDone,
             label: lang.selectGuidedStorageInstallNow,
             onNext: model.selectedStorage != null ? model.save : null,
             onBack: model.reset,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
@@ -106,6 +106,24 @@ class InstallationTypeModel extends SafeChangeNotifier {
         false;
   }
 
+  /// Whether the filesystem wizard is at the end.
+  bool get isDone {
+    switch (_installationType) {
+      case InstallationType.erase:
+        return !_diskService.useEncryption &&
+            _storages?.whereType<GuidedStorageTargetReformat>().length == 1;
+      case InstallationType.alongside:
+        return !_diskService.useEncryption &&
+            _storages?.any((t) => t is GuidedStorageTargetUseGap) == true;
+      case InstallationType.reinstall:
+        throw UnimplementedError();
+      case InstallationType.manual:
+      case InstallationType.bitlocker:
+      case null:
+        return false;
+    }
+  }
+
   /// Initializes the model.
   Future<void> init() async {
     await _diskService.getGuidedStorage().then((r) => _storages = r.possible);

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
@@ -159,10 +159,11 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
         ],
       ),
       bottomBar: WizardBar(
-        leading: WizardAction.back(context),
+        leading: WizardAction.back(context, root: true),
         trailing: [
           WizardAction.next(
             context,
+            root: model.isDone,
             enabled: model.hasStorage,
             arguments: model.installationType,
             onNext: model.save,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
@@ -88,6 +88,7 @@ class _SecurityKeyPageState extends State<SecurityKeyPage> {
         trailing: [
           WizardAction.next(
             context,
+            root: true,
             enabled: context
                 .select<SecurityKeyModel, bool>((model) => model.isValid),
             onNext: context.read<SecurityKeyModel>().saveSecurityKey,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_model.dart
@@ -15,6 +15,9 @@ class SelectGuidedStorageModel extends SafeChangeNotifier {
   var _disks = <String, Disk>{};
   var _selectedIndex = 0;
 
+  /// Whether the filesystem wizard is at the end.
+  bool get isDone => !_service.useEncryption;
+
   /// Available storages for guided partitioning.
   List<GuidedStorageTarget> get storages => _storages;
 

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
@@ -122,6 +122,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
         trailing: [
           WizardAction.next(
             context,
+            root: model.isDone,
             label: lang.selectGuidedStorageInstallNow,
             onNext: model.saveGuidedStorage,
             // If the user returns back to select another disk, the previously

--- a/packages/ubuntu_desktop_installer/lib/routes.dart
+++ b/packages/ubuntu_desktop_installer/lib/routes.dart
@@ -22,4 +22,5 @@ abstract class Routes {
   static const timezone = '/timezone';
   static const notEnoughDiskSpace = '/not-enough-disk-space';
   static const activeDirectory = '/active-directory';
+  static const filesystem = '/filesystem';
 }

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.dart
@@ -35,6 +35,7 @@ void main() {
     int? minimumSize,
     int? maximumSize,
     int? totalSize,
+    bool? isDone,
   }) {
     final model = MockInstallAlongsideModel();
     when(model.storageCount).thenReturn(storageCount ?? 0);
@@ -57,6 +58,7 @@ void main() {
     when(model.minimumSize).thenReturn(minimumSize ?? 0);
     when(model.maximumSize).thenReturn(maximumSize ?? 1);
     when(model.totalSize).thenReturn(totalSize ?? 0);
+    when(model.isDone).thenReturn(isDone ?? false);
     return model;
   }
 
@@ -203,6 +205,7 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final storage = MockDiskStorageService();
     when(storage.existingOS).thenReturn([]);
+    when(storage.useEncryption).thenReturn(false);
     when(storage.getStorage()).thenAnswer((_) async => []);
     when(storage.getGuidedStorage())
         .thenAnswer((_) async => testGuidedStorageResponse());

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_page_test.mocks.dart
@@ -43,6 +43,11 @@ class MockInstallAlongsideModel extends _i1.Mock
   }
 
   @override
+  bool get isDone => (super.noSuchMethod(
+        Invocation.getter(#isDone),
+        returnValue: false,
+      ) as bool);
+  @override
   _i2.ProductInfo get productInfo => (super.noSuchMethod(
         Invocation.getter(#productInfo),
         returnValue: _FakeProductInfo_0(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
@@ -58,6 +58,7 @@ void main() {
     when(model.canInstallAlongside).thenReturn(false);
     when(model.hasStorage).thenReturn(true);
     when(model.hasBitLocker).thenReturn(false);
+    when(model.isDone).thenReturn(false);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
@@ -90,6 +91,7 @@ void main() {
     when(model.canInstallAlongside).thenReturn(false);
     when(model.hasStorage).thenReturn(true);
     when(model.hasBitLocker).thenReturn(false);
+    when(model.isDone).thenReturn(false);
 
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -26,6 +26,7 @@ void main() {
     bool? canInstallAlongside,
     bool? hasStorage,
     bool? hasBitLocker,
+    bool? isDone,
   }) {
     final model = MockInstallationTypeModel();
     when(model.installationType)
@@ -38,6 +39,7 @@ void main() {
     when(model.canInstallAlongside).thenReturn(canInstallAlongside ?? false);
     when(model.hasStorage).thenReturn(hasStorage ?? true);
     when(model.hasBitLocker).thenReturn(hasBitLocker ?? false);
+    when(model.isDone).thenReturn(isDone ?? false);
     return model;
   }
 

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.mocks.dart
@@ -100,6 +100,11 @@ class MockInstallationTypeModel extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
+  bool get isDone => (super.noSuchMethod(
+        Invocation.getter(#isDone),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -34,6 +34,7 @@ void main() {
     int? selectedIndex,
     Disk? selectedDisk,
     GuidedStorageTargetReformat? selectedStorage,
+    bool? isDone,
   }) {
     final model = MockSelectGuidedStorageModel();
     when(model.storages)
@@ -45,6 +46,7 @@ void main() {
         .thenAnswer((i) => disks?.elementAtOrNull(i.positionalArguments.first));
     when(model.getStorage(any)).thenAnswer(
         (i) => storages?.elementAtOrNull(i.positionalArguments.first));
+    when(model.isDone).thenReturn(isDone ?? false);
     return model;
   }
 
@@ -125,6 +127,7 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer((_) async => []);
+    when(service.useEncryption).thenReturn(false);
     when(service.getGuidedStorage())
         .thenAnswer((_) async => testGuidedStorageResponse());
     registerMockService<DiskStorageService>(service);

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.mocks.dart
@@ -32,6 +32,11 @@ class MockSelectGuidedStorageModel extends _i1.Mock
   }
 
   @override
+  bool get isDone => (super.noSuchMethod(
+        Invocation.getter(#isDone),
+        returnValue: false,
+      ) as bool);
+  @override
   List<_i3.GuidedStorageTarget> get storages => (super.noSuchMethod(
         Invocation.getter(#storages),
         returnValue: <_i3.GuidedStorageTarget>[],

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -30,14 +30,16 @@ class WizardAction {
     bool? visible,
     bool? enabled,
     WizardCallback? onBack,
+    bool root = false,
   }) {
     return WizardAction(
       label: UbuntuLocalizations.of(context).previousLabel,
       visible: visible,
       flat: true,
-      enabled: enabled ?? Wizard.maybeOf(context)?.hasPrevious ?? false,
+      enabled:
+          enabled ?? Wizard.maybeOf(context, root: root)?.hasPrevious ?? false,
       onActivated: onBack,
-      execute: () => Wizard.maybeOf(context)?.back(),
+      execute: () => Wizard.maybeOf(context, root: root)?.back(),
     );
   }
 
@@ -52,6 +54,7 @@ class WizardAction {
     Object? arguments,
     WizardCallback? onNext,
     WizardCallback? onBack,
+    bool root = false,
   }) {
     return WizardAction(
       label: label ?? UbuntuLocalizations.of(context).nextLabel,
@@ -61,7 +64,7 @@ class WizardAction {
       highlighted: highlighted,
       onActivated: onNext,
       execute: () async {
-        await Wizard.maybeOf(context)?.next(arguments: arguments);
+        await Wizard.maybeOf(context, root: root)?.next(arguments: arguments);
         onBack?.call();
       },
     );
@@ -77,6 +80,7 @@ class WizardAction {
     bool? highlighted,
     Object? result,
     WizardCallback? onDone,
+    bool root = false,
   }) {
     return WizardAction(
       label: label,
@@ -85,7 +89,7 @@ class WizardAction {
       flat: flat,
       highlighted: highlighted,
       onActivated: onDone,
-      execute: () => Wizard.maybeOf(context)?.done(result: result),
+      execute: () => Wizard.maybeOf(context, root: root)?.done(result: result),
     );
   }
 

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
       path: packages/ubuntu_widgets
       ref: aba58a93465a4ed9040f805d513d47c49f1c941a
   url_launcher: ^6.1.0
-  wizard_router: ^0.10.1
+  wizard_router: ^0.10.2
   yaru: ^0.7.0
   yaru_colors: ^0.1.6
   yaru_widgets: ^2.4.0


### PR DESCRIPTION
This is a preparation step for semi-automated installs. If Subiquity reports that "filesystem" requires configuration, the user is taken to the subwizard. This is just an implementation detail, though. Visually, it looks the same as before in manual installs.

Ref: #1844