### PR TITLE
Sort out imports and exports

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -6,8 +6,6 @@ import 'package:integration_test/integration_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
-import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
-import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';

--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -6,8 +6,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
-import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
-import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';

--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -8,8 +8,6 @@ import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/main.dart' as app;
 import 'package:ubuntu_desktop_installer/pages.dart';
-import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
-import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages.dart
@@ -1,11 +1,5 @@
 export 'pages/active_directory/active_directory_page.dart';
-export 'pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart';
-export 'pages/filesystem/bitlocker/bitlocker_page.dart';
 export 'pages/filesystem/filesystem_page.dart';
-export 'pages/filesystem/install_alongside/install_alongside_page.dart';
-export 'pages/filesystem/installation_type/installation_type_page.dart';
-export 'pages/filesystem/security_key/security_key_page.dart';
-export 'pages/filesystem/select_guided_storage/select_guided_storage_page.dart';
 export 'pages/identity/identity_page.dart';
 export 'pages/installation_complete/installation_complete_page.dart';
 export 'pages/installation_slides/installation_slides_page.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_desktop_installer/installer.dart';
+import 'package:ubuntu_desktop_installer/routes.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../../installer.dart';
-import '../../routes.dart';
-import '../../services.dart';
 import 'allocate_disk_space/allocate_disk_space_page.dart';
 import 'bitlocker/bitlocker_page.dart';
 import 'install_alongside/install_alongside_page.dart';

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
@@ -12,7 +12,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'installation_type_dialogs.dart';
 import 'installation_type_model.dart';
 
-export 'installation_type_model.dart' show InstallationType;
+export 'installation_type_model.dart' show AdvancedFeature, InstallationType;
 
 /// Select between guided and manual partitioning.
 class InstallationTypePage extends StatefulWidget {

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
@@ -15,6 +15,8 @@ import 'network_model.dart';
 import 'wifi_model.dart';
 import 'wifi_view.dart';
 
+export 'connect_model.dart' show ConnectMode;
+
 /// https://github.com/canonical/ubuntu-desktop-installer/issues/30
 class NetworkPage extends StatefulWidget {
   @visibleForTesting


### PR DESCRIPTION
- migrate to barrel imports
- clean up unnecessary exports
- export relevant enums together with pages to avoid the need of importing internals for high level integration testing