### PR TITLE
upgrade ubuntu_wizard to 1.0.0-beta

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -444,20 +444,13 @@ class _UbuntuDesktopInstallerWizardState
   }
 }
 
-class _UbuntuDesktopInstallerWizardObserver extends WizardObserver {
+class _UbuntuDesktopInstallerWizardObserver extends NavigatorObserver {
   _UbuntuDesktopInstallerWizardObserver(this._telemetryService);
 
   final TelemetryService _telemetryService;
 
   @override
-  void onInit(Route route) {
-    if (route.settings.name != null) {
-      _telemetryService.addStage(route.settings.name!.removePrefix('/'));
-    }
-  }
-
-  @override
-  void onNext(Route route, Route previousRoute) {
+  void didPush(Route route, Route? previousRoute) {
     if (route.settings.name != null) {
       _telemetryService.addStage(route.settings.name!.removePrefix('/'));
     }

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
       path: packages/ubuntu_widgets
       ref: aba58a93465a4ed9040f805d513d47c49f1c941a
   url_launcher: ^6.1.0
-  wizard_router: ^0.10.2
+  wizard_router: 1.0.0-beta
   yaru: ^0.7.0
   yaru_colors: ^0.1.6
   yaru_widgets: ^2.4.0


### PR DESCRIPTION
Since `WizardObserver` was removed from ubuntu_wizard, the telemetry service now uses a `NavigatorObserver`.

There's no method corresponding to `onInit()` - is it enough to call `addStage()` in `didPush()`? 