### PR TITLE
ubuntu-desktop-installer: enable lints in tests

### DIFF
--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -18,14 +18,12 @@ import '../../test_utils.dart';
 import 'allocate_disk_space_page_test.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   setUpAll(() => UbuntuTester.context = AlertDialog);
 
   testWidgets('create partition', (tester) async {
     final disk = fakeDisk();
-    final gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
+    const gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
     final model = buildModel(selectedDisk: disk);
 
     registerMockService<UdevService>(MockUdevService());
@@ -33,7 +31,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
         value: model,
-        child: tester.buildApp((_) => AllocateDiskSpacePage()),
+        child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
 
@@ -44,7 +42,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<DataUnit>));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(ValueKey(DataUnit.bytes)).last);
+    await tester.tap(find.byKey(const ValueKey(DataUnit.bytes)).last);
     await tester.pump();
 
     await tester.enterText(find.byType(SpinBox), '123');
@@ -73,7 +71,7 @@ void main() {
 
   testWidgets('create partition with invalid mount point', (tester) async {
     final disk = fakeDisk();
-    final gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
+    const gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
     final model = buildModel(selectedDisk: disk);
 
     registerMockService<UdevService>(MockUdevService());
@@ -81,7 +79,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
         value: model,
-        child: tester.buildApp((_) => AllocateDiskSpacePage()),
+        child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
 
@@ -97,10 +95,10 @@ void main() {
 
   testWidgets('edit partition', (tester) async {
     tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
+    tester.binding.window.physicalSizeTestValue = const Size(960, 680);
 
     final disk = fakeDisk(partitions: [
-      Partition(
+      const Partition(
         number: 1,
         size: 1234567,
         format: 'ext4',
@@ -108,7 +106,7 @@ void main() {
         mount: '/tst',
         preserve: true,
       ),
-      Gap(offset: 123, size: 1000000, usable: GapUsable.YES),
+      const Gap(offset: 123, size: 1000000, usable: GapUsable.YES),
     ]);
     final model = buildModel(selectedDisk: disk);
 
@@ -117,7 +115,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
         value: model,
-        child: tester.buildApp((_) => AllocateDiskSpacePage()),
+        child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
 
@@ -133,7 +131,7 @@ void main() {
     await tester.tap(find.byType(MenuButtonBuilder<DataUnit>));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(ValueKey(DataUnit.bytes)).last);
+    await tester.tap(find.byKey(const ValueKey(DataUnit.bytes)).last);
     await tester.pump();
 
     await tester.enterText(find.byType(SpinBox), '123');
@@ -166,10 +164,10 @@ void main() {
 
   testWidgets('edit partition with invalid mount point', (tester) async {
     tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
+    tester.binding.window.physicalSizeTestValue = const Size(960, 680);
 
     final disk = fakeDisk(partitions: [
-      Partition(
+      const Partition(
         number: 1,
         size: 1234567,
         format: 'ext4',
@@ -177,7 +175,7 @@ void main() {
         mount: '/tst',
         preserve: true,
       ),
-      Gap(offset: 123, size: 1000000, usable: GapUsable.YES),
+      const Gap(offset: 123, size: 1000000, usable: GapUsable.YES),
     ]);
     final model = buildModel(selectedDisk: disk);
 
@@ -186,7 +184,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
         value: model,
-        child: tester.buildApp((_) => AllocateDiskSpacePage()),
+        child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_model_test.dart
@@ -8,21 +8,19 @@ import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'allocate_disk_space_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([DiskStorageService])
 void main() {
   final testDisks = <Disk>[
     fakeDisk(id: 'a', partitions: [
-      Partition(number: 1),
+      const Partition(number: 1),
     ]),
     fakeDisk(
       id: 'b',
       bootDevice: true,
       preserve: true,
       partitions: [
-        Partition(number: 1),
-        Partition(number: 2, grubDevice: true),
+        const Partition(number: 1),
+        const Partition(number: 2, grubDevice: true),
       ],
     ),
   ];
@@ -176,20 +174,20 @@ void main() {
   test('partition formats', () {
     expect(PartitionFormat.defaultValue, equals(PartitionFormat.ext4));
     expect(PartitionFormat.values.contains(PartitionFormat.ext4), isTrue);
-    expect(PartitionFormat.fromPartition(Partition(format: 'ext4')),
+    expect(PartitionFormat.fromPartition(const Partition(format: 'ext4')),
         equals(PartitionFormat.ext4));
-    expect(PartitionFormat.fromPartition(Partition(format: 'unknown')), isNull);
+    expect(PartitionFormat.fromPartition(const Partition(format: 'unknown')), isNull);
   });
 
   test('can add/remove/edit/wipe/reformat', () async {
     final emptyDisk =
-        fakeDisk(partitions: [Gap(offset: 0, size: 1, usable: GapUsable.YES)]);
+        fakeDisk(partitions: [const Gap(offset: 0, size: 1, usable: GapUsable.YES)]);
     final fullDisk = fakeDisk();
-    final normalDisk = emptyDisk.copyWith(partitions: [Partition()]);
+    final normalDisk = emptyDisk.copyWith(partitions: [const Partition()]);
     final formattedPartition =
-        emptyDisk.copyWith(partitions: [Partition(format: 'ext4')]);
+        emptyDisk.copyWith(partitions: [const Partition(format: 'ext4')]);
     final bitLockerPartition =
-        emptyDisk.copyWith(partitions: [Partition(format: 'BitLocker')]);
+        emptyDisk.copyWith(partitions: [const Partition(format: 'BitLocker')]);
 
     final service = MockDiskStorageService();
     when(service.getStorage()).thenAnswer(
@@ -315,7 +313,7 @@ void main() {
       return fakeDisk(
         partitions: [
           for (var i = 0; i < partitions; ++i) Partition(number: i),
-          Gap(offset: 123, size: 456, usable: GapUsable.YES),
+          const Gap(offset: 123, size: 456, usable: GapUsable.YES),
         ],
       );
     }
@@ -332,11 +330,11 @@ void main() {
     // add partition -> select added partition
     when(service.addPartition(
             testPartitions(2),
-            Gap(offset: 123, size: 456, usable: GapUsable.YES),
-            Partition(size: 123, format: 'ext4', mount: '/tst')))
+            const Gap(offset: 123, size: 456, usable: GapUsable.YES),
+            const Partition(size: 123, format: 'ext4', mount: '/tst')))
         .thenAnswer((_) async => [testPartitions(2)]);
     await model.addPartition(
-        model.selectedDisk!, Gap(offset: 123, size: 456, usable: GapUsable.YES),
+        model.selectedDisk!, const Gap(offset: 123, size: 456, usable: GapUsable.YES),
         size: 123, format: PartitionFormat.ext4, mount: '/tst');
     expect(model.selectedDiskIndex, equals(0));
     expect(model.selectedObjectIndex, equals(1));
@@ -392,11 +390,11 @@ void main() {
 
   test('trailing gap', () async {
     final disk = fakeDisk(id: 'a', partitions: [
-      Partition(number: 11, size: 1),
-      Gap(offset: 1, size: 1, usable: GapUsable.YES),
-      Partition(number: 2, size: 22),
-      Gap(offset: 2, size: 2, usable: GapUsable.TOO_MANY_PRIMARY_PARTS),
-      Partition(number: 3, size: 33),
+      const Partition(number: 11, size: 1),
+      const Gap(offset: 1, size: 1, usable: GapUsable.YES),
+      const Partition(number: 2, size: 22),
+      const Gap(offset: 2, size: 2, usable: GapUsable.TOO_MANY_PRIMARY_PARTS),
+      const Partition(number: 3, size: 33),
     ]);
 
     final service = MockDiskStorageService();

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_model_test.dart
@@ -176,12 +176,13 @@ void main() {
     expect(PartitionFormat.values.contains(PartitionFormat.ext4), isTrue);
     expect(PartitionFormat.fromPartition(const Partition(format: 'ext4')),
         equals(PartitionFormat.ext4));
-    expect(PartitionFormat.fromPartition(const Partition(format: 'unknown')), isNull);
+    expect(PartitionFormat.fromPartition(const Partition(format: 'unknown')),
+        isNull);
   });
 
   test('can add/remove/edit/wipe/reformat', () async {
-    final emptyDisk =
-        fakeDisk(partitions: [const Gap(offset: 0, size: 1, usable: GapUsable.YES)]);
+    final emptyDisk = fakeDisk(
+        partitions: [const Gap(offset: 0, size: 1, usable: GapUsable.YES)]);
     final fullDisk = fakeDisk();
     final normalDisk = emptyDisk.copyWith(partitions: [const Partition()]);
     final formattedPartition =
@@ -333,8 +334,8 @@ void main() {
             const Gap(offset: 123, size: 456, usable: GapUsable.YES),
             const Partition(size: 123, format: 'ext4', mount: '/tst')))
         .thenAnswer((_) async => [testPartitions(2)]);
-    await model.addPartition(
-        model.selectedDisk!, const Gap(offset: 123, size: 456, usable: GapUsable.YES),
+    await model.addPartition(model.selectedDisk!,
+        const Gap(offset: 123, size: 456, usable: GapUsable.YES),
         size: 123, format: PartitionFormat.ext4, mount: '/tst');
     expect(model.selectedDiskIndex, equals(0));
     expect(model.selectedObjectIndex, equals(1));

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -20,8 +20,6 @@ import '../../test_utils.dart';
 import 'allocate_disk_space_model_test.mocks.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 final selection = StreamController.broadcast();
 
 final testDisks = <Disk>[
@@ -30,14 +28,14 @@ final testDisks = <Disk>[
     canBeBootDevice: false,
     size: 12,
     partitions: [
-      Partition(
+      const Partition(
         number: 1,
         size: 11,
         mount: '/mnt/1',
         format: 'btrfs',
         preserve: true,
       ),
-      Partition(
+      const Partition(
         number: 2,
         size: 22,
         mount: '/mnt/2',
@@ -50,13 +48,13 @@ final testDisks = <Disk>[
     canBeBootDevice: true,
     size: 23,
     partitions: [
-      Partition(
+      const Partition(
         number: 3,
         size: 33,
         mount: '/mnt/3',
         format: 'ext3',
       ),
-      Partition(
+      const Partition(
         number: 4,
         size: 44,
         mount: '/mnt/4',
@@ -305,13 +303,13 @@ void main() {
     await tester.pump();
 
     final menuItem0 = find.ancestor(
-      of: find.byKey(ValueKey(0)),
+      of: find.byKey(const ValueKey(0)),
       matching: find.byType(MenuItemButton),
     );
     expect(menuItem0, isDisabled);
 
     final menuItem1 = find.ancestor(
-      of: find.byKey(ValueKey(1)),
+      of: find.byKey(const ValueKey(1)),
       matching: find.byType(MenuItemButton),
     );
     expect(menuItem1, isEnabled);
@@ -342,7 +340,7 @@ void main() {
   });
 
   testWidgets('too many primary partitions', (tester) async {
-    final unusableGap = Gap(
+    const unusableGap = Gap(
       offset: 0,
       size: 1,
       usable: GapUsable.TOO_MANY_PRIMARY_PARTS,

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/storage_selector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/storage_selector_test.dart
@@ -4,8 +4,6 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/storage_selector.dart';
 import 'package:ubuntu_test/utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('initial selection', (tester) async {
     await tester.pumpWidget(MaterialApp(
@@ -25,7 +23,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(ValueKey(1)), findsOneWidget);
+    expect(find.byKey(const ValueKey(1)), findsOneWidget);
   });
 
   testWidgets('selection', (tester) async {
@@ -51,7 +49,7 @@ void main() {
 
     final menuItem = find.descendant(
       of: find.byType(MenuItemButton),
-      matching: find.byKey(ValueKey(1)),
+      matching: find.byKey(const ValueKey(1)),
     );
     await tester.ensureVisible(menuItem);
     await tester.tap(menuItem);
@@ -80,13 +78,13 @@ void main() {
     await tester.pumpAndSettle();
 
     final menuItem1 = find.ancestor(
-      of: find.byKey(ValueKey(1)),
+      of: find.byKey(const ValueKey(1)),
       matching: find.byType(MenuItemButton),
     );
     expect(menuItem1, isDisabled);
 
     final menuItem2 = find.ancestor(
-      of: find.byKey(ValueKey(2)),
+      of: find.byKey(const ValueKey(2)),
       matching: find.byType(MenuItemButton),
     );
     expect(menuItem2, isEnabled);

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/storage_table_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/storage_table_test.dart
@@ -6,46 +6,44 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/storage_columns.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/storage_table.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   final sda = fakeDisk(path: '/dev/sda', size: 11);
   final sdb = fakeDisk(
     path: '/dev/sdb',
     size: 22,
     partitions: [
-      Partition(
+      const Partition(
         number: 1,
         size: 2211,
         os: OsProber(long: 'Ubuntu 18.04', label: '', type: ''),
       ),
-      Gap(offset: 2211, size: 2222, usable: GapUsable.YES),
+      const Gap(offset: 2211, size: 2222, usable: GapUsable.YES),
     ],
   );
   final sdc = fakeDisk(
     path: '/dev/sdc',
     size: 33,
     partitions: [
-      Partition(number: 1, size: 3311),
-      Partition(number: 2, size: 3322),
-      Gap(offset: 3322, size: 3333, usable: GapUsable.YES),
+      const Partition(number: 1, size: 3311),
+      const Partition(number: 2, size: 3322),
+      const Gap(offset: 3322, size: 3333, usable: GapUsable.YES),
     ],
   );
   final sdd = fakeDisk(
     path: '/dev/sdd',
     size: 44,
     partitions: [
-      Partition(number: 1, size: 4411),
-      Partition(number: 2, size: 4422),
-      Partition(number: 3, size: 4433),
-      Gap(offset: 4433, size: 4444, usable: GapUsable.YES),
+      const Partition(number: 1, size: 4411),
+      const Partition(number: 2, size: 4422),
+      const Partition(number: 3, size: 4433),
+      const Gap(offset: 4433, size: 4444, usable: GapUsable.YES),
     ],
   );
 
   final pathColumn = StorageColumn(
     titleBuilder: (_) => const Text('path'),
     diskBuilder: (_, disk) => Text(disk.path!),
-    gapBuilder: (_, disk, gap) => SizedBox.shrink(),
+    gapBuilder: (_, disk, gap) => const SizedBox.shrink(),
     partitionBuilder: (_, disk, partition) {
       return Text('${disk.path}${partition.number}');
     },

--- a/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_model_test.dart
@@ -3,8 +3,6 @@ import 'package:mockito/mockito.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/bitlocker/bitlocker_model.dart';
 
-// ignore_for_file: type=lint
-
 void main() async {
   test('reboot', () async {
     final client = MockSubiquityClient();

--- a/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.dart
@@ -13,8 +13,6 @@ import 'package:yaru_window_test/yaru_window_test.dart';
 import '../../test_utils.dart';
 import 'bitlocker_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([BitLockerModel, UrlLauncher])
 void main() {
   setUpAll(YaruTestWindow.ensureInitialized);
@@ -26,7 +24,7 @@ void main() {
     await tester.pumpWidget(
       Provider<BitLockerModel>.value(
         value: model,
-        child: tester.buildApp((_) => BitLockerPage()),
+        child: tester.buildApp((_) => const BitLockerPage()),
       ),
     );
 
@@ -63,7 +61,7 @@ void main() {
     await tester.pumpWidget(
       Provider<BitLockerModel>.value(
         value: model,
-        child: tester.buildApp((_) => BitLockerPage()),
+        child: tester.buildApp((_) => const BitLockerPage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_dialogs_test.dart
@@ -10,8 +10,6 @@ import 'package:ubuntu_test/utils.dart';
 import '../../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   setUpAll(() => UbuntuTester.context = AlertDialog);
 
@@ -25,7 +23,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
         value: model,
-        child: tester.buildApp((_) => InstallationTypePage()),
+        child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );
 
@@ -62,7 +60,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
         value: model,
-        child: tester.buildApp((_) => InstallationTypePage()),
+        child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );
 
@@ -95,7 +93,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<InstallationTypeModel>.value(
         value: model,
-        child: tester.buildApp((_) => InstallationTypePage()),
+        child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_model_test.dart
@@ -8,8 +8,6 @@ import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'installation_type_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([DiskStorageService, ProductService, TelemetryService])
 void main() {
   test('init', () async {
@@ -167,7 +165,7 @@ void main() {
   });
 
   test('single reformat target', () async {
-    final reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
+    const reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
 
     final service = MockDiskStorageService();
     when(service.useLvm).thenReturn(false);
@@ -210,14 +208,14 @@ void main() {
     expect(model.canInstallAlongside, isFalse);
 
     // reformat
-    final reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
+    const reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => fakeGuidedStorageResponse(possible: [reformat]));
     await model.init();
     expect(model.canInstallAlongside, isFalse);
 
     // resize
-    final resize = GuidedStorageTargetResize(
+    const resize = GuidedStorageTargetResize(
         diskId: '',
         partitionNumber: 0,
         newSize: 0,
@@ -231,7 +229,7 @@ void main() {
     expect(model.canInstallAlongside, isTrue);
 
     // gap
-    final gap = GuidedStorageTargetUseGap(
+    const gap = GuidedStorageTargetUseGap(
       diskId: '',
       gap: Gap(offset: 0, size: 0, usable: GapUsable.YES),
       capabilities: [],
@@ -270,7 +268,7 @@ void main() {
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // reformat
-    final reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
+    const reformat = GuidedStorageTargetReformat(diskId: '', capabilities: []);
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => fakeGuidedStorageResponse(possible: [reformat]));
     await model.init();
@@ -289,7 +287,7 @@ void main() {
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // resize
-    final resize = GuidedStorageTargetResize(
+    const resize = GuidedStorageTargetResize(
         diskId: '',
         partitionNumber: 0,
         newSize: 0,
@@ -306,7 +304,7 @@ void main() {
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // gap
-    final gap = GuidedStorageTargetUseGap(
+    const gap = GuidedStorageTargetUseGap(
       diskId: '',
       gap: Gap(offset: 0, size: 1, usable: GapUsable.YES),
       capabilities: [],
@@ -320,12 +318,12 @@ void main() {
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // multiple gaps
-    final gap2 = GuidedStorageTargetUseGap(
+    const gap2 = GuidedStorageTargetUseGap(
       diskId: '',
       gap: Gap(offset: 0, size: 2, usable: GapUsable.YES),
       capabilities: [],
     );
-    final gap3 = GuidedStorageTargetUseGap(
+    const gap3 = GuidedStorageTargetUseGap(
       diskId: '',
       gap: Gap(offset: 0, size: 3, usable: GapUsable.YES),
       capabilities: [],

--- a/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_page_test.dart
@@ -13,8 +13,6 @@ import 'package:ubuntu_test/utils.dart';
 import '../../test_utils.dart';
 import 'installation_type_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([InstallationTypeModel])
 void main() {
   InstallationTypeModel buildModel({
@@ -46,7 +44,7 @@ void main() {
   Widget buildPage(InstallationTypeModel model) {
     return ChangeNotifierProvider<InstallationTypeModel>.value(
       value: model,
-      child: InstallationTypePage(),
+      child: const InstallationTypePage(),
     );
   }
 
@@ -61,7 +59,7 @@ void main() {
 
   testWidgets('one existing OS', (tester) async {
     final model = buildModel(existingOS: [
-      OsProber(long: 'Ubuntu 18.04 LTS', label: 'Ubuntu', type: 'ext4')
+      const OsProber(long: 'Ubuntu 18.04 LTS', label: 'Ubuntu', type: 'ext4')
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -73,8 +71,8 @@ void main() {
 
   testWidgets('two existing OSes', (tester) async {
     final model = buildModel(existingOS: [
-      OsProber(long: 'Ubuntu 18.04 LTS', label: 'Ubuntu', type: 'ext4'),
-      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
+      const OsProber(long: 'Ubuntu 18.04 LTS', label: 'Ubuntu', type: 'ext4'),
+      const OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -87,9 +85,9 @@ void main() {
 
   testWidgets('multiple existing OSes', (tester) async {
     final model = buildModel(existingOS: [
-      OsProber(long: 'Windows 10', label: 'windows', type: 'ntfs'),
-      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4'),
-      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
+      const OsProber(long: 'Windows 10', label: 'windows', type: 'ntfs'),
+      const OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4'),
+      const OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -101,8 +99,8 @@ void main() {
 
   testWidgets('duplicate existing OSes', (tester) async {
     final model = buildModel(existingOS: [
-      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4'),
-      OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
+      const OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4'),
+      const OsProber(long: 'Ubuntu 20.04 LTS', label: 'Ubuntu', type: 'ext4')
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -114,7 +112,7 @@ void main() {
 
   testWidgets('reinstall', (tester) async {
     final model = buildModel(existingOS: [
-      OsProber(
+      const OsProber(
         long: 'Ubuntu 18.04 LTS',
         label: 'Ubuntu',
         version: '18.04 LTS',
@@ -134,7 +132,7 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Windows 10',
           label: 'WIN10',
           version: '10',
@@ -156,7 +154,7 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Windows 11',
           label: 'WIN11',
           version: '11',
@@ -180,7 +178,7 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 18.04 LTS',
           label: 'Ubuntu',
           version: '18.04 LTS',
@@ -216,13 +214,13 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Windows 10',
           label: 'WIN10',
           version: '10',
           type: 'ntfs',
         ),
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 20.04 LTS',
           label: 'Ubuntu',
           version: '20.04 LTS',
@@ -245,13 +243,13 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 20.04 LTS',
           label: 'Ubuntu1',
           version: '20.04 LTS',
           type: 'ext4',
         ),
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 20.04 LTS',
           label: 'Ubuntu2',
           version: '20.04 LTS',
@@ -273,19 +271,19 @@ void main() {
     final model = buildModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),
       existingOS: [
-        OsProber(
+        const OsProber(
           long: 'Windows 10',
           label: 'WIN10',
           version: '10',
           type: 'ntfs',
         ),
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 18.04 LTS',
           label: 'Ubuntu',
           version: '18.04 LTS',
           type: 'ext4',
         ),
-        OsProber(
+        const OsProber(
           long: 'Ubuntu 20.04 LTS',
           label: 'Ubuntu',
           version: '20.04 LTS',

--- a/packages/ubuntu_desktop_installer/test/filesystem/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/security_key/security_key_page_test.dart
@@ -12,8 +12,6 @@ import '../../test_utils.dart';
 import 'security_key_model_test.mocks.dart';
 import 'security_key_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SecurityKeyModel])
 void main() {
   SecurityKeyModel buildModel({
@@ -33,7 +31,7 @@ void main() {
   Widget buildPage(SecurityKeyModel model) {
     return ChangeNotifierProvider<SecurityKeyModel>.value(
       value: model,
-      child: SecurityKeyPage(),
+      child: const SecurityKeyPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/test/filesystem/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/select_guided_storage/select_guided_storage_page_test.dart
@@ -17,8 +17,6 @@ import '../../test_utils.dart';
 import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SelectGuidedStorageModel])
 void main() {
   final testDisks = <Disk>[
@@ -87,7 +85,7 @@ void main() {
 
     final dropdownItem = find.descendant(
       of: find.byType(MenuItemButton),
-      matching: find.byKey(ValueKey(1)),
+      matching: find.byKey(const ValueKey(1)),
     );
     await tester.ensureVisible(dropdownItem.last);
     await tester.tap(dropdownItem.last);

--- a/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
@@ -13,8 +13,6 @@ import 'package:ubuntu_wizard/utils.dart';
 
 import 'identity_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 class MockProductNameFile extends Mock implements File {
   MockProductNameFile(this._product);
   final String _product;
@@ -41,7 +39,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -68,7 +66,7 @@ void main() {
 
   test('load auto-login', () async {
     final client = MockSubiquityClient();
-    when(client.getIdentity()).thenAnswer((_) async => IdentityData());
+    when(client.getIdentity()).thenAnswer((_) async => const IdentityData());
     when(client.hasActiveDirectorySupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -76,7 +74,7 @@ void main() {
         .thenAnswer((_) async => 'someone');
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -106,7 +104,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -136,7 +134,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -168,7 +166,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -201,7 +199,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -228,7 +226,7 @@ void main() {
     final client = MockSubiquityClient();
     final config = MockConfigService();
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
     final model = IdentityModel(
@@ -253,7 +251,7 @@ void main() {
     final client = MockSubiquityClient();
     final config = MockConfigService();
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
     final model = IdentityModel(
@@ -301,7 +299,7 @@ void main() {
     final client = MockSubiquityClient();
     final config = MockConfigService();
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
     final model = IdentityModel(
@@ -383,7 +381,7 @@ void main() {
         .thenAnswer((_) async => UsernameValidation.TOO_LONG);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -418,7 +416,7 @@ void main() {
   test('respect existing values', () async {
     final client = MockSubiquityClient();
     when(client.getIdentity()).thenAnswer((_) async {
-      return IdentityData(
+      return const IdentityData(
         realname: 'Default',
         username: 'default',
         hostname: 'default',
@@ -431,7 +429,7 @@ void main() {
     when(client.hasActiveDirectorySupport()).thenAnswer((_) async => false);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 
@@ -486,7 +484,7 @@ void main() {
 
   test('active directory support', () async {
     final client = MockSubiquityClient();
-    when(client.getIdentity()).thenAnswer((_) async => IdentityData());
+    when(client.getIdentity()).thenAnswer((_) async => const IdentityData());
     when(client.hasActiveDirectorySupport()).thenAnswer((_) async => true);
 
     final config = MockConfigService();
@@ -494,7 +492,7 @@ void main() {
         .thenAnswer((_) async => null);
 
     final network = MockNetworkService();
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
 
     final telemetry = MockTelemetryService();
 

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -14,8 +14,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../test_utils.dart';
 import 'identity_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([IdentityModel])
 void main() {
   IdentityModel buildModel({
@@ -55,7 +53,7 @@ void main() {
   Widget buildPage(IdentityModel model) {
     return ChangeNotifierProvider<IdentityModel>.value(
       value: model,
-      child: IdentityPage(),
+      child: const IdentityPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_model_test.dart
@@ -5,8 +5,6 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/installation_complete/installation_complete_model.dart';
 import 'package:ubuntu_desktop_installer/services/product_service.dart';
 
-// ignore_for_file: type=lint
-
 import 'installation_complete_model_test.mocks.dart';
 
 @GenerateMocks([ProductService])

--- a/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_complete/installation_complete_page_test.dart
@@ -14,8 +14,6 @@ import 'package:yaru_window_test/yaru_window_test.dart';
 import '../test_utils.dart';
 import 'installation_complete_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([InstallationCompleteModel])
 void main() {
   setUpAll(YaruTestWindow.ensureInitialized);
@@ -24,7 +22,7 @@ void main() {
     when(model.productInfo).thenReturn(ProductInfo(name: 'Ubuntu'));
     return Provider<InstallationCompleteModel>.value(
       value: model,
-      child: InstallationCompletePage(),
+      child: const InstallationCompletePage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_model_test.dart
@@ -10,8 +10,6 @@ import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'installation_slides_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([JournalService, ProductService])
 void main() async {
   test('product info', () {
@@ -32,9 +30,9 @@ void main() async {
     final client = MockSubiquityClient();
     final journal = MockJournalService();
     when(journal.start(['log', 'event'], output: JournalOutput.short))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
     when(journal.start(['event'], output: JournalOutput.cat))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
     final product = MockProductService();
     final model = InstallationSlidesModel(client, journal, product);
 
@@ -73,9 +71,9 @@ void main() async {
 
     final journal = MockJournalService();
     when(journal.start(['log', 'event'], output: JournalOutput.short))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
     when(journal.start(['event'], output: JournalOutput.cat))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
 
     final product = MockProductService();
 
@@ -121,9 +119,9 @@ void main() async {
 
     final journal = MockJournalService();
     when(journal.start(['log', 'event'], output: JournalOutput.short))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
     when(journal.start(['event'], output: JournalOutput.cat))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
 
     final product = MockProductService();
 
@@ -161,7 +159,7 @@ void main() async {
 
     final journal = MockJournalService();
     when(journal.start(['log', 'event'], output: JournalOutput.short))
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
     when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => events.stream);
 

--- a/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/installation_slides_page_test.dart
@@ -19,8 +19,6 @@ import '../test_utils.dart';
 import 'installation_slides_model_test.mocks.dart';
 import 'installation_slides_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([InstallationSlidesModel])
 void main() {
   UbuntuTester.context = InstallationSlidesPage;
@@ -41,7 +39,7 @@ void main() {
     when(model.isDone).thenReturn(isDone ?? false);
     when(model.hasError).thenReturn(hasError ?? false);
     when(model.isInstalling).thenReturn(isInstalling ?? false);
-    when(model.log).thenAnswer((_) => log ?? Stream<String>.empty());
+    when(model.log).thenAnswer((_) => log ?? const Stream<String>.empty());
     when(model.event).thenReturn(event ?? InstallationEvent.fromString(''));
     when(model.isLogVisible).thenReturn(isLogVisible ?? false);
     when(model.isPlaying).thenReturn(isPlaying ?? false);
@@ -54,9 +52,9 @@ void main() {
     return ChangeNotifierProvider<InstallationSlidesModel>.value(
       value: model,
       child: SlidesContext(slides: [
-        (context) => SizedBox.expand(child: Text('slide1')),
-        (context) => SizedBox.expand(child: Text('slide2')),
-      ], child: InstallationSlidesPage()),
+        (context) => const SizedBox.expand(child: Text('slide1')),
+        (context) => const SizedBox.expand(child: Text('slide2')),
+      ], child: const InstallationSlidesPage()),
     );
   }
 
@@ -159,7 +157,7 @@ void main() {
     when(model.event)
         .thenReturn(InstallationEvent.fromString('installing system'));
     await tester.pumpWidget(Container(
-      key: ValueKey('force rebuild for installing system'),
+      key: const ValueKey('force rebuild for installing system'),
       child: tester.buildApp((_) => buildPage(model)),
     ));
     await tester.pump();
@@ -172,7 +170,7 @@ void main() {
     when(model.event)
         .thenReturn(InstallationEvent.fromString('final system configuration'));
     await tester.pumpWidget(Container(
-      key: ValueKey('force rebuild for configuring system'),
+      key: const ValueKey('force rebuild for configuring system'),
       child: tester.buildApp((_) => buildPage(model)),
     ));
     await tester.pump();
@@ -184,7 +182,7 @@ void main() {
 
     when(model.hasError).thenReturn(true);
     await tester.pumpWidget(Container(
-      key: ValueKey('force rebuild for hasError'),
+      key: const ValueKey('force rebuild for hasError'),
       child: tester.buildApp((_) => buildPage(model)),
     ));
     await tester.pump();
@@ -211,7 +209,7 @@ void main() {
     await tester.pumpWidget(
       SlidesContext(
         slides: [
-          (_) => SizedBox.shrink(),
+          (_) => const SizedBox.shrink(),
         ],
         child: tester.buildApp(InstallationSlidesPage.create),
       ),

--- a/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
@@ -19,7 +19,8 @@ void main() {
     slide1(_) => const Text('slide1');
     slide2(_) => const Text('slide2');
 
-    final widget = SlidesContext(slides: [slide1, slide2], child: const Text('page'));
+    final widget =
+        SlidesContext(slides: [slide1, slide2], child: const Text('page'));
     await tester.pumpWidget(MaterialApp(home: widget));
 
     final context = tester.element(find.text('page'));

--- a/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installation_slides/slides_test.dart
@@ -11,16 +11,15 @@ import 'package:ubuntu_wizard/utils.dart';
 import '../test_utils.dart';
 import 'slides_test.mocks.dart';
 
-// ignore_for_file: type=lint
 @GenerateMocks([UrlLauncher])
 void main() {
   setUpAll(() => UbuntuTester.context = Scaffold);
 
   testWidgets('inherited slides', (tester) async {
-    final slide1 = (_) => Text('slide1');
-    final slide2 = (_) => Text('slide2');
+    slide1(_) => const Text('slide1');
+    slide2(_) => const Text('slide2');
 
-    final widget = SlidesContext(slides: [slide1, slide2], child: Text('page'));
+    final widget = SlidesContext(slides: [slide1, slide2], child: const Text('page'));
     await tester.pumpWidget(MaterialApp(home: widget));
 
     final context = tester.element(find.text('page'));
@@ -32,13 +31,13 @@ void main() {
 
     expect(
       widget.updateShouldNotify(
-        SlidesContext(slides: [slide1, slide2], child: Text('page')),
+        SlidesContext(slides: [slide1, slide2], child: const Text('page')),
       ),
       isFalse,
     );
     expect(
       widget.updateShouldNotify(
-        SlidesContext(slides: [slide2, slide1], child: Text('page')),
+        SlidesContext(slides: [slide2, slide1], child: const Text('page')),
       ),
       isTrue,
     );

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_detector_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_detector_test.dart
@@ -6,13 +6,11 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_detector.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('init', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep('0')).thenAnswer((_) async {
-      return AnyStep.stepPressKey(keycodes: {}, symbols: ['a', 'b', 'c']);
+      return const AnyStep.stepPressKey(keycodes: {}, symbols: ['a', 'b', 'c']);
     });
 
     final detector = KeyboardDetector(client);
@@ -26,13 +24,13 @@ void main() {
   test('key press', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep('0')).thenAnswer((_) async {
-      return AnyStep.stepPressKey(
+      return const AnyStep.stepPressKey(
         symbols: ['a', 'b', 'c'],
         keycodes: {12: '34'},
       );
     });
     when(client.getKeyboardStep('34')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: '56', yes: '', no: '');
+      return const AnyStep.stepKeyPresent(symbol: '56', yes: '', no: '');
     });
 
     final detector = KeyboardDetector(client);
@@ -54,13 +52,13 @@ void main() {
   test('key present', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep('78')).thenAnswer((_) async {
-      return AnyStep.stepResult(layout: 'is', variant: 'present');
+      return const AnyStep.stepResult(layout: 'is', variant: 'present');
     });
 
     late AnyStep result;
     final detector = KeyboardDetector(
       client,
-      value: AnyStep.stepKeyPresent(symbol: 'y', yes: '78', no: ''),
+      value: const AnyStep.stepKeyPresent(symbol: 'y', yes: '78', no: ''),
       onResult: (value) => result = value,
     );
 
@@ -74,19 +72,19 @@ void main() {
     detector.removeListener(waitNotify.complete);
 
     expect(detector.value, isA<StepResult>());
-    expect(result, equals(StepResult(layout: 'is', variant: 'present')));
+    expect(result, equals(const StepResult(layout: 'is', variant: 'present')));
   });
 
   test('key not present', () async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep('90')).thenAnswer((_) async {
-      return AnyStep.stepResult(layout: 'not', variant: 'present');
+      return const AnyStep.stepResult(layout: 'not', variant: 'present');
     });
 
     late AnyStep result;
     final detector = KeyboardDetector(
       client,
-      value: AnyStep.stepKeyPresent(symbol: 'n', yes: '', no: '90'),
+      value: const AnyStep.stepKeyPresent(symbol: 'n', yes: '', no: '90'),
       onResult: (value) => result = value,
     );
 
@@ -100,6 +98,6 @@ void main() {
     detector.removeListener(waitNotify.complete);
 
     expect(detector.value, isA<StepResult>());
-    expect(result, equals(StepResult(layout: 'not', variant: 'present')));
+    expect(result, equals(const StepResult(layout: 'not', variant: 'present')));
   });
 }

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_dialogs_test.dart
@@ -10,24 +10,22 @@ import 'package:ubuntu_test/utils.dart';
 
 import '../test_utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   setUpAll(() => UbuntuTester.context = DetectKeyboardView);
 
   testWidgets('detect layout', (tester) async {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep('0')).thenAnswer((_) async {
-      return AnyStep.stepPressKey(symbols: ['a'], keycodes: {30: '40'});
+      return const AnyStep.stepPressKey(symbols: ['a'], keycodes: {30: '40'});
     });
     when(client.getKeyboardStep('40')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: 'b', yes: '50', no: '');
+      return const AnyStep.stepKeyPresent(symbol: 'b', yes: '50', no: '');
     });
     when(client.getKeyboardStep('50')).thenAnswer((_) async {
-      return AnyStep.stepKeyPresent(symbol: 'c', yes: '', no: '60');
+      return const AnyStep.stepKeyPresent(symbol: 'c', yes: '', no: '60');
     });
     when(client.getKeyboardStep('60')).thenAnswer((_) async {
-      return AnyStep.stepResult(layout: 'd', variant: 'e');
+      return const AnyStep.stepResult(layout: 'd', variant: 'e');
     });
     registerMockService<SubiquityClient>(client);
 
@@ -69,6 +67,6 @@ void main() {
     verify(client.getKeyboardStep('60')).called(1);
 
     // result
-    expect(await result, equals(StepResult(layout: 'd', variant: 'e')));
+    expect(await result, equals(const StepResult(layout: 'd', variant: 'e')));
   });
 }

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_model_test.dart
@@ -166,7 +166,8 @@ void main() {
 
     test('selection updates input source', () async {
       await model.selectLayout(0);
-      verify(client.setInputSource(const KeyboardSetting(layout: 'bar'), user: 'usr'))
+      verify(client.setInputSource(const KeyboardSetting(layout: 'bar'),
+              user: 'usr'))
           .called(1);
 
       await model.selectLayout(1);
@@ -236,7 +237,8 @@ void main() {
     reset(client);
 
     await model.save();
-    verify(client.setKeyboard(const KeyboardSetting(layout: 'foo', variant: 'qux')))
+    verify(client
+            .setKeyboard(const KeyboardSetting(layout: 'foo', variant: 'qux')))
         .called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_model_test.dart
@@ -5,8 +5,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_model.dart';
 
-// ignore_for_file: type=lint
-
 const testLayouts = <KeyboardLayout>[
   KeyboardLayout(code: 'empty-variants', name: 'Empty variants', variants: []),
   KeyboardLayout(
@@ -100,8 +98,8 @@ void main() {
       client = MockSubiquityClient();
       when(client.getKeyboard()).thenAnswer((_) async {
         return testSetup([
-          KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
-          KeyboardLayout(code: 'foo', name: 'Foo', variants: [
+          const KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
+          const KeyboardLayout(code: 'foo', name: 'Foo', variants: [
             KeyboardVariant(code: 'baz', name: 'Baz'),
             KeyboardVariant(code: 'qux', name: 'Qux'),
           ]),
@@ -168,18 +166,18 @@ void main() {
 
     test('selection updates input source', () async {
       await model.selectLayout(0);
-      verify(client.setInputSource(KeyboardSetting(layout: 'bar'), user: 'usr'))
+      verify(client.setInputSource(const KeyboardSetting(layout: 'bar'), user: 'usr'))
           .called(1);
 
       await model.selectLayout(1);
       verify(client.setInputSource(
-              KeyboardSetting(layout: 'foo', variant: 'baz'),
+              const KeyboardSetting(layout: 'foo', variant: 'baz'),
               user: 'usr'))
           .called(1);
 
       await model.selectVariant(1);
       verify(client.setInputSource(
-              KeyboardSetting(layout: 'foo', variant: 'qux'),
+              const KeyboardSetting(layout: 'foo', variant: 'qux'),
               user: 'usr'))
           .called(1);
     });
@@ -222,8 +220,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getKeyboard()).thenAnswer((_) async {
       return testSetup([
-        KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
-        KeyboardLayout(code: 'foo', name: 'Foo', variants: [
+        const KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
+        const KeyboardLayout(code: 'foo', name: 'Foo', variants: [
           KeyboardVariant(code: 'baz', name: 'Baz'),
           KeyboardVariant(code: 'qux', name: 'Qux'),
         ]),
@@ -238,7 +236,7 @@ void main() {
     reset(client);
 
     await model.save();
-    verify(client.setKeyboard(KeyboardSetting(layout: 'foo', variant: 'qux')))
+    verify(client.setKeyboard(const KeyboardSetting(layout: 'foo', variant: 'qux')))
         .called(1);
   });
 
@@ -246,9 +244,9 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getKeyboard()).thenAnswer((_) async {
       return testSetup([
-        KeyboardLayout(code: 'bbb', name: 'BBB', variants: []),
-        KeyboardLayout(code: 'aaa', name: 'AAA', variants: []),
-        KeyboardLayout(code: 'äää', name: 'ÄÄÄ', variants: []),
+        const KeyboardLayout(code: 'bbb', name: 'BBB', variants: []),
+        const KeyboardLayout(code: 'aaa', name: 'AAA', variants: []),
+        const KeyboardLayout(code: 'äää', name: 'ÄÄÄ', variants: []),
       ], layout: '', variant: '');
     });
 
@@ -265,8 +263,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getKeyboard()).thenAnswer((_) async {
       return testSetup([
-        KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
-        KeyboardLayout(code: 'foo', name: 'Foo', variants: [
+        const KeyboardLayout(code: 'bar', name: 'Bar', variants: []),
+        const KeyboardLayout(code: 'foo', name: 'Foo', variants: [
           KeyboardVariant(code: 'baz', name: 'Baz'),
           KeyboardVariant(code: 'qux', name: 'Qux'),
         ]),

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -18,8 +18,6 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import '../test_utils.dart';
 import 'keyboard_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([KeyboardModel])
 void main() {
   MockKeyboardModel buildModel({
@@ -41,20 +39,20 @@ void main() {
       when(model.variantName(i)).thenReturn(variants![i]);
     }
     when(model.selectedVariantIndex).thenReturn(selectedVariantIndex ?? 0);
-    when(model.onLayoutSelected).thenAnswer((_) => Stream<int>.empty());
-    when(model.onVariantSelected).thenAnswer((_) => Stream<int>.empty());
+    when(model.onLayoutSelected).thenAnswer((_) => const Stream<int>.empty());
+    when(model.onVariantSelected).thenAnswer((_) => const Stream<int>.empty());
     return model;
   }
 
   Widget buildPage(KeyboardModel model) {
     final client = MockSubiquityClient();
     when(client.getKeyboardStep(any)).thenAnswer(
-        (_) async => AnyStep.stepPressKey(keycodes: {}, symbols: []));
+        (_) async => const AnyStep.stepPressKey(keycodes: {}, symbols: []));
     registerMockService<SubiquityClient>(client);
 
     return ChangeNotifierProvider<KeyboardModel>.value(
       value: model,
-      child: KeyboardPage(),
+      child: const KeyboardPage(),
     );
   }
 
@@ -121,7 +119,7 @@ void main() {
 
     final context = tester.element(find.byType(DetectKeyboardView));
     Navigator.of(context)
-        .pop(AnyStep.stepResult(layout: 'layout', variant: 'variant'));
+        .pop(const AnyStep.stepResult(layout: 'layout', variant: 'variant'));
     await tester.pumpAndSettle();
     verify(model.trySelectLayoutVariant('layout', 'variant'));
   });
@@ -188,8 +186,8 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.getKeyboard()).thenAnswer((_) async =>
-        KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
-    when(client.setInputSource(KeyboardSetting(layout: '')))
+        const KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
+    when(client.setInputSource(const KeyboardSetting(layout: '')))
         .thenAnswer((_) async {});
     registerMockService<SubiquityClient>(client);
 

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_widgets_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_widgets_test.dart
@@ -4,8 +4,6 @@ import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_widgets.dart';
 
 import '../test_utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   setUpAll(() => UbuntuTester.context = DetectKeyboardView);
 
@@ -36,7 +34,7 @@ void main() {
 
   testWidgets('find key', (tester) async {
     await tester.pumpWidget(
-      tester.buildApp((_) => DetectKeyboardView(keyPresent: 'x')),
+      tester.buildApp((_) => const DetectKeyboardView(keyPresent: 'x')),
     );
 
     expect(find.byType(KeyPresentView), findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
@@ -8,8 +8,6 @@ import 'package:ubuntu_desktop_installer/pages/locale/locale_model.dart';
 
 import 'locale_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('load languages', () async {
     final client = MockSubiquityClient();
@@ -45,9 +43,9 @@ void main() {
     expect(model.selectedLanguageIndex, equals(0));
 
     // falls back to the base locale (en_US)
-    model.selectLocale(Locale('foo'));
+    model.selectLocale(const Locale('foo'));
     expect(
-        model.locale(model.selectedLanguageIndex), equals(Locale('en', 'US')));
+        model.locale(model.selectedLanguageIndex), equals(const Locale('en', 'US')));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);
@@ -66,7 +64,7 @@ void main() {
     final sound = MockSoundService();
 
     final model = LocaleModel(client: client, sound: sound);
-    model.applyLocale(Locale('fr', 'CA'));
+    model.applyLocale(const Locale('fr', 'CA'));
     verify(client.setLocale('fr_CA.UTF-8')).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
@@ -44,8 +44,8 @@ void main() {
 
     // falls back to the base locale (en_US)
     model.selectLocale(const Locale('foo'));
-    expect(
-        model.locale(model.selectedLanguageIndex), equals(const Locale('en', 'US')));
+    expect(model.locale(model.selectedLanguageIndex),
+        equals(const Locale('en', 'US')));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -18,8 +18,6 @@ import 'package:ubuntu_wizard/widgets.dart';
 
 import 'locale_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SoundService, TelemetryService])
 void main() {
   late MaterialApp app;
@@ -33,20 +31,20 @@ void main() {
     app = MaterialApp(
       supportedLocales: supportedLocales,
       localizationsDelegates: localizationsDelegates,
-      locale: Locale('en'),
+      locale: const Locale('en'),
       home: Flavor(
         data: const FlavorData(name: 'Ubuntu'),
         child: Wizard(
           routes: <String, WizardRoute>{
-            Routes.locale: WizardRoute(builder: (_) => LocalePage()),
-            Routes.welcome: WizardRoute(builder: (_) => Text(Routes.welcome)),
+            Routes.locale: WizardRoute(builder: (_) => const LocalePage()),
+            Routes.welcome: WizardRoute(builder: (_) => const Text(Routes.welcome)),
           },
         ),
       ),
     );
     final client = MockSubiquityClient();
     when(client.getKeyboard()).thenAnswer((_) async =>
-        KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
+        const KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
     await tester.pumpWidget(
       MultiProvider(providers: [
         ChangeNotifierProvider(
@@ -72,7 +70,7 @@ void main() {
     expect(listItems.evaluate().length, lessThan(app.supportedLocales.length));
     for (final language in ['English', 'Français', 'Galego', 'Italiano']) {
       final listItem = find.listTile(language, skipOffstage: false);
-      await tester.dragUntilVisible(listItem, languageList, Offset(0, -10));
+      await tester.dragUntilVisible(listItem, languageList, const Offset(0, -10));
       await tester.pumpAndSettle();
       expect(listItem, findsOneWidget);
     }

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -37,7 +37,8 @@ void main() {
         child: Wizard(
           routes: <String, WizardRoute>{
             Routes.locale: WizardRoute(builder: (_) => const LocalePage()),
-            Routes.welcome: WizardRoute(builder: (_) => const Text(Routes.welcome)),
+            Routes.welcome:
+                WizardRoute(builder: (_) => const Text(Routes.welcome)),
           },
         ),
       ),
@@ -70,7 +71,8 @@ void main() {
     expect(listItems.evaluate().length, lessThan(app.supportedLocales.length));
     for (final language in ['English', 'Français', 'Galego', 'Italiano']) {
       final listItem = find.listTile(language, skipOffstage: false);
-      await tester.dragUntilVisible(listItem, languageList, const Offset(0, -10));
+      await tester.dragUntilVisible(
+          listItem, languageList, const Offset(0, -10));
       await tester.pumpAndSettle();
       expect(listItem, findsOneWidget);
     }

--- a/packages/ubuntu_desktop_installer/test/network/network_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_model_test.dart
@@ -23,7 +23,8 @@ void main() {
 
     final ethernet = MockConnectModel();
     when(ethernet.connectMode).thenReturn(ConnectMode.ethernet);
-    when(ethernet.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(ethernet.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
     model.addConnectMode(ethernet);
 
     final wifi = MockConnectModel();
@@ -33,7 +34,8 @@ void main() {
 
     final hiddenWifi = MockConnectModel();
     when(hiddenWifi.connectMode).thenReturn(ConnectMode.hiddenWifi);
-    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(hiddenWifi.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
     model.addConnectMode(hiddenWifi);
 
     final none = MockConnectModel();
@@ -117,7 +119,8 @@ void main() {
     final ethernet = MockConnectModel();
     when(ethernet.isEnabled).thenReturn(true);
     when(ethernet.connectMode).thenReturn(ConnectMode.ethernet);
-    when(ethernet.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(ethernet.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
 
     final wifi = MockConnectModel();
     when(wifi.isEnabled).thenReturn(true);
@@ -127,7 +130,8 @@ void main() {
     final hiddenWifi = MockConnectModel();
     when(hiddenWifi.isEnabled).thenReturn(true);
     when(hiddenWifi.connectMode).thenReturn(ConnectMode.hiddenWifi);
-    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(hiddenWifi.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
 
     final none = MockConnectModel();
     when(none.isEnabled).thenReturn(true);

--- a/packages/ubuntu_desktop_installer/test/network/network_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_model_test.dart
@@ -9,8 +9,6 @@ import 'package:ubuntu_desktop_installer/pages/network/network_model.dart';
 import 'network_model_test.mocks.dart';
 import 'network_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([ConnectModel])
 void main() {
   test('connects the service', () async {
@@ -25,22 +23,22 @@ void main() {
 
     final ethernet = MockConnectModel();
     when(ethernet.connectMode).thenReturn(ConnectMode.ethernet);
-    when(ethernet.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(ethernet.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
     model.addConnectMode(ethernet);
 
     final wifi = MockConnectModel();
     when(wifi.connectMode).thenReturn(ConnectMode.wifi);
-    when(wifi.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(wifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
     model.addConnectMode(wifi);
 
     final hiddenWifi = MockConnectModel();
     when(hiddenWifi.connectMode).thenReturn(ConnectMode.hiddenWifi);
-    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
     model.addConnectMode(hiddenWifi);
 
     final none = MockConnectModel();
     when(none.connectMode).thenReturn(ConnectMode.none);
-    when(none.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(none.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
     model.addConnectMode(none);
 
     await model.init();
@@ -73,7 +71,7 @@ void main() {
 
     final wifi = MockConnectModel();
     when(wifi.connectMode).thenReturn(ConnectMode.wifi);
-    when(wifi.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(wifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
     model.addConnectMode(wifi);
     verify(wifi.connectMode).called(1);
     verify(wifi.onAvailabilityChanged).called(1);
@@ -119,22 +117,22 @@ void main() {
     final ethernet = MockConnectModel();
     when(ethernet.isEnabled).thenReturn(true);
     when(ethernet.connectMode).thenReturn(ConnectMode.ethernet);
-    when(ethernet.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(ethernet.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final wifi = MockConnectModel();
     when(wifi.isEnabled).thenReturn(true);
     when(wifi.connectMode).thenReturn(ConnectMode.wifi);
-    when(wifi.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(wifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final hiddenWifi = MockConnectModel();
     when(hiddenWifi.isEnabled).thenReturn(true);
     when(hiddenWifi.connectMode).thenReturn(ConnectMode.hiddenWifi);
-    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(hiddenWifi.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final none = MockConnectModel();
     when(none.isEnabled).thenReturn(true);
     when(none.connectMode).thenReturn(ConnectMode.none);
-    when(none.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(none.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final model = NetworkModel(service);
     model.addConnectMode(ethernet);
@@ -198,7 +196,7 @@ void main() {
     when(none.connectMode).thenReturn(ConnectMode.none);
     when(none.isEnabled).thenReturn(true);
     when(none.hasActiveConnection).thenReturn(false);
-    when(none.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(none.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final model = NetworkModel(service);
     model.addConnectMode(ethernet);

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -53,7 +53,8 @@ void main() {
     when(ethernetModel.isConnected).thenReturn(true);
     when(ethernetModel.isConnecting).thenReturn(false);
     when(ethernetModel.isEnabled).thenReturn(ethernet ?? true);
-    when(ethernetModel.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(ethernetModel.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
 
     final accessPoint = MockAccessPoint();
     when(accessPoint.name).thenReturn('ap');
@@ -78,7 +79,8 @@ void main() {
     when(wifiModel.canConnect).thenReturn(true);
     when(wifiModel.isConnected).thenReturn(true);
     when(wifiModel.isConnecting).thenReturn(false);
-    when(wifiModel.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
+    when(wifiModel.onAvailabilityChanged)
+        .thenAnswer((_) => const Stream.empty());
 
     final hiddenWifiModel = MockHiddenWifiModel();
     when(hiddenWifiModel.connectMode).thenReturn(ConnectMode.hiddenWifi);

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -23,8 +23,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../test_utils.dart';
 import 'network_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([
   AccessPoint,
   EthernetModel,
@@ -55,7 +53,7 @@ void main() {
     when(ethernetModel.isConnected).thenReturn(true);
     when(ethernetModel.isConnecting).thenReturn(false);
     when(ethernetModel.isEnabled).thenReturn(ethernet ?? true);
-    when(ethernetModel.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(ethernetModel.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final accessPoint = MockAccessPoint();
     when(accessPoint.name).thenReturn('ap');
@@ -80,7 +78,7 @@ void main() {
     when(wifiModel.canConnect).thenReturn(true);
     when(wifiModel.isConnected).thenReturn(true);
     when(wifiModel.isConnecting).thenReturn(false);
-    when(wifiModel.onAvailabilityChanged).thenAnswer((_) => Stream.empty());
+    when(wifiModel.onAvailabilityChanged).thenAnswer((_) => const Stream.empty());
 
     final hiddenWifiModel = MockHiddenWifiModel();
     when(hiddenWifiModel.connectMode).thenReturn(ConnectMode.hiddenWifi);
@@ -93,7 +91,7 @@ void main() {
     when(hiddenWifiModel.isConnected).thenReturn(true);
     when(hiddenWifiModel.isConnecting).thenReturn(false);
     when(hiddenWifiModel.onAvailabilityChanged)
-        .thenAnswer((_) => Stream.empty());
+        .thenAnswer((_) => const Stream.empty());
 
     return MultiProvider(
       providers: [

--- a/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
@@ -12,8 +12,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../test_utils.dart';
 import 'secure_boot_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SecureBootModel])
 void main() {
   SecureBootModel buildModel({
@@ -39,7 +37,7 @@ void main() {
   Widget buildPage(SecureBootModel model) {
     return ChangeNotifierProvider<SecureBootModel>.value(
       value: model,
-      child: SecureBootPage(),
+      child: const SecureBootPage(),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/disk_storage_service_test.dart
@@ -4,8 +4,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   final testDisks = <Disk>[fakeDisk(id: 'a'), fakeDisk(id: 'b')];
   final testTargets = testDisks
@@ -23,7 +21,7 @@ void main() {
         .thenAnswer((_) async => fakeStorageResponse(disks: testDisks));
     when(client.hasRst()).thenAnswer((_) async => false);
     when(client.hasBitLocker()).thenAnswer((_) async => false);
-    when(client.getStatus()).thenAnswer((_) async => ApplicationStatus(
+    when(client.getStatus()).thenAnswer((_) async => const ApplicationStatus(
           cloudInitOk: null,
           confirmingTty: '',
           echoSyslogId: '',
@@ -153,8 +151,8 @@ void main() {
 
   test('add/edit/remove partition', () async {
     final disk = fakeDisk(id: 'tst');
-    final gap = Gap(offset: 2, size: 3, usable: GapUsable.YES);
-    final partition = Partition(number: 1);
+    const gap = Gap(offset: 2, size: 3, usable: GapUsable.YES);
+    const partition = Partition(number: 1);
     final service = DiskStorageService(client);
 
     when(client.addPartitionV2(disk, gap, partition))
@@ -236,13 +234,13 @@ void main() {
         disks: [
           fakeDisk(
             partitions: [
-              Partition(os: win10),
+              const Partition(os: win10),
             ],
           ),
           fakeDisk(
             partitions: [
-              Partition(os: ubuntu2110),
-              Partition(os: ubuntu2204),
+              const Partition(os: ubuntu2110),
+              const Partition(os: ubuntu2204),
             ],
           ),
         ],

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -18,8 +18,6 @@ import '../test_utils.dart';
 import 'source_model_test.mocks.dart';
 import 'source_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SourceModel, TelemetryService])
 void main() {
   SourceModel buildModel({
@@ -31,7 +29,7 @@ void main() {
   }) {
     final model = MockSourceModel();
     when(model.sources).thenReturn([
-      SourceSelection(
+      const SourceSelection(
         id: kMinimalSourceId,
         name: '',
         description: '',
@@ -39,7 +37,7 @@ void main() {
         variant: 'desktop',
         isDefault: false,
       ),
-      SourceSelection(
+      const SourceSelection(
         id: kNormalSourceId,
         name: '',
         description: '',
@@ -62,7 +60,7 @@ void main() {
 
     return ChangeNotifierProvider<SourceModel>.value(
       value: model,
-      child: SourcePage(),
+      child: const SourcePage(),
     );
   }
 
@@ -201,12 +199,12 @@ void main() {
 
     final power = MockPowerService();
     when(power.onBattery).thenReturn(false);
-    when(power.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(power.propertiesChanged).thenAnswer((_) => const Stream.empty());
     registerMockService<PowerService>(power);
 
     final network = MockNetworkService();
     when(network.isConnected).thenReturn(true);
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
     registerMockService<NetworkService>(network);
 
     final storage = MockDiskStorageService();

--- a/packages/ubuntu_desktop_installer/test/theme/theme_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/theme/theme_page_test.dart
@@ -9,8 +9,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../test_utils.dart';
 import 'theme_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([DesktopService])
 void main() {
   testWidgets('ThemePage applies theme', (tester) async {
@@ -21,7 +19,7 @@ void main() {
 
     final lightOptionCard = find.widgetWithImage(
       YaruSelectableContainer,
-      AssetImage('assets/theme/light-theme.png'),
+      const AssetImage('assets/theme/light-theme.png'),
     );
     expect(lightOptionCard, findsOneWidget);
     await tester.tap(lightOptionCard);
@@ -29,7 +27,7 @@ void main() {
 
     final darkOptionCard = find.widgetWithImage(
       YaruSelectableContainer,
-      AssetImage('assets/theme/dark-theme.png'),
+      const AssetImage('assets/theme/dark-theme.png'),
     );
     expect(darkOptionCard, findsOneWidget);
     await tester.tap(darkOptionCard);

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_model_test.dart
@@ -4,13 +4,11 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_model.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('init', () async {
     final client = MockSubiquityClient();
     when(client.getTimezone()).thenAnswer((_) async =>
-        TimeZoneInfo(timezone: 'Europe/Stockholm', fromGeoip: false));
+        const TimeZoneInfo(timezone: 'Europe/Stockholm', fromGeoip: false));
 
     final model = TimezoneModel(client);
 

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -14,8 +14,6 @@ import 'package:ubuntu_test/utils.dart';
 import '../test_utils.dart';
 import 'timezone_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([GeoService, TimezoneController, TimezoneModel])
 void main() {
   MockTimezoneController buildController({
@@ -111,7 +109,7 @@ void main() {
     final model = buildModel();
     final controller = buildController();
     when(controller.searchLocation('b')).thenAnswer((_) async => locations);
-    when(controller.selectLocation(GeoLocation())).thenAnswer((_) {});
+    when(controller.selectLocation(const GeoLocation())).thenAnswer((_) {});
 
     await tester
         .pumpWidget(tester.buildApp((_) => buildPage(model, controller)));
@@ -131,7 +129,7 @@ void main() {
     await tester.ensureVisible(item);
     await tester.tapAt(tester.getTopLeft(item));
     await tester.pump();
-    verify(controller.selectLocation(GeoLocation(name: 'b'))).called(1);
+    verify(controller.selectLocation(const GeoLocation(name: 'b'))).called(1);
   });
 
   testWidgets('select timezone', (tester) async {
@@ -143,7 +141,7 @@ void main() {
     final model = buildModel();
     final controller = buildController();
     when(controller.searchTimezone('b')).thenAnswer((_) async => timezones);
-    when(controller.selectTimezone(GeoLocation())).thenAnswer((_) {});
+    when(controller.selectTimezone(const GeoLocation())).thenAnswer((_) {});
 
     await tester
         .pumpWidget(tester.buildApp((_) => buildPage(model, controller)));
@@ -163,7 +161,7 @@ void main() {
     await tester.ensureVisible(item);
     await tester.tapAt(tester.getTopLeft(item));
     await tester.pump();
-    verify(controller.selectTimezone(GeoLocation(timezone: 'b'))).called(1);
+    verify(controller.selectTimezone(const GeoLocation(timezone: 'b'))).called(1);
   });
 
   testWidgets('select coordinates', (tester) async {
@@ -268,7 +266,7 @@ void main() {
   testWidgets('creates a model and controller', (tester) async {
     final client = MockSubiquityClient();
     when(client.getTimezone())
-        .thenAnswer((_) async => TimeZoneInfo(timezone: '', fromGeoip: false));
+        .thenAnswer((_) async => const TimeZoneInfo(timezone: '', fromGeoip: false));
     registerMockService<SubiquityClient>(client);
 
     final service = MockGeoService();

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -161,7 +161,8 @@ void main() {
     await tester.ensureVisible(item);
     await tester.tapAt(tester.getTopLeft(item));
     await tester.pump();
-    verify(controller.selectTimezone(const GeoLocation(timezone: 'b'))).called(1);
+    verify(controller.selectTimezone(const GeoLocation(timezone: 'b')))
+        .called(1);
   });
 
   testWidgets('select coordinates', (tester) async {
@@ -265,8 +266,8 @@ void main() {
 
   testWidgets('creates a model and controller', (tester) async {
     final client = MockSubiquityClient();
-    when(client.getTimezone())
-        .thenAnswer((_) async => const TimeZoneInfo(timezone: '', fromGeoip: false));
+    when(client.getTimezone()).thenAnswer(
+        (_) async => const TimeZoneInfo(timezone: '', fromGeoip: false));
     registerMockService<SubiquityClient>(client);
 
     final service = MockGeoService();

--- a/packages/ubuntu_desktop_installer/test/welcome/rst/rst_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/rst/rst_model_test.dart
@@ -3,8 +3,6 @@ import 'package:mockito/mockito.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/welcome/rst/rst_model.dart';
 
-// ignore_for_file: type=lint
-
 void main() async {
   test('reboot', () async {
     final client = MockSubiquityClient();

--- a/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
@@ -13,8 +13,6 @@ import 'package:yaru_window_test/yaru_window_test.dart';
 import '../../test_utils.dart';
 import 'rst_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([RstModel, UrlLauncher])
 void main() {
   setUpAll(YaruTestWindow.ensureInitialized);
@@ -25,7 +23,7 @@ void main() {
     await tester.pumpWidget(
       Provider<RstModel>.value(
         value: model,
-        child: tester.buildApp((_) => RstPage()),
+        child: tester.buildApp((_) => const RstPage()),
       ),
     );
 
@@ -64,7 +62,7 @@ void main() {
     await tester.pumpWidget(
       Provider<RstModel>.value(
         value: model,
-        child: tester.buildApp((_) => RstPage()),
+        child: tester.buildApp((_) => const RstPage()),
       ),
     );
 

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_model_test.dart
@@ -9,8 +9,6 @@ import 'package:ubuntu_desktop_installer/services/network_service.dart';
 
 import 'welcome_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([NetworkService])
 void main() {
   test('selected option', () {
@@ -43,7 +41,7 @@ void main() {
 https://wiki.ubuntu.com/IntrepidReleaseNotes/\${LANG}
     ''');
 
-    final url = model.releaseNotesURL(Locale('fr'), fs: fs);
+    final url = model.releaseNotesURL(const Locale('fr'), fs: fs);
     expect(url, equals('https://wiki.ubuntu.com/IntrepidReleaseNotes/fr'));
   });
 
@@ -61,7 +59,7 @@ version,codename,series,created,release,eol,eol-server,eol-esm
 5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31
     ''');
 
-    final url = model.releaseNotesURL(Locale('en'), fs: fs);
+    final url = model.releaseNotesURL(const Locale('en'), fs: fs);
     expect(url, equals('https://wiki.ubuntu.com/HoaryHedgehog/ReleaseNotes'));
   });
 
@@ -71,7 +69,7 @@ version,codename,series,created,release,eol,eol-server,eol-esm
     final model = WelcomeModel(client: client, network: network);
 
     final fs = MemoryFileSystem.test();
-    final url = model.releaseNotesURL(Locale('en'), fs: fs);
+    final url = model.releaseNotesURL(const Locale('en'), fs: fs);
     expect(url, equals('https://ubuntu.com/download/desktop'));
   });
 }

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -18,8 +18,6 @@ import 'package:yaru_window_test/yaru_window_test.dart';
 
 import 'welcome_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([UrlLauncher, NetworkService])
 void main() {
   setUpAll(YaruTestWindow.ensureInitialized);
@@ -32,20 +30,20 @@ void main() {
     when(client.hasRst()).thenAnswer((_) async => false);
     final network = MockNetworkService();
     when(network.isConnected).thenReturn(isConnected);
-    when(network.propertiesChanged).thenAnswer((_) => Stream.empty());
+    when(network.propertiesChanged).thenAnswer((_) => const Stream.empty());
     model = WelcomeModel(client: client, network: network);
 
     app = MaterialApp(
       supportedLocales: supportedLocales,
       localizationsDelegates: localizationsDelegates,
-      locale: Locale('en'),
+      locale: const Locale('en'),
       home: InheritedLocale(
         child: Flavor(
           data: const FlavorData(name: 'Ubuntu'),
           child: Wizard(
             routes: {
               Routes.welcome: WizardRoute(
-                builder: (_) => WelcomePage(),
+                builder: (_) => const WelcomePage(),
                 onNext: (settings) {
                   switch (model.option) {
                     case Option.repairUbuntu:
@@ -58,10 +56,10 @@ void main() {
                 },
               ),
               Routes.repairUbuntu: WizardRoute(
-                builder: (context) => Text(Routes.repairUbuntu),
+                builder: (context) => const Text(Routes.repairUbuntu),
               ),
               Routes.keyboard: WizardRoute(
-                builder: (context) => Text(Routes.keyboard),
+                builder: (context) => const Text(Routes.keyboard),
               ),
             },
           ),

--- a/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_desktop_installer/test/widgets/storage_size_box_test.dart
@@ -8,8 +8,6 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets/storage_size_box.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   testWidgets('enter size', (tester) async {
     int? size;
@@ -50,7 +48,7 @@ void main() {
     await tester.tap(find.byType(MenuAnchor));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(ValueKey(DataUnit.megabytes)).last);
+    await tester.tap(find.byKey(const ValueKey(DataUnit.megabytes)).last);
     await tester.pump();
 
     expect(unit, equals(DataUnit.megabytes));

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_model_test.dart
@@ -8,47 +8,45 @@ import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'write_changes_to_disk_model_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([DiskStorageService])
 void main() {
   final testDisks = <Disk>[
     fakeDisk(
       path: '/dev/sda',
       preserve: false,
-      partitions: [Partition(number: 1, preserve: false)],
+      partitions: [const Partition(number: 1, preserve: false)],
     ),
     fakeDisk(
       path: '/dev/sdb',
       preserve: true,
       partitions: [
-        Partition(number: 1),
-        Partition(number: 2, preserve: false),
+        const Partition(number: 1),
+        const Partition(number: 2, preserve: false),
       ],
     ),
     fakeDisk(
       path: '/dev/sdc',
       preserve: false,
       partitions: [
-        Partition(number: 3, preserve: false),
-        Partition(number: 4, grubDevice: false),
+        const Partition(number: 3, preserve: false),
+        const Partition(number: 4, grubDevice: false),
       ],
     ),
     fakeDisk(
       path: '/dev/sdd',
       preserve: true,
       partitions: [
-        Partition(number: 1, preserve: true),
-        Partition(number: 2, mount: '/mnt'),
-        Partition(number: 3, wipe: 'superblock'),
-        Partition(number: 4, resize: true),
+        const Partition(number: 1, preserve: true),
+        const Partition(number: 2, mount: '/mnt'),
+        const Partition(number: 3, wipe: 'superblock'),
+        const Partition(number: 4, resize: true),
       ],
     ),
     fakeDisk(
       path: '/dev/sde',
       preserve: true,
       partitions: [
-        Partition(number: 1, preserve: true),
+        const Partition(number: 1, preserve: true),
       ],
     ),
   ];
@@ -79,24 +77,24 @@ void main() {
     expect(
       model.partitions,
       equals({
-        'sda': [Partition(number: 1, preserve: false)],
-        'sdb': [Partition(number: 2, preserve: false)],
-        'sdc': [Partition(number: 3, preserve: false)],
+        'sda': [const Partition(number: 1, preserve: false)],
+        'sdb': [const Partition(number: 2, preserve: false)],
+        'sdc': [const Partition(number: 3, preserve: false)],
         'sdd': [
-          Partition(number: 2, mount: '/mnt'),
-          Partition(number: 3, wipe: 'superblock'),
-          Partition(number: 4, resize: true),
+          const Partition(number: 2, mount: '/mnt'),
+          const Partition(number: 3, wipe: 'superblock'),
+          const Partition(number: 4, resize: true),
         ],
       }),
     );
     expect(
       model.getOriginalPartition('sdd', 3),
-      Partition(number: 3, wipe: 'superblock'),
+      const Partition(number: 3, wipe: 'superblock'),
     );
   });
 
   test('set guided storage', () async {
-    final target =
+    const target =
         GuidedStorageTarget.reformat(diskId: 'sda', capabilities: []);
 
     final client = MockSubiquityClient();

--- a/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/write_changes_to_disk/write_changes_to_disk_page_test.dart
@@ -16,15 +16,13 @@ import '../test_utils.dart';
 import 'write_changes_to_disk_model_test.mocks.dart';
 import 'write_changes_to_disk_page_test.mocks.dart';
 
-// ignore_for_file: type=lint
-
 final testDisks = <Disk>[
   fakeDisk(
     path: '/dev/sda',
     size: 12,
     preserve: false,
     partitions: [
-      Partition(
+      const Partition(
         path: '/dev/sda1',
         number: 1,
         size: 11,
@@ -32,7 +30,7 @@ final testDisks = <Disk>[
         format: 'ext',
         preserve: false,
       ),
-      Partition(
+      const Partition(
         path: '/dev/sda2',
         number: 2,
         size: 22,
@@ -47,7 +45,7 @@ final testDisks = <Disk>[
     size: 23,
     preserve: false,
     partitions: [
-      Partition(
+      const Partition(
         path: '/dev/sdb3',
         number: 3,
         size: 33,
@@ -55,26 +53,26 @@ final testDisks = <Disk>[
         mount: '/mnt/3',
         format: 'ext3',
       ),
-      Partition(
+      const Partition(
         path: '/dev/sdb4',
         number: 4,
         size: 44,
         wipe: 'superblock',
         format: 'ext4',
       ),
-      Partition(
+      const Partition(
         path: '/dev/sdb5',
         number: 5,
         size: 55,
         mount: '/mnt/5',
       ),
-      Partition(
+      const Partition(
         path: '/dev/sdb6',
         number: 6,
         size: 66,
         resize: true,
       ),
-      Partition(
+      const Partition(
         path: '/dev/sdb7',
         number: 7,
         preserve: false,
@@ -139,7 +137,7 @@ void main() {
       testDisks.first.sysname: testDisks.first.partitions.cast<Partition>(),
       testDisks.last.sysname: testDisks.last.partitions.cast<Partition>(),
     }, originals: {
-      'sdb': [Partition(number: 6, size: 123)],
+      'sdb': [const Partition(number: 6, size: 123)],
     });
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 


### PR DESCRIPTION
Removed ``// ignore_for_file: type=lint`` in `packages/ubuntu_desktop_installer/test/**` and ran `dart fix --apply`