### PR TITLE
Adapt tests to wizard button changes

### DIFF
--- a/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
@@ -144,35 +144,26 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   testWidgets('save AD connection info', (tester) async {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.save()).called(1);
 
     verify(model.getJoinResult()).called(1);
@@ -185,13 +176,10 @@ void main() {
         buildModel(isValid: true, joinResult: AdJoinResult.JOIN_ERROR);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.save()).called(1);
 
     verify(model.getJoinResult()).called(1);

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -13,6 +13,7 @@ import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/al
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/storage_selector.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test_utils.dart';
@@ -300,13 +301,10 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
     verifyNever(model.reformatDisk(disk));
 
-    final continueButton = find.descendant(
-      of: find.byType(AlertDialog),
-      matching: find.text(tester.ulang.okLabel),
-    );
-    expect(continueButton, findsOneWidget);
+    final okButton = find.button(tester.ulang.okLabel);
+    expect(okButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(okButton);
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsNothing);
@@ -357,13 +355,10 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.setStorage()).called(1);
   });
 
@@ -371,12 +366,9 @@ void main() {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   testWidgets('too many primary partitions', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/bitlocker/bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/bitlocker/bitlocker_page_test.dart
@@ -42,11 +42,11 @@ void main() {
     await tester.pumpAndSettle();
     verifyNever(model.reboot());
 
-    final continueButton = find.descendant(
+    final dialogButton = find.descendant(
         of: find.byType(AlertDialog),
         matching: find.text(tester.lang.restartButtonText));
 
-    await tester.tap(continueButton);
+    await tester.tap(dialogButton);
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsNothing);

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -204,22 +204,16 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   testWidgets('auto-login', (tester) async {
@@ -270,13 +264,10 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.save()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
@@ -8,6 +8,7 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_model.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test_utils.dart';
@@ -47,8 +48,7 @@ void main() {
     final model = MockInstallationCompleteModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton =
-        find.widgetWithText(OutlinedButton, tester.lang.continueTesting);
+    final continueButton = find.button(tester.lang.continueTesting);
     expect(continueButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -8,6 +8,7 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test_utils.dart';
@@ -376,14 +377,11 @@ void main() {
     final model = buildModel(hasStorage: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, false);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, false);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verifyNever(model.save());
   });
 
@@ -391,13 +389,10 @@ void main() {
     final model = buildModel(hasStorage: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.save()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -131,24 +131,18 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   testWidgets('key search', (tester) async {
@@ -183,12 +177,9 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    await tester.tap(continueButton);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     verify(model.updateInputSource()).called(1);

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -147,11 +147,10 @@ void main() {
   testWidgets('should continue to next page', (tester) async {
     await setUpApp(tester);
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     expect(find.byType(LocalePage), findsNothing);

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -16,6 +16,7 @@ import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_view.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -185,10 +186,9 @@ void main() {
     verify(model.init()).called(1);
     verifyNever(model.cleanup());
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    await tester.tap(continueButton);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     verifyNever(model.init());
@@ -276,10 +276,9 @@ void main() {
     verify(model.init()).called(1);
     verifyNever(model.cleanup());
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    await tester.tap(continueButton);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     verify(model.markConfigured()).called(1);

--- a/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
@@ -110,21 +110,15 @@ void main() {
     final model = buildModel(isFormValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isFormValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/security_key/security_key_page_test.dart
@@ -64,22 +64,16 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   testWidgets('show security key', (tester) async {
@@ -98,13 +92,10 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.saveSecurityKey()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/select_guided_storage/select_guided_storage_page_test.dart
@@ -10,6 +10,7 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/select_guided_storage/select_guided_storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/select_guided_storage/select_guided_storage_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 import '../test_utils.dart';
@@ -117,11 +118,10 @@ void main() {
     verify(model.loadGuidedStorage()).called(1);
     verifyNever(model.saveGuidedStorage());
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.saveGuidedStorage()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -10,6 +10,7 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/source/source_model.dart';
 import 'package:ubuntu_desktop_installer/pages/source/source_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -185,12 +186,9 @@ void main() {
     final model = buildModel(sourceId: kNormalSourceId);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    expect(continueButton, findsOneWidget);
-    await tester.tap(continueButton);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     verify(model.save()).called(1);

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -9,6 +9,7 @@ import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_model.dart';
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 
 import '../test_utils.dart';
 import 'timezone_page_test.mocks.dart';
@@ -68,11 +69,8 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildPage(model, controller)));
 
-    final continueButton = find.widgetWithText(
-      FilledButton,
-      tester.ulang.nextLabel,
-    );
-    await tester.tap(continueButton);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    await tester.tap(nextButton);
     verify(model.save(null)).called(1);
   });
 
@@ -289,17 +287,14 @@ void main() {
     expect(controller, isNotNull);
   });
 
-  testWidgets('back button is disabled', (tester) async {
+  testWidgets('previous button is disabled', (tester) async {
     final model = buildModel();
     final controller = buildController();
     await tester
         .pumpWidget(tester.buildApp((_) => buildPage(model, controller)));
 
-    final backButton = find.widgetWithText(
-      OutlinedButton,
-      tester.ulang.previousLabel,
-    );
-    expect(backButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(backButton).enabled, isFalse);
+    final previousButton = find.button(tester.ulang.previousLabel);
+    expect(previousButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(previousButton).enabled, isFalse);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
@@ -43,11 +43,11 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
     verifyNever(model.reboot());
 
-    final continueButton = find.descendant(
+    final dialogButton = find.descendant(
         of: find.byType(AlertDialog),
         matching: find.text(tester.lang.restartButtonText));
 
-    await tester.tap(continueButton);
+    await tester.tap(dialogButton);
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsNothing);

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -106,12 +106,9 @@ void main() {
   testWidgets('selecting an option should enable continuing', (tester) async {
     await setUpApp(tester);
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    expect(
-        (continueButton.evaluate().single.widget as ButtonStyleButton).enabled,
-        false);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, false);
 
     final options = find.byType(OptionButton);
     expect(options, findsWidgets);
@@ -119,8 +116,7 @@ void main() {
     await tester.tap(options.first);
     await tester.pump();
 
-    expect(
-        (continueButton.evaluate().single.widget as ButtonStyleButton).enabled,
+    expect((nextButton.evaluate().single.widget as ButtonStyleButton).enabled,
         true);
   });
 
@@ -134,11 +130,10 @@ void main() {
     await tester.tap(option);
     await tester.pump();
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     await tester.pumpAndSettle();
 
     expect(find.byType(WelcomePage), findsNothing);
@@ -148,10 +143,9 @@ void main() {
   testWidgets('try ubuntu', (tester) async {
     await setUpApp(tester);
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
 
     final option =
         find.widgetWithText(OptionButton, tester.lang.tryUbuntu('Ubuntu'));
@@ -160,11 +154,11 @@ void main() {
     await tester.tap(option);
     await tester.pump();
 
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
 
     final windowClosed = YaruTestWindow.waitForClosed();
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     await tester.pump();
 
     await expectLater(windowClosed, completes);

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -10,6 +10,7 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/write_changes_to_disk/write_changes_to_disk_model.dart';
 import 'package:ubuntu_desktop_installer/pages/write_changes_to_disk/write_changes_to_disk_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 
 import '../test_utils.dart';
 import 'write_changes_to_disk_model_test.mocks.dart';
@@ -164,13 +165,10 @@ void main() {
     final model = buildModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.widgetWithText(
-      ElevatedButton,
-      tester.lang.startInstallingButtonText,
-    );
-    expect(continueButton, findsOneWidget);
+    final installButton = find.button(tester.lang.startInstallingButtonText);
+    expect(installButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(installButton);
     verifyNever(model.startInstallation());
 
     await tester.pumpAndSettle(kThemeAnimationDuration);

--- a/packages/ubuntu_test/lib/src/finders.dart
+++ b/packages/ubuntu_test/lib/src/finders.dart
@@ -2,6 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 extension UbuntuCommonFinders on CommonFinders {
+  /// Finds a button specified by its [label].
+  ///
+  /// The button can be any [ButtonStyleButton] subclass,
+  /// such as [FilledButton], [OutlinedButton], or [ElevatedButton].
+  Finder button(String label) {
+    return ancestor(
+      of: find.text(label),
+      matching: find.bySubtype<ButtonStyleButton>(),
+    );
+  }
+
   /// Finds a [TextField] specified by its [label] (or hint).
   Finder textField(String label) => find.widgetWithText(TextField, label);
 }

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -165,20 +165,18 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isTrue);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isTrue);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
-    expect(tester.widget<ButtonStyleButton>(continueButton).enabled, isFalse);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
+    expect(tester.widget<ButtonStyleButton>(nextButton).enabled, isFalse);
   });
 
   // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
@@ -207,11 +205,10 @@ void main() {
     verify(model.loadProfileSetup()).called(1);
     verifyNever(model.saveProfileSetup());
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.saveProfileSetup()).called(1);
   });
 

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
@@ -88,11 +89,10 @@ void main() {
     verifyNever(model.getServerLocale());
     verify(model.selectLocale(Locale('fr_FR'))).called(1);
 
-    final continueButton =
-        find.widgetWithText(FilledButton, tester.ulang.nextLabel);
-    expect(continueButton, findsOneWidget);
+    final nextButton = find.button(tester.ulang.nextLabel);
+    expect(nextButton, findsOneWidget);
 
-    await tester.tap(continueButton);
+    await tester.tap(nextButton);
     verify(model.applyLocale(Locale('fr_FR'))).called(1);
   });
 


### PR DESCRIPTION
The former _Back_ & _Continue_ wizard buttons were changed to _Previous_ & _Next_ last minute before the UI freeze, deliberately keeping the changes to a minimum. This PR adapts the remaining finder variables etc. to ensure consistent naming in tests.

- #1644