### PR TITLE
screenshot_test: run with only one theme by default

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -440,21 +440,21 @@ class YaruThemeVariant extends ValueVariant<ThemeData> {
 
   static Set<ThemeData> _resolveThemes(String? name) {
     switch (name) {
-      case 'light':
-        return {yaruLight};
       case 'dark':
         return {yaruDark};
       case 'high-contrast-light':
         return {yaruHighContrastLight};
       case 'high-contrast-dark':
         return {yaruHighContrastDark};
-      default:
+      case 'all':
         return {
           yaruLight,
           yaruDark,
           yaruHighContrastLight,
           yaruHighContrastDark,
         };
+      default:
+        return {yaruLight};
     }
   }
 }


### PR DESCRIPTION
The test is much more convenient to work with if it doesn't run all four themes by default but only when explicitly requested.