### PR TITLE
Remove Wizard(Action).done

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/installation_complete/installation_complete_page.dart
@@ -58,7 +58,6 @@ class InstallationCompletePage extends StatelessWidget {
                       child: ElevatedButton(
                         onPressed: () async {
                           final window = YaruWindow.of(context);
-                          await Wizard.of(context).done();
                           model.reboot().then((_) => window.close());
                         },
                         child: Text(lang.restartNow),
@@ -67,11 +66,7 @@ class InstallationCompletePage extends StatelessWidget {
                     const SizedBox(width: kContentSpacing),
                     Expanded(
                       child: OutlinedButton(
-                        onPressed: () async {
-                          final window = YaruWindow.of(context);
-                          await Wizard.of(context).done();
-                          window.close();
-                        },
+                        onPressed: YaruWindow.of(context).close,
                         child: Text(lang.continueTesting),
                       ),
                     ),

--- a/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -90,10 +90,7 @@ class NotEnoughDiskSpacePage extends StatelessWidget {
               const SizedBox(height: kContentSpacing),
               FilledButton(
                   onPressed: () async {
-                    await Wizard.of(context).done();
-                    if (context.mounted) {
-                      YaruWindow.of(context).close();
-                    }
+                    YaruWindow.of(context).close();
                     // TODO: tell subiquity to quit?
                   },
                   child: Text(lang.quitButtonText)),

--- a/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/try_or_install/try_or_install_page.dart
@@ -101,11 +101,10 @@ class TryOrInstallPageState extends State<TryOrInstallPage> {
       bottomBar: WizardBar(
         leading: WizardAction.back(context),
         trailing: [
-          WizardAction.done(
-            context,
+          WizardAction(
             label: UbuntuLocalizations.of(context).nextLabel,
             visible: model.option == Option.tryUbuntu,
-            onDone: YaruWindow.of(context).close,
+            execute: YaruWindow.of(context).close,
           ),
           WizardAction.next(
             context,

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_action.dart
@@ -70,29 +70,6 @@ class WizardAction {
     );
   }
 
-  /// An action that finishes the wizard.
-  factory WizardAction.done(
-    BuildContext context, {
-    String? label,
-    bool? visible,
-    bool? enabled,
-    bool? flat,
-    bool? highlighted,
-    Object? result,
-    WizardCallback? onDone,
-    bool root = false,
-  }) {
-    return WizardAction(
-      label: label,
-      visible: visible,
-      enabled: enabled,
-      flat: flat,
-      highlighted: highlighted,
-      onActivated: onDone,
-      execute: () => Wizard.maybeOf(context, root: root)?.done(result: result),
-    );
-  }
-
   /// Text label of the back button.
   final String? label;
 


### PR DESCRIPTION
It was used to finish the telemetry report and write it on the disk but that approach didn't work because Subiquity copies it to /target when it finishes installing and it's too late to write anything from the GUI when it quits. Also, writing any telemetry data from early exits is irrelevant because it doesn't end up stored anywhere anyway.