### PR TITLE
Prevent `Guarded function conflict` on tests.

### DIFF
--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -167,6 +167,7 @@ void expectPage(
   String Function(AppLocalizations lang) title,
 ) {
   LangTester.type = page;
-  expect(find.byType(page), findsOneWidget);
-  expect(find.widgetWithText(AppBar, title(tester.lang)), findsWidgets);
+  // Prevent `Guarded function conflict` on tests.
+  expectSync(find.byType(page), findsOneWidget);
+  expectSync(find.widgetWithText(AppBar, title(tester.lang)), findsWidgets);
 }


### PR DESCRIPTION
Recently we started to see this error quite often when testing on Windows. The error is quite clear:

```
FlutterError: Guarded function conflict.
  	You must use "await" with all Future-returning test APIs.
  	The guarded method "pump" from class WidgetTester was called from package:***_test/src/integration_test.dart on line 174.
  	Then, the "expect" function was called from file:///C:/actions-runner/_work/WSL/WSL/***-desktop-installer/packages/***_wsl_setup/integration_test/test_pages.dart on line 171.
  	The first method (WidgetTester.pump) had not yet finished executing at the time that the second function (expect) was called. Since both are guarded, and the second was not a
      nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the
      call to the first.
  	If you are confident that all test APIs are being called using "await", and this expect() call is not being called at the top level but is itself being called from some sort of
      callback registered before the pump method was called, then consider using expectSync() instead.
      
```

Since we are very consistent in applying `await` let's try the `expectSync()` approach suggested by the framework.