### PR TITLE
Shrink network page radio buttons tap area

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
@@ -62,7 +62,7 @@ class _NetworkPageState extends State<NetworkPage> {
       ),
       header: Text(lang.connectToInternetDescription),
       content: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           EthernetRadioButton(
             value: model.connectMode,


### PR DESCRIPTION
Closes https://github.com/canonical/ubuntu-desktop-installer/issues/1673.

The fix is just a one liner, by aligning the text at the start instead of stretching each radio wraps to occupy just the size  of its text. 

cc: @jpnurmi 