### PR TITLE
Move has_bitlocker call from startup to installation_type

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
@@ -49,6 +49,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
   InstallationType? _installationType;
   var _advancedFeature = AdvancedFeature.none;
   var _encryption = false;
+  var _hasBitLocker = false;
   List<GuidedStorageTarget>? _storages;
 
   /// The selected installation type.
@@ -93,7 +94,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
   bool get hasStorage => _storages != null;
 
   /// Whether BitLocker is detected.
-  bool get hasBitLocker => _diskService.hasBitLocker;
+  bool get hasBitLocker => _hasBitLocker;
 
   /// Whether installation alongside an existing OS is possible.
   ///
@@ -133,6 +134,7 @@ class InstallationTypeModel extends SafeChangeNotifier {
     _advancedFeature =
         _diskService.useLvm ? AdvancedFeature.lvm : AdvancedFeature.none;
     _encryption = _diskService.useEncryption;
+    _hasBitLocker = await _diskService.hasBitLocker();
     notifyListeners();
   }
 

--- a/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/disk_storage_service.dart
@@ -19,10 +19,7 @@ class DiskStorageService {
     final status = await _client.status();
     if (status.state == ApplicationState.ERROR) return;
     await _client.getStorageV2().then(_updateStorage);
-    await Future.wait([
-      _client.hasRst().then((value) => _hasRst = value),
-      _client.hasBitLocker().then((value) => _hasBitLocker = value),
-    ]);
+    await _client.hasRst().then((value) => _hasRst = value);
   }
 
   bool? _needRoot;
@@ -30,7 +27,6 @@ class DiskStorageService {
   bool? _useLvm;
   bool? _useEncryption;
   bool? _hasRst;
-  bool? _hasBitLocker;
   bool? _hasMultipleDisks;
   int? _installMinimumSize;
   int? _largestDiskSize;
@@ -48,8 +44,6 @@ class DiskStorageService {
   bool get needBoot => _needBoot ?? true;
 
   bool get hasRst => _hasRst ?? false;
-
-  bool get hasBitLocker => _hasBitLocker ?? false;
 
   /// Whether FDE (Full Disk Encryption) should be used.
   bool get useEncryption => _useEncryption ?? false;
@@ -96,6 +90,9 @@ class DiskStorageService {
 
   /// Returns whether the system has enough disk space to install.
   bool get hasEnoughDiskSpace => installMinimumSize <= largestDiskSize;
+
+  /// Fetches whether the system has BitLocker enabled.
+  Future<bool> hasBitLocker() => _client.hasBitLocker();
 
   /// Fetches the current guided storage configuration.
   Future<GuidedStorageResponseV2> getGuidedStorage() async {

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_model_test.mocks.dart
@@ -62,11 +62,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -137,6 +132,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install_alongside/install_alongside_model_test.mocks.dart
@@ -73,11 +73,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -148,6 +143,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+  @override
+  _i5.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
   @override
   _i5.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.dart
@@ -16,7 +16,7 @@ void main() {
     final service = MockDiskStorageService();
     when(service.useLvm).thenReturn(true);
     when(service.useEncryption).thenReturn(true);
-    when(service.hasBitLocker).thenReturn(true);
+    when(service.hasBitLocker()).thenAnswer((_) async => true);
     when(service.getGuidedStorage())
         .thenAnswer((_) async => testGuidedStorageResponse());
 
@@ -174,6 +174,7 @@ void main() {
     when(service.useEncryption).thenReturn(false);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => testGuidedStorageResponse(possible: [reformat]));
+    when(service.hasBitLocker()).thenAnswer((_) async => false);
 
     final model = InstallationTypeModel(
       service,
@@ -194,6 +195,7 @@ void main() {
     when(service.useEncryption).thenReturn(false);
     when(service.useLvm).thenReturn(false);
     when(service.useEncryption).thenReturn(false);
+    when(service.hasBitLocker()).thenAnswer((_) async => false);
 
     final model = InstallationTypeModel(
       service,
@@ -250,6 +252,8 @@ void main() {
     final service = MockDiskStorageService();
     when(service.useLvm).thenReturn(false);
     when(service.useEncryption).thenReturn(false);
+    when(service.hasBitLocker()).thenAnswer((_) async => false);
+
     final model = InstallationTypeModel(
       service,
       MockTelemetryService(),

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_model_test.mocks.dart
@@ -75,11 +75,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -150,6 +145,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+  @override
+  _i5.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
   @override
   _i5.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/not_enough_disk_space/not_enough_disk_space_model_test.mocks.dart
@@ -62,11 +62,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -137,6 +132,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/security_key/security_key_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/security_key/security_key_model_test.mocks.dart
@@ -62,11 +62,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -137,6 +132,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_model_test.mocks.dart
@@ -62,11 +62,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -137,6 +132,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -219,14 +219,12 @@ void main() {
     final service = DiskStorageService(client);
 
     when(client.hasBitLocker()).thenAnswer((_) async => true);
-    await service.init();
-    expect(service.hasBitLocker, isTrue);
+    expect(await service.hasBitLocker(), isTrue);
     verify(client.hasBitLocker()).called(1);
 
     when(client.hasBitLocker()).thenAnswer((_) async => false);
-    await service.init();
+    expect(await service.hasBitLocker(), isFalse);
     verify(client.hasBitLocker()).called(1);
-    expect(service.hasBitLocker, isFalse);
   });
 
   test('existing OS', () async {

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.mocks.dart
@@ -62,11 +62,6 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  bool get hasBitLocker => (super.noSuchMethod(
-        Invocation.getter(#hasBitLocker),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get useEncryption => (super.noSuchMethod(
         Invocation.getter(#useEncryption),
         returnValue: false,
@@ -137,6 +132,14 @@ class MockDiskStorageService extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+  @override
+  _i4.Future<bool> hasBitLocker() => (super.noSuchMethod(
+        Invocation.method(
+          #hasBitLocker,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
   @override
   _i4.Future<_i2.GuidedStorageResponseV2> getGuidedStorage() =>
       (super.noSuchMethod(


### PR DESCRIPTION
This takes us one step closer to removing the unconditional source selection on startup. The one and only screen that needs this information is the _Installation type_ screen. We can fetch it there instead of doing it on startup.