### PR TITLE
Add additional convenience finders for buttons and alike

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -9,6 +9,7 @@ import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru/yaru.dart';
@@ -362,7 +363,7 @@ void main() {
         '$currentThemeName/14.installation-slide-$i',
       );
       if (i < defaultSlides.length - 1) {
-        await tester.tap(find.byIcon(YaruIcons.pan_end));
+        await tester.tap(find.iconButton(YaruIcons.pan_end));
         await tester.pump(kThemeAnimationDuration);
       }
     }

--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -9,7 +9,6 @@ import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 import 'package:yaru_window_test/yaru_window_test.dart';
 
 import '../test/test_utils.dart';
@@ -25,7 +24,7 @@ Future<void> testLocalePage(
   await tester.pumpAndSettle(); // auto-scroll
 
   if (language != null) {
-    final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
+    final tile = find.listTile(language, skipOffstage: false);
     await tester.ensureVisible(tile);
     await tester.pump();
     await tester.tap(tile);
@@ -49,13 +48,7 @@ Future<void> testWelcomePage(
       tester, WelcomePage, (lang) => lang.tryOrInstallPageTitle('Ubuntu'));
 
   if (option != null) {
-    final labels = {
-      Option.repairUbuntu: tester.lang.repairInstallation,
-      Option.tryUbuntu: tester.lang.tryUbuntu('Ubuntu'),
-      Option.installUbuntu: tester.lang.installUbuntu('Ubuntu'),
-    };
-    await tester
-        .tap(find.widgetWithText(YaruRadioButton<Option>, labels[option]!));
+    await tester.tap(find.radio<Option>(option));
     await tester.pump();
   }
   await tester.pumpAndSettle();
@@ -79,16 +72,14 @@ Future<void> testKeyboardPage(
 
   if (keyboard != null) {
     if (keyboard.layout.isNotEmpty) {
-      final tile =
-          find.widgetWithText(ListTile, keyboard.layout, skipOffstage: false);
+      final tile = find.listTile(keyboard.layout, skipOffstage: false);
       await tester.ensureVisible(tile.last);
       await tester.pump();
       await tester.tap(tile.last);
       await tester.pump();
     }
     if (keyboard.variant.isNotEmpty) {
-      final tile =
-          find.widgetWithText(ListTile, keyboard.variant, skipOffstage: false);
+      final tile = find.listTile(keyboard.variant, skipOffstage: false);
       await tester.ensureVisible(tile.first);
       await tester.pump();
       await tester.tap(tile.first);

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -53,8 +53,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<PartitionFormat?>));
     await tester.pumpAndSettle();
 
-    await tester
-        .tap(find.widgetWithText(MenuItemButton, PartitionFormat.btrfs.name!));
+    await tester.tap(find.menuItem(PartitionFormat.btrfs.name!));
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(YaruAutocomplete<String>), '/tst');
@@ -143,8 +142,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<PartitionFormat?>));
     await tester.pumpAndSettle();
 
-    await tester
-        .tap(find.widgetWithText(MenuItemButton, PartitionFormat.btrfs.name!));
+    await tester.tap(find.menuItem(PartitionFormat.btrfs.name!));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byType(YaruCheckbox));

--- a/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -171,10 +171,7 @@ void main() {
         canReformatDisk: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final addButton = find.ancestor(
-      of: find.byIcon(Icons.add),
-      matching: find.byType(OutlinedButton),
-    );
+    final addButton = find.iconButton(Icons.add);
     expect(addButton, findsOneWidget);
     expect(addButton, isDisabled);
 
@@ -182,10 +179,7 @@ void main() {
     expect(editButton, findsOneWidget);
     expect(editButton, isDisabled);
 
-    final removeButton = find.ancestor(
-      of: find.byIcon(Icons.remove),
-      matching: find.byType(OutlinedButton),
-    );
+    final removeButton = find.iconButton(Icons.remove);
     expect(removeButton, findsOneWidget);
     expect(removeButton, isDisabled);
 
@@ -198,10 +192,7 @@ void main() {
     final model = buildModel(disks: testDisks, canAddPartition: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final addButton = find.ancestor(
-      of: find.byIcon(Icons.add),
-      matching: find.byType(OutlinedButton),
-    );
+    final addButton = find.iconButton(Icons.add);
     expect(addButton, findsOneWidget);
     expect(addButton, isEnabled);
   });
@@ -239,10 +230,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final removeButton = find.ancestor(
-      of: find.byIcon(Icons.remove),
-      matching: find.byType(OutlinedButton),
-    );
+    final removeButton = find.iconButton(Icons.remove);
     expect(removeButton, findsOneWidget);
     expect(removeButton, isEnabled);
 
@@ -362,10 +350,7 @@ void main() {
     final model = buildModel(selectedGap: unusableGap);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final addButton = find.ancestor(
-      of: find.byIcon(Icons.add),
-      matching: find.byType(OutlinedButton),
-    );
+    final addButton = find.iconButton(Icons.add);
     expect(addButton, isDisabled);
     expect(
       find.ancestor(

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -218,8 +218,7 @@ void main() {
     final model = buildModel(autoLogin: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final requiredPasswordSwitch = find.widgetWithText(
-      YaruSwitchButton,
+    final requiredPasswordSwitch = find.switchButton(
       tester.lang.whoAreYouPageRequirePassword,
     );
     expect(requiredPasswordSwitch, findsOneWidget);
@@ -274,8 +273,7 @@ void main() {
         buildModel(isConnected: true, hasActiveDirectorySupport: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final checkbox =
-        find.widgetWithText(YaruCheckButton, tester.lang.activeDirectoryOption);
+    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
     expect(checkbox, findsOneWidget);
     expect(tester.widget<YaruCheckButton>(checkbox).value, isFalse);
     expect(tester.widget<YaruCheckButton>(checkbox).onChanged, isNotNull);
@@ -289,8 +287,7 @@ void main() {
         buildModel(isConnected: true, hasActiveDirectorySupport: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final checkbox =
-        find.widgetWithText(YaruCheckButton, tester.lang.activeDirectoryOption);
+    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
     expect(checkbox, findsNothing);
   });
 
@@ -299,8 +296,7 @@ void main() {
         buildModel(isConnected: false, hasActiveDirectorySupport: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final checkbox =
-        find.widgetWithText(YaruCheckButton, tester.lang.activeDirectoryOption);
+    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
     expect(checkbox, findsOneWidget);
     expect(tester.widget<YaruCheckButton>(checkbox).value, isFalse);
     expect(tester.widget<YaruCheckButton>(checkbox).onChanged, isNull);

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -12,6 +12,7 @@ import 'package:ubuntu_desktop_installer/pages/installation_slides/installation_
 import 'package:ubuntu_desktop_installer/pages/installation_slides/slide_view.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/slides.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 import '../test_utils.dart';
@@ -101,7 +102,7 @@ void main() {
     expect(tester.widget<IconButton>(nextButton).onPressed, isNotNull);
 
     // go to second slide
-    await tester.tap(find.byIcon(YaruIcons.pan_end));
+    await tester.tap(find.iconButton(YaruIcons.pan_end));
     await tester.pumpAndSettle();
     expect(findsSlide('slide1'), findsNothing);
     expect(findsSlide('slide2'), findsOneWidget);
@@ -109,7 +110,7 @@ void main() {
     expect(tester.widget<IconButton>(nextButton).onPressed, isNull);
 
     // back to first slide
-    await tester.tap(find.byIcon(YaruIcons.pan_start));
+    await tester.tap(find.iconButton(YaruIcons.pan_start));
     await tester.pumpAndSettle();
     expect(findsSlide('slide1'), findsOneWidget);
     expect(findsSlide('slide2'), findsNothing);
@@ -130,7 +131,7 @@ void main() {
 
     expect(getLogOffset(tester), equals(1.0));
 
-    await tester.tap(find.byIcon(YaruIcons.terminal));
+    await tester.tap(find.iconButton(YaruIcons.terminal));
     verify(model.toggleLogVisibility()).called(1);
   });
 
@@ -141,7 +142,7 @@ void main() {
 
     expect(getLogOffset(tester), equals(0.0));
 
-    await tester.tap(find.byIcon(YaruIcons.terminal));
+    await tester.tap(find.iconButton(YaruIcons.terminal));
     verify(model.toggleLogVisibility()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_dialogs_test.dart
@@ -6,7 +6,6 @@ import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/inst
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_page.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
@@ -34,12 +33,12 @@ void main() {
         tester.element(find.byType(InstallationTypePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(
-        YaruRadioButton<AdvancedFeature>, tester.lang.installationTypeZFS));
+    await tester.tap(
+        find.radioButton<AdvancedFeature>(tester.lang.installationTypeZFS));
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(
-        YaruCheckButton, tester.lang.installationTypeEncrypt('Ubuntu')));
+    await tester
+        .tap(find.checkButton(tester.lang.installationTypeEncrypt('Ubuntu')));
     await tester.pump();
 
     await tester.tap(find.button(tester.lang.okButtonText));
@@ -71,7 +70,7 @@ void main() {
         tester.element(find.byType(InstallationTypePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(YaruRadioButton<AdvancedFeature>,
+    await tester.tap(find.radioButton<AdvancedFeature>(
         tester.lang.installationTypeLVM('Ubuntu')));
     await tester.pump();
 
@@ -104,12 +103,12 @@ void main() {
         tester.element(find.byType(InstallationTypePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(YaruRadioButton<AdvancedFeature>,
+    await tester.tap(find.radioButton<AdvancedFeature>(
         tester.lang.installationTypeLVM('Ubuntu')));
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(
-        YaruCheckButton, tester.lang.installationTypeEncrypt('Ubuntu')));
+    await tester
+        .tap(find.checkButton(tester.lang.installationTypeEncrypt('Ubuntu')));
     await tester.pump();
 
     await tester.tap(find.button(tester.lang.okButtonText));

--- a/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_type/installation_type_page_test.dart
@@ -9,7 +9,6 @@ import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/inst
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
@@ -124,7 +123,7 @@ void main() {
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeReinstall('Ubuntu 18.04 LTS'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -146,7 +145,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -169,7 +168,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 11'));
     expect(radio, findsOneWidget);
 
@@ -192,10 +191,8 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(
-        YaruRadioButton<InstallationType>,
-        tester.lang
-            .installationTypeAlongside('Ubuntu 22.10', 'Ubuntu 18.04 LTS'));
+    final radio = find.radioButton<InstallationType>(tester.lang
+        .installationTypeAlongside('Ubuntu 22.10', 'Ubuntu 18.04 LTS'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.installationType = InstallationType.alongside).called(1);
@@ -208,7 +205,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeAlongsideUnknown('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -236,9 +233,8 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(
-        YaruRadioButton<InstallationType>,
-        tester.lang.installationTypeAlongsideDual(
+    final radio = find.radioButton<InstallationType>(tester.lang
+        .installationTypeAlongsideDual(
             'Ubuntu 22.10', 'Windows 10', 'Ubuntu 20.04 LTS'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -266,7 +262,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -300,7 +296,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -311,7 +307,7 @@ void main() {
     final model = buildModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(YaruRadioButton<InstallationType>,
+    final radio = find.radioButton<InstallationType>(
         tester.lang.installationTypeErase('Ubuntu'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -322,8 +318,8 @@ void main() {
     final model = buildModel(installationType: InstallationType.manual);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.widgetWithText(
-        YaruRadioButton<InstallationType>, tester.lang.installationTypeManual);
+    final radio =
+        find.radioButton<InstallationType>(tester.lang.installationTypeManual);
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.installationType = InstallationType.manual).called(1);

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -72,7 +72,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     for (var i = 0; i < 3; ++i) {
-      final layoutTile = find.widgetWithText(ListTile, 'Layout $i');
+      final layoutTile = find.listTile('Layout $i');
       expect(layoutTile, findsOneWidget);
       await tester.tap(layoutTile);
       verify(model.selectLayout(i)).called(1);
@@ -88,7 +88,7 @@ void main() {
     for (var i = 0; i < 3; ++i) {
       await tester.tap(find.byType(MenuButtonBuilder<int>));
       await tester.pumpAndSettle();
-      final variantItem = find.widgetWithText(MenuItemButton, 'Variant $i');
+      final variantItem = find.menuItem('Variant $i');
       expect(variantItem, findsOneWidget);
       await tester.tap(variantItem);
       await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -71,21 +71,15 @@ void main() {
     expect(listItems, findsWidgets);
     expect(listItems.evaluate().length, lessThan(app.supportedLocales.length));
     for (final language in ['English', 'Français', 'Galego', 'Italiano']) {
-      final listItem =
-          find.widgetWithText(ListTile, language, skipOffstage: false);
+      final listItem = find.listTile(language, skipOffstage: false);
       await tester.dragUntilVisible(listItem, languageList, Offset(0, -10));
       await tester.pumpAndSettle();
       expect(listItem, findsOneWidget);
     }
 
-    final itemItalian =
-        find.widgetWithText(ListTile, 'Italiano', skipOffstage: false);
-
-    final itemFrench =
-        find.widgetWithText(ListTile, 'Français', skipOffstage: false);
-
-    final itemGalego =
-        find.widgetWithText(ListTile, 'Galego', skipOffstage: false);
+    final itemItalian = find.listTile('Italiano', skipOffstage: false);
+    final itemFrench = find.listTile('Français', skipOffstage: false);
+    final itemGalego = find.listTile('Galego', skipOffstage: false);
 
     // scroll forward to Italian
     await tester.scrollUntilVisible(itemItalian, -kMinInteractiveDimension / 2);

--- a/packages/ubuntu_desktop_installer/test/network/hidden_wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/hidden_wifi_view_test.dart
@@ -135,10 +135,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<WifiDevice>));
     await tester.pumpAndSettle();
 
-    final item1 = find.descendant(
-      of: find.byType(MenuItemButton),
-      matching: find.text('device 1'),
-    );
+    final item1 = find.menuItem('device 1');
     expect(item1, findsOneWidget);
     await tester.ensureVisible(item1);
     await tester.tap(item1);
@@ -148,10 +145,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<WifiDevice>));
     await tester.pumpAndSettle();
 
-    final item2 = find.descendant(
-      of: find.byType(MenuItemButton),
-      matching: find.text('device 2'),
-    );
+    final item2 = find.menuItem('device 2');
     expect(item2, findsOneWidget);
     await tester.ensureVisible(item2);
     await tester.tap(item2);

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -165,7 +165,7 @@ void main() {
         .buildApp((_) => buildPage(model: model, ethernet: false, wifi: true)));
     await tester.pumpAndSettle();
 
-    final tile = find.widgetWithText(ListTile, 'ap').first;
+    final tile = find.listTile('ap').first;
     expect(tile, findsOneWidget);
     await tester.pump();
     await tester.tap(tile);

--- a/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
@@ -79,7 +79,7 @@ void main() {
     );
 
     // inactive device
-    final tile1 = find.widgetWithText(ListTile, 'model1');
+    final tile1 = find.listTile('model1');
     expect(tile1, findsOneWidget);
     expect(
       find.descendant(
@@ -90,7 +90,7 @@ void main() {
     );
 
     // connecting device
-    final tile2 = find.widgetWithText(ListTile, 'model2');
+    final tile2 = find.listTile('model2');
     expect(tile2, findsOneWidget);
     expect(
       find.descendant(
@@ -101,14 +101,14 @@ void main() {
     );
 
     // select ap
-    final ap1 = find.widgetWithText(ListTile, 'ap1').first;
+    final ap1 = find.listTile('ap1').first;
     expect(ap1, findsOneWidget);
     await tester.tap(ap1);
     expect(selectedDevice, equals(device1));
     expect(selectedAccessPoint, equals(accessPoint1));
 
     // select another ap
-    final ap2 = find.widgetWithText(ListTile, 'ap2').first;
+    final ap2 = find.listTile('ap2').first;
     expect(ap2, findsOneWidget);
     await tester.tap(ap2);
     expect(selectedDevice, equals(device2));

--- a/packages/ubuntu_desktop_installer/test/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/security_key/security_key_page_test.dart
@@ -7,7 +7,6 @@ import 'package:ubuntu_desktop_installer/pages/filesystem/security_key/security_
 import 'package:ubuntu_desktop_installer/pages/filesystem/security_key/security_key_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test_utils.dart';
 import 'security_key_model_test.mocks.dart';
@@ -78,8 +77,7 @@ void main() {
     final model = buildModel(showSecurityKey: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final showSecurityKeyButton =
-        find.widgetWithText(YaruCheckButton, tester.lang.showSecurityKey);
+    final showSecurityKeyButton = find.checkButton(tester.lang.showSecurityKey);
     expect(showSecurityKeyButton, findsOneWidget);
 
     await tester.tap(showSecurityKeyButton);

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -70,14 +70,12 @@ void main() {
     final model = buildModel(sourceId: kNormalSourceId);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final normalInstallationTile = find.widgetWithText(
-      YaruRadioButton<String>,
+    final normalInstallationTile = find.radioButton<String>(
       tester.lang.normalInstallationTitle,
     );
     expect(normalInstallationTile, findsOneWidget);
 
-    final minimalInstallationTile = find.widgetWithText(
-      YaruRadioButton<String>,
+    final minimalInstallationTile = find.radioButton<String>(
       tester.lang.minimalInstallationTitle,
     );
     expect(minimalInstallationTile, findsOneWidget);
@@ -104,8 +102,7 @@ void main() {
     final model = buildModel(installDrivers: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final installDriversTile = find.widgetWithText(
-      YaruCheckButton,
+    final installDriversTile = find.checkButton(
       tester.lang.installDriversTitle,
     );
     expect(installDriversTile, findsOneWidget);
@@ -123,8 +120,7 @@ void main() {
     final model = buildModel(installCodecs: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final installCodecsTile = find.widgetWithText(
-      YaruCheckButton,
+    final installCodecsTile = find.checkButton(
       tester.lang.installCodecsTitle,
     );
     expect(installCodecsTile, findsOneWidget);
@@ -165,10 +161,7 @@ void main() {
 
     expect(find.text(tester.lang.offlineWarning), findsNothing);
 
-    final installCodecsTile = find.widgetWithText(
-      YaruCheckButton,
-      tester.lang.installCodecsTitle,
-    );
+    final installCodecsTile = find.checkButton(tester.lang.installCodecsTitle);
     expect(installCodecsTile, findsOneWidget);
     expect(tester.widget<YaruCheckButton>(installCodecsTile).onChanged, isNull);
 

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -16,7 +16,6 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_window_test/yaru_window_test.dart';
 
-import '../test_utils.dart';
 import 'welcome_page_test.mocks.dart';
 
 // ignore_for_file: type=lint
@@ -122,8 +121,7 @@ void main() {
   testWidgets('install ubuntu', (tester) async {
     await setUpApp(tester);
 
-    final option =
-        find.widgetWithText(OptionButton, tester.lang.installUbuntu('Ubuntu'));
+    final option = find.radio(Option.installUbuntu);
     expect(option, findsOneWidget);
 
     await tester.tap(option);
@@ -146,8 +144,7 @@ void main() {
     expect(nextButton, findsOneWidget);
     expect(nextButton, isDisabled);
 
-    final option =
-        find.widgetWithText(OptionButton, tester.lang.tryUbuntu('Ubuntu'));
+    final option = find.radio(Option.tryUbuntu);
     expect(option, findsOneWidget);
 
     await tester.tap(option);

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_wizard_test.dart
@@ -4,7 +4,6 @@ import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/pages/welcome/welcome_widgets.dart';
 import 'package:ubuntu_desktop_installer/pages/welcome/welcome_wizard.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -12,7 +11,6 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import '../test_utils.dart';
 import 'welcome_model_test.mocks.dart';
 
 void main() {
@@ -27,7 +25,7 @@ void main() {
 
     expect(find.byType(WelcomePage), findsOneWidget);
 
-    await tester.tapOption(tester.lang.installUbuntu('Ubuntu'));
+    await tester.tap(find.radio(Option.installUbuntu));
     await tester.pump();
 
     // welcome -> last
@@ -61,7 +59,7 @@ void main() {
 
     expect(find.byType(WelcomePage), findsOneWidget);
 
-    await tester.tapOption(tester.lang.installUbuntu('Ubuntu'));
+    await tester.tap(find.radio(Option.installUbuntu));
     await tester.pump();
 
     // welcome -> rst
@@ -126,11 +124,5 @@ extension on WidgetTester {
         ),
       ),
     );
-  }
-
-  Future<void> tapOption(String label) {
-    final button = find.widgetWithText(OptionButton, label);
-    expect(button, findsOneWidget);
-    return tap(button);
   }
 }

--- a/packages/ubuntu_test/lib/src/finders.dart
+++ b/packages/ubuntu_test/lib/src/finders.dart
@@ -29,7 +29,6 @@ extension UbuntuCommonFinders on CommonFinders {
       matching: any([
         bySubtype<ButtonStyleButton>(),
         bySubtype<IconButton>(),
-        bySubtype<YaruIconButton>(),
       ]),
     );
   }

--- a/packages/ubuntu_test/lib/src/finders.dart
+++ b/packages/ubuntu_test/lib/src/finders.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 extension UbuntuCommonFinders on CommonFinders {
+  /// Finds elements that match any given [matchers].
+  Finder any(List<Finder> matchers) => _AnyFinder(matchers);
+
   /// Finds a button specified by its [label].
   ///
   /// The button can be any [ButtonStyleButton] subclass,
@@ -13,6 +17,66 @@ extension UbuntuCommonFinders on CommonFinders {
     );
   }
 
+  /// Finds [YaruCheckButton] by [text].
+  Finder checkButton(String text) {
+    return widgetWithText(YaruCheckButton, text);
+  }
+
+  /// Finds any [IconButton] or [ButtonStyleButton] by [icon].
+  Finder iconButton(IconData icon) {
+    return ancestor(
+      of: byIcon(icon),
+      matching: any([
+        bySubtype<ButtonStyleButton>(),
+        bySubtype<IconButton>(),
+        bySubtype<YaruIconButton>(),
+      ]),
+    );
+  }
+
+  /// Finds [MenuItemButton] by [text].
+  Finder menuItem(String text) {
+    return widgetWithText(MenuItemButton, text);
+  }
+
+  /// Finds [ListTile] by [text].
+  Finder listTile(String text, {bool skipOffstage = true}) {
+    return widgetWithText(ListTile, text, skipOffstage: skipOffstage);
+  }
+
+  /// Finds [Radio] or [YaruRadio] by [value].
+  Finder radio<T>(T value) {
+    return byWidgetPredicate(
+      (w) =>
+          (w is Radio<T> && w.value == value) ||
+          (w is YaruRadio<T> && w.value == value),
+    );
+  }
+
+  /// Finds [YaruRadioButton] by [text].
+  Finder radioButton<T>(String text) {
+    return widgetWithText(YaruRadioButton<T>, text);
+  }
+
+  /// Finds [YaruSwitchButton] by [text].
+  Finder switchButton(String text) {
+    return widgetWithText(YaruSwitchButton, text);
+  }
+
   /// Finds a [TextField] specified by its [label] (or hint).
   Finder textField(String label) => find.widgetWithText(TextField, label);
+}
+
+class _AnyFinder extends Finder {
+  _AnyFinder(List<Finder> matchers) : matchers = matchers.cast();
+
+  final List<MatchFinder> matchers;
+
+  @override
+  String get description => 'matches any $matchers';
+
+  @override
+  Iterable<Element> apply(Iterable<Element> candidates) {
+    return candidates.where((c) => matchers.any((f) => f.matches(c)));
+  }
 }

--- a/packages/ubuntu_wizard/test/list_widget_test.dart
+++ b/packages/ubuntu_wizard/test/list_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 void main() {
@@ -11,7 +12,7 @@ void main() {
     final listWidget = find.byType(ListWidget);
     expect(listWidget, findsOneWidget);
 
-    final listTile = find.widgetWithText(ListTile, '50');
+    final listTile = find.listTile('50');
     expect(listTile, findsOneWidget);
     expect(tester.getCenter(listTile), tester.getCenter(listWidget));
   });
@@ -25,13 +26,13 @@ void main() {
     expect(listWidget, findsOneWidget);
 
     var i = selectedIndex.value - 1;
-    while (tester.getRect(find.widgetWithText(ListTile, '$i')).top >=
+    while (tester.getRect(find.listTile('$i')).top >=
         tester.getRect(find.byType(ListWidget)).top) {
       --i;
     }
     expect(i, lessThan(selectedIndex.value));
 
-    final listTile = find.widgetWithText(ListTile, '$i');
+    final listTile = find.listTile('$i');
     expect(tester.getRect(listTile).top,
         lessThan(tester.getRect(find.byType(ListWidget)).top));
 
@@ -51,13 +52,13 @@ void main() {
     expect(listWidget, findsOneWidget);
 
     var i = selectedIndex.value + 1;
-    while (tester.getRect(find.widgetWithText(ListTile, '$i')).bottom <=
+    while (tester.getRect(find.listTile('$i')).bottom <=
         tester.getRect(find.byType(ListWidget)).bottom) {
       ++i;
     }
     expect(i, greaterThan(selectedIndex.value));
 
-    final listTile = find.widgetWithText(ListTile, '$i');
+    final listTile = find.listTile('$i');
     expect(tester.getRect(listTile).bottom,
         greaterThan(tester.getRect(find.byType(ListWidget)).bottom));
 
@@ -76,7 +77,7 @@ void main() {
     final listWidget = find.byType(ListWidget);
     expect(listWidget, findsOneWidget);
 
-    final listTile = find.widgetWithText(ListTile, '50');
+    final listTile = find.listTile('50');
     expect(listTile, findsNothing);
 
     selectedIndex.value = 50;

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -40,7 +40,7 @@ Future<void> testSelectYourLanguagePage(
   expectPage(tester, SelectLanguagePage, (lang) => lang.selectLanguageTitle);
 
   if (language != null) {
-    final tile = find.widgetWithText(ListTile, language, skipOffstage: false);
+    final tile = find.listTile(language, skipOffstage: false);
     expect(tile, findsOneWidget);
     final viewRect = tester.getRect(find.byType(ListView));
     await tester.scrollUntilVisible(tile, viewRect.height / 2);

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
@@ -11,7 +11,6 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/advanced_setup/advanced_setup_model.dart';
 import 'package:ubuntu_wsl_setup/pages/advanced_setup/advanced_setup_page.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'advanced_setup_page_test.mocks.dart';
 import 'test_utils.dart';
@@ -86,8 +85,8 @@ void main() {
     final model = buildModel(enableHostGeneration: false);
     await tester.pumpWidget(buildApp(model));
 
-    final checkbox = find.widgetWithText(
-        YaruCheckButton, tester.lang.advancedSetupHostGenerationTitle);
+    final checkbox =
+        find.checkButton(tester.lang.advancedSetupHostGenerationTitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.enableHostGeneration = true).called(1);
@@ -97,8 +96,8 @@ void main() {
     final model = buildModel(enableResolvConfGeneration: false);
     await tester.pumpWidget(buildApp(model));
 
-    final checkbox = find.widgetWithText(
-        YaruCheckButton, tester.lang.advancedSetupResolvConfGenerationTitle);
+    final checkbox =
+        find.checkButton(tester.lang.advancedSetupResolvConfGenerationTitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.enableResolvConfGeneration = true).called(1);

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
@@ -11,7 +11,6 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
 import 'package:ubuntu_wsl_setup/pages/configuration_ui/configuration_ui_model.dart';
 import 'package:ubuntu_wsl_setup/pages/configuration_ui/configuration_ui_page.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'configuration_ui_page_test.mocks.dart';
 import 'test_utils.dart';
@@ -67,8 +66,8 @@ void main() {
     final model = buildModel(automountEnabled: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final checkbox = find.widgetWithText(
-        YaruCheckButton, tester.lang.configurationUIAutoMountSubtitle);
+    final checkbox =
+        find.checkButton(tester.lang.configurationUIAutoMountSubtitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.automountEnabled = true).called(1);
@@ -78,8 +77,8 @@ void main() {
     final model = buildModel(automountMountfstab: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final checkbox = find.widgetWithText(
-        YaruCheckButton, tester.lang.configurationUIMountFstabTitle);
+    final checkbox =
+        find.checkButton(tester.lang.configurationUIMountFstabTitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.automountMountfstab = true).called(1);
@@ -89,8 +88,8 @@ void main() {
     final model = buildModel(interopEnabled: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final checkbox = find.widgetWithText(
-        YaruCheckButton, tester.lang.configurationUIInteroperabilitySubtitle);
+    final checkbox =
+        find.checkButton(tester.lang.configurationUIInteroperabilitySubtitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.interopEnabled = true).called(1);
@@ -100,8 +99,8 @@ void main() {
     final model = buildModel(interopAppendwindowspath: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final checkbox = find.widgetWithText(YaruCheckButton,
-        tester.lang.configurationUIInteropAppendWindowsPathTitle);
+    final checkbox = find
+        .checkButton(tester.lang.configurationUIInteropAppendWindowsPathTitle);
     expect(checkbox, findsOneWidget);
     await tester.tap(checkbox);
     verify(model.interopAppendwindowspath = true).called(1);

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/app_model.dart';
@@ -130,7 +131,7 @@ void main() {
         .pumpWidget(buildApp((_) => buildPage(model, [const Text(title)])));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.terminal));
+    await tester.tap(find.iconButton(Icons.terminal));
     verify(model.toggleLogVisibility()).called(1);
   });
 
@@ -140,7 +141,7 @@ void main() {
         .pumpWidget(buildApp((_) => buildPage(model, [const Text(title)])));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.terminal));
+    await tester.tap(find.iconButton(Icons.terminal));
     verify(model.toggleLogVisibility()).called(1);
   });
 
@@ -182,11 +183,11 @@ void main() {
 
       // hidden
       expect(getLogOffsetByText(tester, lorem), equals(1.0));
-      await tester.tap(find.byIcon(Icons.terminal));
+      await tester.tap(find.iconButton(Icons.terminal));
       await tester.pump();
       // visible
       expect(getLogOffsetByText(tester, lorem), equals(0.0));
-      await tester.tap(find.byIcon(Icons.terminal));
+      await tester.tap(find.iconButton(Icons.terminal));
       await tester.pump();
       // hidden again
       expect(getLogOffsetByText(tester, lorem), equals(1.0));
@@ -208,7 +209,7 @@ void main() {
 
       final image1 = find.byType(SvgPicture);
       expect(image1, findsWidgets);
-      await tester.tap(find.byIcon(Icons.chevron_right));
+      await tester.tap(find.iconButton(Icons.chevron_right));
       await tester.pump();
       final image2 = find.byType(SvgPicture);
       expect(image1, findsWidgets);

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -186,8 +186,8 @@ void main() {
   //   final model = buildModel(showAdvancedOptions: true);
   //   await tester.pumpWidget(buildApp(tester, model));
 
-  //   final checkbox = find.widgetWithText(
-  //       YaruCheckButton, tester.lang.profileSetupShowAdvancedOptions);
+  //   final checkbox =
+  //       find.checkButton(tester.lang.profileSetupShowAdvancedOptions);
   //   expect(checkbox, findsOneWidget);
   //   expect(tester.widget<YaruCheckButton>(checkbox).value, isTrue);
 

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -72,7 +72,7 @@ void main() {
     verify(model.loadLanguages()).called(1);
     verify(model.selectLocale(Locale('fr_FR'))).called(1);
 
-    final listTile = find.widgetWithText(ListTile, 'German');
+    final listTile = find.listTile('German');
     expect(listTile, findsOneWidget);
     await tester.tap(listTile);
     verify(model.selectedLanguageIndex = 2).called(1);


### PR DESCRIPTION
We are using a lot of check buttons, radio buttons, icon buttons, and list tiles across the GUI. These finders make it more pleasant and less verbose to test them.

Note: Eventually, all these new common finders and matchers will be extracted into a separate package.