### PR TITLE
ubuntu_wsl_setup: enable lints for tests

### DIFF
--- a/packages/ubuntu_wsl_setup/test/advanced_setup_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_model_test.dart
@@ -4,8 +4,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_wsl_setup/pages/advanced_setup/advanced_setup_model.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('load advanced setup', () async {
     const conf = WSLConfigurationBase(
@@ -38,7 +36,7 @@ void main() {
     model.enableHostGeneration = false;
     model.enableResolvConfGeneration = false;
 
-    final conf = WSLConfigurationBase(
+    const conf = WSLConfigurationBase(
       automountRoot: 'path',
       automountOptions: 'opt',
       networkGeneratehosts: false,

--- a/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/advanced_setup_page_test.dart
@@ -15,8 +15,6 @@ import 'package:ubuntu_wsl_setup/pages/advanced_setup/advanced_setup_page.dart';
 import 'advanced_setup_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([AdvancedSetupModel])
 void main() {
   LangTester.type = AdvancedSetupPage;
@@ -41,7 +39,7 @@ void main() {
   Widget buildPage(AdvancedSetupModel model) {
     return ChangeNotifierProvider<AdvancedSetupModel>.value(
       value: model,
-      child: AdvancedSetupPage(),
+      child: const AdvancedSetupPage(),
     );
   }
 
@@ -138,7 +136,7 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.wslConfigurationBase())
-        .thenAnswer((_) async => WSLConfigurationBase());
+        .thenAnswer((_) async => const WSLConfigurationBase());
     registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(

--- a/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/applying_changes_page_test.dart
@@ -15,8 +15,6 @@ import 'package:yaru_window_test/yaru_window_test.dart';
 import 'applying_changes_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([ApplyingChangesModel])
 void main() {
   setUpAll(YaruTestWindow.ensureInitialized);
@@ -27,7 +25,7 @@ void main() {
   Widget buildPage(ApplyingChangesModel model) {
     return ChangeNotifierProvider<ApplyingChangesModel>.value(
       value: model,
-      child: ApplyingChangesPage(),
+      child: const ApplyingChangesPage(),
     );
   }
 
@@ -45,8 +43,8 @@ void main() {
           ),
           if (hasNext)
             '/end': WizardRoute(
-              builder: (_) => Center(
-                child: const Text(theEnd),
+              builder: (_) => const Center(
+                child: Text(theEnd),
               ),
               onNext: (settings) => '/end',
             ),

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_model_test.dart
@@ -4,8 +4,6 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_wsl_setup/pages/configuration_ui/configuration_ui_model.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('load UI configuration', () async {
     const conf = WSLConfigurationAdvanced(
@@ -38,7 +36,7 @@ void main() {
     model.automountEnabled = false;
     model.automountMountfstab = false;
 
-    final conf = WSLConfigurationAdvanced(
+    const conf = WSLConfigurationAdvanced(
       interopEnabled: true,
       interopAppendwindowspath: true,
       automountEnabled: false,

--- a/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/configuration_ui_page_test.dart
@@ -15,8 +15,6 @@ import 'package:ubuntu_wsl_setup/pages/configuration_ui/configuration_ui_page.da
 import 'configuration_ui_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([ConfigurationUIModel])
 void main() {
   LangTester.type = ConfigurationUIPage;
@@ -42,13 +40,13 @@ void main() {
   Widget buildPage(ConfigurationUIModel model) {
     return ChangeNotifierProvider<ConfigurationUIModel>.value(
       value: model,
-      child: ConfigurationUIPage(),
+      child: const ConfigurationUIPage(),
     );
   }
 
   Widget buildApp(WidgetTester tester, ConfigurationUIModel model) {
     tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
+    tester.binding.window.physicalSizeTestValue = const Size(960, 680);
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
@@ -141,7 +139,7 @@ void main() {
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.wslConfigurationAdvanced())
-        .thenAnswer((_) async => WSLConfigurationAdvanced());
+        .thenAnswer((_) async => const WSLConfigurationAdvanced());
     registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(

--- a/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/installation_slides_page_test.dart
@@ -22,7 +22,6 @@ import 'package:ubuntu_wsl_setup/services/journal.dart';
 import 'installation_slides_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
 const theEnd = 'The end';
 const title = 'A title';
 const lorem = 'Lorem ipsum';
@@ -62,13 +61,14 @@ void main() {
     final provider = SlidesProvider(slides);
     return ChangeNotifierProvider<InstallationSlidesModel>.value(
       value: model,
-      child: Provider.value(value: provider, child: InstallationSlidesPage()),
+      child: Provider.value(
+          value: provider, child: const InstallationSlidesPage()),
     );
   }
 
   Widget buildApp(Widget Function(BuildContext) builder) {
     return Provider<AppModel>(
-      create: (_) => AppModel(),
+      create: (_) => const AppModel(),
       child: MaterialApp(
         localizationsDelegates: localizationsDelegates,
         home: Wizard(routes: {
@@ -77,8 +77,8 @@ void main() {
             onNext: (settings) => '/end',
           ),
           '/end': WizardRoute(
-            builder: (_) => Center(
-              child: const Text(theEnd),
+            builder: (_) => const Center(
+              child: Text(theEnd),
             ),
             onNext: (settings) => '/end',
           ),
@@ -148,11 +148,12 @@ void main() {
   testWidgets('creates a model', (tester) async {
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     final journal = MockJournalService();
-    when(journal.stream).thenAnswer((realInvocation) => Stream<String>.empty());
+    when(journal.stream)
+        .thenAnswer((realInvocation) => const Stream<String>.empty());
     final monitor = MockSubiquityStatusMonitor();
     when(monitor.status).thenAnswer((realInvocation) => null);
     when(monitor.onStatusChanged).thenAnswer(
-      (realInvocation) => Stream.empty(),
+      (realInvocation) => const Stream.empty(),
     );
     registerMockService<JournalService>(journal);
     registerMockService<SubiquityStatusMonitor>(monitor);
@@ -174,7 +175,7 @@ void main() {
       );
       final monitor = MockSubiquityStatusMonitor();
       when(monitor.status).thenAnswer((_) => null);
-      when(monitor.onStatusChanged).thenAnswer((_) => Stream.empty());
+      when(monitor.onStatusChanged).thenAnswer((_) => const Stream.empty());
       registerMockService<JournalService>(journal);
       registerMockService<SubiquityStatusMonitor>(monitor);
 
@@ -201,7 +202,7 @@ void main() {
       );
       final monitor = MockSubiquityStatusMonitor();
       when(monitor.status).thenAnswer((_) => null);
-      when(monitor.onStatusChanged).thenAnswer((_) => Stream.empty());
+      when(monitor.onStatusChanged).thenAnswer((_) => const Stream.empty());
       registerMockService<JournalService>(journal);
       registerMockService<SubiquityStatusMonitor>(monitor);
       await tester.pumpWidget(buildApp(InstallationSlidesPage.create));

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -17,8 +17,6 @@ import 'package:ubuntu_wsl_setup/pages/profile_setup/profile_setup_page.dart';
 import 'profile_setup_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([ProfileSetupModel, UrlLauncher])
 void main() {
   LangTester.type = ProfileSetupPage;
@@ -49,13 +47,13 @@ void main() {
   Widget buildPage(ProfileSetupModel model) {
     return ChangeNotifierProvider<ProfileSetupModel>.value(
       value: model,
-      child: ProfileSetupPage(),
+      child: const ProfileSetupPage(),
     );
   }
 
   Widget buildApp(WidgetTester tester, ProfileSetupModel model) {
     tester.binding.window.devicePixelRatioTestValue = 1;
-    tester.binding.window.physicalSizeTestValue = Size(960, 680);
+    tester.binding.window.physicalSizeTestValue = const Size(960, 680);
     return MaterialApp(
       localizationsDelegates: localizationsDelegates,
       home: Wizard(
@@ -227,7 +225,7 @@ void main() {
 
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
-    when(client.getIdentity()).thenAnswer((_) async => IdentityData());
+    when(client.getIdentity()).thenAnswer((_) async => const IdentityData());
     registerMockService<SubiquityClient>(client);
 
     await tester.pumpWidget(MaterialApp(

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -8,13 +8,11 @@ import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_wsl_setup/pages/select_language/select_language_model.dart';
 import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 
-// ignore_for_file: type=lint
-
 void main() {
   test('load languages', () async {
     final model = SelectLanguageModel(
       MockSubiquityClient(),
-      LanguageFallbackService({}),
+      const LanguageFallbackService({}),
     );
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
@@ -23,7 +21,7 @@ void main() {
   test('sort languages', () async {
     final model = SelectLanguageModel(
       MockSubiquityClient(),
-      LanguageFallbackService({}),
+      const LanguageFallbackService({}),
     );
     await model.loadLanguages();
 
@@ -38,16 +36,16 @@ void main() {
   test('select locale', () async {
     final model = SelectLanguageModel(
       MockSubiquityClient(),
-      LanguageFallbackService({}),
+      const LanguageFallbackService({}),
     );
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
     expect(model.selectedLanguageIndex, equals(0));
 
     // falls back to the base locale (en_US)
-    model.selectLocale(Locale('foo'));
+    model.selectLocale(const Locale('foo'));
     expect(
-        model.locale(model.selectedLanguageIndex), equals(Locale('en', 'US')));
+        model.locale(model.selectedLanguageIndex), equals(const Locale('en', 'US')));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);
@@ -61,23 +59,23 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getLocale()).thenAnswer((_) async => 'fr_FR.UTF-8');
 
-    final model = SelectLanguageModel(client, LanguageFallbackService({}));
+    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
     final locale = await model.getServerLocale();
     verify(client.getLocale()).called(1);
-    expect(locale, equals(Locale('fr', 'FR')));
+    expect(locale, equals(const Locale('fr', 'FR')));
   });
 
   test('set locale', () {
     final client = MockSubiquityClient();
-    final model = SelectLanguageModel(client, LanguageFallbackService({}));
-    model.applyLocale(Locale('fr', 'CA'));
+    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
+    model.applyLocale(const Locale('fr', 'CA'));
     verify(client.setLocale('fr_CA.UTF-8')).called(1);
   });
 
   test('selected language', () {
     final model = SelectLanguageModel(
       MockSubiquityClient(),
-      LanguageFallbackService({}),
+      const LanguageFallbackService({}),
     );
 
     var wasNotified = false;
@@ -118,10 +116,10 @@ void main() {
   test('get install lang packs option', () async {
     final client = MockSubiquityClient();
     when(client.wslSetupOptions()).thenAnswer(
-      (_) async => WSLSetupOptions(installLanguageSupportPackages: false),
+      (_) async => const WSLSetupOptions(installLanguageSupportPackages: false),
     );
 
-    final model = SelectLanguageModel(client, LanguageFallbackService({}));
+    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
     await model.getInstallLanguagePacks();
     verify(client.wslSetupOptions()).called(1);
     expect(model.installLanguagePacks, isFalse);
@@ -129,11 +127,11 @@ void main() {
 
   test('set install lang packs option', () {
     final client = MockSubiquityClient();
-    final model = SelectLanguageModel(client, LanguageFallbackService({}));
+    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
     model.setInstallLanguagePacks(false);
     model.applyInstallLanguagePacks();
     verify(client.setWslSetupOptions(
-      WSLSetupOptions(installLanguageSupportPackages: false),
+      const WSLSetupOptions(installLanguageSupportPackages: false),
     )).called(1);
   });
 }

--- a/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_model_test.dart
@@ -44,8 +44,8 @@ void main() {
 
     // falls back to the base locale (en_US)
     model.selectLocale(const Locale('foo'));
-    expect(
-        model.locale(model.selectedLanguageIndex), equals(const Locale('en', 'US')));
+    expect(model.locale(model.selectedLanguageIndex),
+        equals(const Locale('en', 'US')));
 
     final firstLocale = model.locale(0);
     final lastLocale = model.locale(model.languageCount - 1);
@@ -59,7 +59,8 @@ void main() {
     final client = MockSubiquityClient();
     when(client.getLocale()).thenAnswer((_) async => 'fr_FR.UTF-8');
 
-    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
+    final model =
+        SelectLanguageModel(client, const LanguageFallbackService({}));
     final locale = await model.getServerLocale();
     verify(client.getLocale()).called(1);
     expect(locale, equals(const Locale('fr', 'FR')));
@@ -67,7 +68,8 @@ void main() {
 
   test('set locale', () {
     final client = MockSubiquityClient();
-    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
+    final model =
+        SelectLanguageModel(client, const LanguageFallbackService({}));
     model.applyLocale(const Locale('fr', 'CA'));
     verify(client.setLocale('fr_CA.UTF-8')).called(1);
   });
@@ -119,7 +121,8 @@ void main() {
       (_) async => const WSLSetupOptions(installLanguageSupportPackages: false),
     );
 
-    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
+    final model =
+        SelectLanguageModel(client, const LanguageFallbackService({}));
     await model.getInstallLanguagePacks();
     verify(client.wslSetupOptions()).called(1);
     expect(model.installLanguagePacks, isFalse);
@@ -127,7 +130,8 @@ void main() {
 
   test('set install lang packs option', () {
     final client = MockSubiquityClient();
-    final model = SelectLanguageModel(client, const LanguageFallbackService({}));
+    final model =
+        SelectLanguageModel(client, const LanguageFallbackService({}));
     model.setInstallLanguagePacks(false);
     model.applyInstallLanguagePacks();
     verify(client.setWslSetupOptions(

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -34,7 +34,8 @@ void main() {
     when(model.locale(2)).thenReturn(const Locale('de_DE'));
     when(model.uiLocale(2)).thenReturn(const Locale('de_DE'));
     when(model.selectedLanguageIndex).thenReturn(1);
-    when(model.getServerLocale()).thenAnswer((_) async => const Locale('fr', 'FR'));
+    when(model.getServerLocale())
+        .thenAnswer((_) async => const Locale('fr', 'FR'));
     when(model.installLanguagePacks).thenReturn(true);
     return model;
   }

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -17,8 +17,6 @@ import 'package:ubuntu_wsl_setup/services/language_fallback.dart';
 import 'select_language_page_test.mocks.dart';
 import 'test_utils.dart';
 
-// ignore_for_file: type=lint
-
 @GenerateMocks([SelectLanguageModel])
 void main() {
   LangTester.type = SelectLanguagePage;
@@ -27,16 +25,16 @@ void main() {
     final model = MockSelectLanguageModel();
     when(model.languageCount).thenReturn(3);
     when(model.language(0)).thenReturn('English');
-    when(model.locale(0)).thenReturn(Locale('en_US'));
-    when(model.uiLocale(0)).thenReturn(Locale('en_US'));
+    when(model.locale(0)).thenReturn(const Locale('en_US'));
+    when(model.uiLocale(0)).thenReturn(const Locale('en_US'));
     when(model.language(1)).thenReturn('French');
-    when(model.locale(1)).thenReturn(Locale('fr_FR'));
-    when(model.uiLocale(1)).thenReturn(Locale('fr_FR'));
+    when(model.locale(1)).thenReturn(const Locale('fr_FR'));
+    when(model.uiLocale(1)).thenReturn(const Locale('fr_FR'));
     when(model.language(2)).thenReturn('German');
-    when(model.locale(2)).thenReturn(Locale('de_DE'));
-    when(model.uiLocale(2)).thenReturn(Locale('de_DE'));
+    when(model.locale(2)).thenReturn(const Locale('de_DE'));
+    when(model.uiLocale(2)).thenReturn(const Locale('de_DE'));
     when(model.selectedLanguageIndex).thenReturn(1);
-    when(model.getServerLocale()).thenAnswer((_) async => Locale('fr', 'FR'));
+    when(model.getServerLocale()).thenAnswer((_) async => const Locale('fr', 'FR'));
     when(model.installLanguagePacks).thenReturn(true);
     return model;
   }
@@ -46,7 +44,7 @@ void main() {
       providers: [
         ChangeNotifierProvider<SelectLanguageModel>.value(value: model),
       ],
-      child: InheritedLocale(value: locale, child: SelectLanguagePage()),
+      child: InheritedLocale(value: locale, child: const SelectLanguagePage()),
     );
   }
 
@@ -67,10 +65,10 @@ void main() {
 
   testWidgets('select and apply locale', (tester) async {
     final model = buildModel();
-    await tester.pumpWidget(buildApp(tester, model, Locale('fr_FR')));
+    await tester.pumpWidget(buildApp(tester, model, const Locale('fr_FR')));
 
     verify(model.loadLanguages()).called(1);
-    verify(model.selectLocale(Locale('fr_FR'))).called(1);
+    verify(model.selectLocale(const Locale('fr_FR'))).called(1);
 
     final listTile = find.listTile('German');
     expect(listTile, findsOneWidget);
@@ -78,29 +76,29 @@ void main() {
     verify(model.selectedLanguageIndex = 2).called(1);
 
     final context = tester.element(find.byType(SelectLanguagePage));
-    expect(InheritedLocale.of(context), Locale('de_DE'));
+    expect(InheritedLocale.of(context), const Locale('de_DE'));
   });
 
   testWidgets('load and apply locale', (tester) async {
     final model = buildModel();
-    await tester.pumpWidget(buildApp(tester, model, Locale('fr_FR')));
+    await tester.pumpWidget(buildApp(tester, model, const Locale('fr_FR')));
 
     verify(model.loadLanguages()).called(1);
     verifyNever(model.getServerLocale());
-    verify(model.selectLocale(Locale('fr_FR'))).called(1);
+    verify(model.selectLocale(const Locale('fr_FR'))).called(1);
 
     final nextButton = find.button(tester.ulang.nextLabel);
     expect(nextButton, findsOneWidget);
 
     await tester.tap(nextButton);
-    verify(model.applyLocale(Locale('fr_FR'))).called(1);
+    verify(model.applyLocale(const Locale('fr_FR'))).called(1);
   });
 
   testWidgets('creates a model', (tester) async {
     final client = MockSubiquityClient();
     when(client.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     when(client.wslSetupOptions()).thenAnswer(
-      (_) async => WSLSetupOptions(installLanguageSupportPackages: true),
+      (_) async => const WSLSetupOptions(installLanguageSupportPackages: true),
     );
     registerMockService<SubiquityClient>(client);
     registerService(LanguageFallbackService.linux);


### PR DESCRIPTION
Removed ``// ignore_for_file: type=lint`` in `packages/ubuntu_wsl_setup/test/**` and ran `dart fix --apply`