### PR TITLE
refactor(locale): decouple from subiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -78,6 +78,8 @@ Future<void> runInstallerApp(
   tryRegisterService<DesktopService>(() => GnomeService());
   tryRegisterService(() => DiskStorageService(getService<SubiquityClient>()));
   tryRegisterService(JournalService.new);
+  tryRegisterService<LocaleService>(
+      () => SubiquityLocaleService(getService<SubiquityClient>()));
   tryRegisterService(() => NetworkService(getService<SubiquityClient>()));
   tryRegisterService(PowerService.new);
   tryRegisterService(ProductService.new);

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:safe_change_notifier/safe_change_notifier.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -14,12 +13,12 @@ final log = Logger('locale');
 class LocaleModel extends SafeChangeNotifier {
   /// Creates a model with the specified [client].
   LocaleModel({
-    required SubiquityClient client,
+    required LocaleService locale,
     required SoundService? sound,
-  })  : _client = client,
+  })  : _locale = locale,
         _sound = sound;
 
-  final SubiquityClient _client;
+  final LocaleService _locale;
   final SoundService? _sound;
 
   /// The index of the currently selected language.
@@ -51,7 +50,7 @@ class LocaleModel extends SafeChangeNotifier {
   /// Applies the given [locale].
   Future<void> applyLocale(Locale locale) {
     log.info('Set $locale as system locale');
-    return _client
+    return _locale
         .setLocale('${locale.languageCode}_${locale.countryCode}.UTF-8');
   }
 

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
@@ -16,7 +15,7 @@ class LocalePage extends ConsumerStatefulWidget {
 
   static final modelProvider = ChangeNotifierProvider((ref) {
     return LocaleModel(
-      client: getService<SubiquityClient>(),
+      locale: getService<LocaleService>(),
       sound: tryGetService<SoundService>(),
     );
   });

--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -4,6 +4,7 @@ export 'services/config_service.dart' hide log;
 export 'services/desktop_service.dart';
 export 'services/disk_storage_service.dart' hide log;
 export 'services/journal_service.dart';
+export 'services/locale_service.dart';
 export 'services/network_service.dart';
 export 'services/power_service.dart';
 export 'services/product_service.dart';

--- a/packages/ubuntu_desktop_installer/lib/services/locale_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/locale_service.dart
@@ -1,0 +1,18 @@
+import 'package:subiquity_client/subiquity_client.dart';
+
+abstract class LocaleService {
+  Future<String> getLocale();
+  Future<void> setLocale(String locale);
+}
+
+class SubiquityLocaleService implements LocaleService {
+  const SubiquityLocaleService(this._subiquity);
+
+  final SubiquityClient _subiquity;
+
+  @override
+  Future<String> getLocale() => _subiquity.getLocale();
+
+  @override
+  Future<void> setLocale(String locale) => _subiquity.setLocale(locale);
+}

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -11,6 +11,7 @@ import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 import 'installation_slides/installation_slides_model_test.mocks.dart';
+import 'locale/locale_page_test.mocks.dart';
 import 'theme/theme_page_test.mocks.dart';
 
 void main() {
@@ -92,6 +93,7 @@ extension on WidgetTester {
     registerMockService<DesktopService>(MockDesktopService());
     registerMockService<DiskStorageService>(DiskStorageService(client));
     registerMockService<JournalService>(journal);
+    registerMockService<LocaleService>(MockLocaleService());
     registerMockService<ProductService>(ProductService());
     registerMockService<TelemetryService>(TelemetryService());
 

--- a/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
@@ -3,26 +3,25 @@ import 'dart:ui';
 import 'package:diacritic/diacritic.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_model.dart';
 
 import 'locale_page_test.mocks.dart';
 
 void main() {
   test('load languages', () async {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
   });
 
   test('sort languages', () async {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     await model.loadLanguages();
 
     final languages = List.generate(model.languageCount, model.language);
@@ -34,10 +33,10 @@ void main() {
   });
 
   test('select locale', () async {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     await model.loadLanguages();
     expect(model.languageCount, greaterThan(1));
     expect(model.selectedLanguageIndex, equals(0));
@@ -59,20 +58,20 @@ void main() {
   });
 
   test('set locale', () {
-    final client = MockSubiquityClient();
-    when(client.setLocale('fr_CA.UTF-8')).thenAnswer((_) async {});
+    final locale = MockLocaleService();
+    when(locale.setLocale('fr_CA.UTF-8')).thenAnswer((_) async {});
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     model.applyLocale(const Locale('fr', 'CA'));
-    verify(client.setLocale('fr_CA.UTF-8')).called(1);
+    verify(locale.setLocale('fr_CA.UTF-8')).called(1);
   });
 
   test('selected language', () {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
 
     var wasNotified = false;
     model.addListener(() => wasNotified = true);
@@ -88,10 +87,10 @@ void main() {
   });
 
   test('search language', () async {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     await model.loadLanguages();
 
     final english = model.searchLanguage('eng');
@@ -123,10 +122,10 @@ void main() {
   });
 
   test('play welcome sound', () async {
-    final client = MockSubiquityClient();
+    final locale = MockLocaleService();
     final sound = MockSoundService();
 
-    final model = LocaleModel(client: client, sound: sound);
+    final model = LocaleModel(locale: locale, sound: sound);
     await model.playWelcomeSound();
     verify(sound.play('system-ready')).called(1);
   });

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -3,9 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
-import 'package:subiquity_client/subiquity_client.dart';
-import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_model.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_page.dart';
@@ -18,7 +15,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 
 import 'locale_page_test.mocks.dart';
 
-@GenerateMocks([SoundService, TelemetryService])
+@GenerateMocks([LocaleService, SoundService, TelemetryService])
 void main() {
   late MaterialApp app;
 
@@ -43,13 +40,11 @@ void main() {
         ),
       ),
     );
-    final client = MockSubiquityClient();
-    when(client.getKeyboard()).thenAnswer((_) async =>
-        const KeyboardSetup(layouts: [], setting: KeyboardSetting(layout: '')));
     await tester.pumpWidget(
       ProviderScope(overrides: [
         LocalePage.modelProvider.overrideWith(
-          (_) => LocaleModel(client: client, sound: MockSoundService()),
+          (_) => LocaleModel(
+              locale: MockLocaleService(), sound: MockSoundService()),
         ),
       ], child: InheritedLocale(child: app)),
     );

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.mocks.dart
@@ -6,9 +6,10 @@
 import 'dart:async' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services/sound_service.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services/locale_service.dart' as _i2;
+import 'package:ubuntu_desktop_installer/services/sound_service.dart' as _i4;
 import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
-    as _i4;
+    as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -21,10 +22,37 @@ import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+/// A class which mocks [LocaleService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockLocaleService extends _i1.Mock implements _i2.LocaleService {
+  MockLocaleService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i3.Future<String> getLocale() => (super.noSuchMethod(
+        Invocation.method(
+          #getLocale,
+          [],
+        ),
+        returnValue: _i3.Future<String>.value(''),
+      ) as _i3.Future<String>);
+  @override
+  _i3.Future<void> setLocale(String? locale) => (super.noSuchMethod(
+        Invocation.method(
+          #setLocale,
+          [locale],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+}
+
 /// A class which mocks [SoundService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSoundService extends _i1.Mock implements _i2.SoundService {
+class MockSoundService extends _i1.Mock implements _i4.SoundService {
   MockSoundService() {
     _i1.throwOnMissingStub(this);
   }
@@ -43,7 +71,7 @@ class MockSoundService extends _i1.Mock implements _i2.SoundService {
 /// A class which mocks [TelemetryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTelemetryService extends _i1.Mock implements _i4.TelemetryService {
+class MockTelemetryService extends _i1.Mock implements _i5.TelemetryService {
   MockTelemetryService() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/ubuntu_desktop_installer/test/services/locale_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/locale_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_desktop_installer/services/locale_service.dart';
+
+void main() {
+  group('subiquity', () {
+    test('get locale', () async {
+      final client = MockSubiquityClient();
+      when(client.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
+
+      final service = SubiquityLocaleService(client);
+
+      final locale = await service.getLocale();
+      expect(locale, equals('en_US.UTF-8'));
+
+      verify(client.getLocale()).called(1);
+    });
+
+    test('set locale', () async {
+      final client = MockSubiquityClient();
+      when(client.setLocale('en_US.UTF-8')).thenAnswer((_) async {});
+
+      final service = SubiquityLocaleService(client);
+
+      await service.setLocale('en_US.UTF-8');
+      verify(client.setLocale('en_US.UTF-8')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Get and set the locale via a service class that can be implemented with alternative backends, such as org.freedesktop.locale1 aka systemd-localed, in addition to the subiquity-based one.