### PR TITLE
Update melos to version 3

### DIFF
--- a/packages/ubuntu_desktop_installer/pubspec_overrides.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec_overrides.yaml
@@ -1,5 +1,8 @@
+# melos_managed_dependency_overrides: ubuntu_test
 dependency_overrides:
   subiquity_client:
     path: ../subiquity_client
+  ubuntu_test:
+    path: ../ubuntu_test
   ubuntu_wizard:
     path: ../ubuntu_wizard

--- a/packages/ubuntu_wizard/pubspec_overrides.yaml
+++ b/packages/ubuntu_wizard/pubspec_overrides.yaml
@@ -1,3 +1,6 @@
+# melos_managed_dependency_overrides: ubuntu_test
 dependency_overrides:
   subiquity_client:
     path: ../subiquity_client
+  ubuntu_test:
+    path: ../ubuntu_test

--- a/packages/ubuntu_wsl_setup/pubspec_overrides.yaml
+++ b/packages/ubuntu_wsl_setup/pubspec_overrides.yaml
@@ -1,5 +1,8 @@
+# melos_managed_dependency_overrides: ubuntu_test
 dependency_overrides:
   subiquity_client:
     path: ../subiquity_client
+  ubuntu_test:
+    path: ../ubuntu_test
   ubuntu_wizard:
     path: ../ubuntu_wizard

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,6 @@
+name: ubuntu_desktop_installer_workspace
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+dev_dependencies:
+  melos: ^3.0.1


### PR DESCRIPTION
This PR updates the project to use melos 3, this solves one of the issues described in  #1885. The only required change to support melos 3 is https://github.com/canonical/ubuntu-desktop-installer/commit/b45b70f90a45ccaebdf88ed5ed3c896ad8253271, that adds a `pubspec.yaml` at the root of the  project.  

I followed the migration steps at their website https://melos.invertase.dev/guides/migrations, and also tested that all `scripts` continue to work.

cc: @jpnurmi 