### PR TITLE
Replace wrong "Install now" labels with "Next" buttons

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -304,7 +304,7 @@ Future<void> testSelectGuidedStoragePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapButton(tester.lang.selectGuidedStorageInstallNow);
+  await tester.tapContinue();
 }
 
 Future<void> testInstallAlongsidePage(
@@ -338,7 +338,7 @@ Future<void> testInstallAlongsidePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapButton(tester.lang.selectGuidedStorageInstallNow);
+  await tester.tapContinue();
 }
 
 Future<void> testWriteChangesToDiskPage(

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
@@ -116,7 +116,6 @@ class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
           WizardAction.next(
             context,
             root: model.isDone,
-            label: lang.selectGuidedStorageInstallNow,
             onNext: model.selectedStorage != null ? model.save : null,
             onBack: model.reset,
           ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
@@ -123,7 +123,6 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
           WizardAction.next(
             context,
             root: model.isDone,
-            label: lang.selectGuidedStorageInstallNow,
             onNext: model.saveGuidedStorage,
             // If the user returns back to select another disk, the previously
             // configured guided storage must be reset to avoid multiple disks

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -116,11 +116,11 @@ void main() {
     verify(model.loadGuidedStorage()).called(1);
     verifyNever(model.saveGuidedStorage());
 
-    final installButton = find.widgetWithText(
-        FilledButton, tester.lang.selectGuidedStorageInstallNow);
-    expect(installButton, findsOneWidget);
+    final continueButton =
+        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
+    expect(continueButton, findsOneWidget);
 
-    await tester.tap(installButton);
+    await tester.tap(continueButton);
     verify(model.saveGuidedStorage()).called(1);
   });
 


### PR DESCRIPTION
The "Install now" button label doesn't make sense in these guided partitioning screens. When encryption is not used, the transition from a filled "Install now" to an elevated "Install" button is awkward. When encryption is used, things get even weirder because there's an extra "Next" button in between "Install now" and "Install".

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/234909221-6b13d29b-c8e5-49a3-95b6-a7098526d0a5.png) | ![Screenshot from 2023-04-27 17-13-02](https://user-images.githubusercontent.com/140617/234908104-145ccd83-7968-4719-bb16-995185c7c313.png) |

Illustrated by the A->B->C flow below:

- Before: "Install now" -> "Next" -> "Install"
- After: "Next" -> "Next" -> "Install"

| A | B | C |
|---|---|---|
| ![Screenshot from 2023-04-27 17-13-02](https://user-images.githubusercontent.com/140617/234908104-145ccd83-7968-4719-bb16-995185c7c313.png) | ![image](https://user-images.githubusercontent.com/140617/234908939-dfce9564-68aa-433a-9eb4-9254bab55332.png) | ![Screenshot from 2023-04-27 17-13-14](https://user-images.githubusercontent.com/140617/234908143-7419f09a-f533-4669-b6cf-b0d5296cf58a.png) |