### PR TITLE
Add InstallerViewModel mixin

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -25,6 +25,7 @@ import 'theme.dart';
 import 'widgets.dart';
 
 export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
+export 'installer/view_model.dart';
 export 'slides.dart';
 
 final assetBundle =

--- a/packages/ubuntu_desktop_installer/lib/installer/view_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/view_model.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/foundation.dart';
+
+mixin InstallerViewModel on ChangeNotifier {
+  Future<void> init();
+}


### PR DESCRIPTION
The idea is that all view models will follow the same init pattern:

```dart
import 'package:ubuntu_desktop_installer/installer.dart';

class FooModel extends (Safe)ChangeNotifier with InstallerViewModel {
  @override
  Future<void> init() {
    // ...
  }
}
```
This will allow us to initialize view models upfront, for example.