### PR TITLE
CI: auto-merge l10n-only PRs

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,20 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  l10n:
+    runs-on: ubuntu-latest
+    if: ${{github.event.label.name == 'l10n'}}
+    steps:
+      - run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Run `gh pr merge --auto` to enable auto-merge for PRs that are labeled [l10n](https://github.com/canonical/ubuntu-desktop-installer/pulls?q=is%3Apr+label%3Al10n).

NOTE: [Automatic merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) happens only if all required status checks pass.