### PR TITLE
migrate filesystem view models to riverpod

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dartx/dartx.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -28,6 +29,10 @@ enum PartitionLocation {
   /// At the end of the free space.
   end,
 }
+
+/// Provider for [AllocateDiskSpaceModel].
+final allocateDiskSpaceModelProvider = ChangeNotifierProvider(
+    (_) => AllocateDiskSpaceModel(getService<DiskStorageService>()));
 
 /// View model for [AllocateDiskSpacePage].
 class AllocateDiskSpaceModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_page.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -13,24 +12,15 @@ import 'allocate_disk_space_model.dart';
 import 'allocate_disk_space_widgets.dart';
 import 'storage_selector.dart';
 
-class AllocateDiskSpacePage extends StatefulWidget {
-  const AllocateDiskSpacePage({
-    super.key,
-  });
-
-  static Widget create(BuildContext context) {
-    final service = getService<DiskStorageService>();
-    return ChangeNotifierProvider(
-      create: (_) => AllocateDiskSpaceModel(service),
-      child: const AllocateDiskSpacePage(),
-    );
-  }
+class AllocateDiskSpacePage extends ConsumerStatefulWidget {
+  const AllocateDiskSpacePage({super.key});
 
   @override
-  State<AllocateDiskSpacePage> createState() => _AllocateDiskSpacePageState();
+  ConsumerState<AllocateDiskSpacePage> createState() =>
+      _AllocateDiskSpacePageState();
 }
 
-class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
+class _AllocateDiskSpacePageState extends ConsumerState<AllocateDiskSpacePage> {
   final _scrollController = AutoScrollController();
   StreamSubscription? _scrollSubscription;
 
@@ -38,7 +28,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
   void initState() {
     super.initState();
 
-    final model = Provider.of<AllocateDiskSpaceModel>(context, listen: false);
+    final model = ref.read(allocateDiskSpaceModelProvider);
     _scrollSubscription = model.onSelectionChanged.listen((_) {
       _scrollToSelection();
     });
@@ -55,7 +45,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
   void _scrollToSelection() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      final model = Provider.of<AllocateDiskSpaceModel>(context, listen: false);
+      final model = ref.read(allocateDiskSpaceModelProvider);
       if (model.selectedDiskIndex != -1) {
         _scrollController.scrollToIndex(
           Object.hashAll([model.selectedDiskIndex, model.selectedObjectIndex]),
@@ -66,7 +56,7 @@ class _AllocateDiskSpacePageState extends State<AllocateDiskSpacePage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AllocateDiskSpaceModel>(context);
+    final model = ref.watch(allocateDiskSpaceModelProvider);
     final lang = AppLocalizations.of(context);
 
     return WizardPage(

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/allocate_disk_space_widgets.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
@@ -14,12 +14,12 @@ import 'storage_columns.dart';
 import 'storage_table.dart';
 import 'storage_types.dart';
 
-class PartitionBar extends StatelessWidget {
+class PartitionBar extends ConsumerWidget {
   const PartitionBar({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final model = Provider.of<AllocateDiskSpaceModel>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(allocateDiskSpaceModelProvider);
     return YaruBorderContainer(
       borderRadius: BorderRadius.circular(kYaruButtonRadius),
       clipBehavior: Clip.antiAlias,
@@ -78,12 +78,12 @@ class _PartitionPainter extends CustomPainter {
   }
 }
 
-class PartitionLegend extends StatelessWidget {
+class PartitionLegend extends ConsumerWidget {
   const PartitionLegend({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final model = Provider.of<AllocateDiskSpaceModel>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(allocateDiskSpaceModelProvider);
     final lang = AppLocalizations.of(context);
 
     final objects = model.selectedDisk?.partitions ?? [];
@@ -158,14 +158,14 @@ class _PartitionLabel extends StatelessWidget {
   }
 }
 
-class PartitionTable extends StatelessWidget {
+class PartitionTable extends ConsumerWidget {
   const PartitionTable({super.key, required this.controller});
 
   final AutoScrollController controller;
 
   @override
-  Widget build(BuildContext context) {
-    final model = Provider.of<AllocateDiskSpaceModel>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(allocateDiskSpaceModelProvider);
     return StorageTable(
       columns: [
         StorageDeviceColumn(),
@@ -188,12 +188,12 @@ class PartitionTable extends StatelessWidget {
   }
 }
 
-class PartitionButtonRow extends StatelessWidget {
+class PartitionButtonRow extends ConsumerWidget {
   const PartitionButtonRow({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final model = Provider.of<AllocateDiskSpaceModel>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(allocateDiskSpaceModelProvider);
     final lang = AppLocalizations.of(context);
 
     return Row(
@@ -258,7 +258,7 @@ class PartitionButtonRow extends StatelessWidget {
           children: [
             OutlinedButton(
               onPressed: model.canReformatDisk
-                  ? () => _maybeReformatDisk(context)
+                  ? () => _maybeReformatDisk(context, ref)
                   : null,
               child: Text(lang.newPartitionTable),
             ),
@@ -272,8 +272,8 @@ class PartitionButtonRow extends StatelessWidget {
     );
   }
 
-  Future<void> _maybeReformatDisk(BuildContext context) async {
-    final model = Provider.of<AllocateDiskSpaceModel>(context, listen: false);
+  Future<void> _maybeReformatDisk(BuildContext context, WidgetRef ref) async {
+    final model = ref.read(allocateDiskSpaceModelProvider.notifier);
     final lang = AppLocalizations.of(context);
 
     final disk = model.selectedDisk!;

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/storage_columns.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/allocate_disk_space/storage_columns.dart
@@ -1,6 +1,6 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -188,15 +188,17 @@ class StorageWipeColumn extends StorageColumn {
             return const SizedBox.shrink();
           },
           partitionBuilder: (context, disk, partition) {
-            final model = context.read<AllocateDiskSpaceModel>();
-            final config = model.originalConfig(partition);
-            final forceWipe = config?.mustWipe(partition.format) != false;
-            return YaruCheckbox(
-              value: partition.isWiped || forceWipe,
-              onChanged: partition.canWipe && !forceWipe
-                  ? (wipe) => onWipe(disk, partition, wipe!)
-                  : null,
-            );
+            return Consumer(builder: (context, ref, child) {
+              final model = ref.read(allocateDiskSpaceModelProvider);
+              final config = model.originalConfig(partition);
+              final forceWipe = config?.mustWipe(partition.format) != false;
+              return YaruCheckbox(
+                value: partition.isWiped || forceWipe,
+                onChanged: partition.canWipe && !forceWipe
+                    ? (wipe) => onWipe(disk, partition, wipe!)
+                    : null,
+              );
+            });
           },
         );
 

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/bitlocker/bitlocker_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/bitlocker/bitlocker_model.dart
@@ -1,11 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal
 final log = Logger('bitlocker');
 
+/// Provider for [BitLockerModel].
+final bitLockerModelProvider = ChangeNotifierProvider(
+    (_) => BitLockerModel(getService<SubiquityClient>()));
+
 /// View model for [BitLockerPage].
-class BitLockerModel {
+class BitLockerModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
   BitLockerModel(this._client) {
     log.info('BitLocker must be turned off');

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/bitlocker/bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/bitlocker/bitlocker_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:provider/provider.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -13,21 +11,12 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'bitlocker_model.dart';
 
-class BitLockerPage extends StatelessWidget {
-  @visibleForTesting
+class BitLockerPage extends ConsumerWidget {
   const BitLockerPage({super.key});
 
-  static Widget create(BuildContext context) {
-    final client = getService<SubiquityClient>();
-    return Provider(
-      create: (_) => BitLockerModel(client),
-      child: const BitLockerPage(),
-    );
-  }
-
   @override
-  Widget build(BuildContext context) {
-    final model = Provider.of<BitLockerModel>(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(bitLockerModelProvider);
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -35,7 +35,7 @@ class FilesystemPage extends StatelessWidget {
           builder: (_) => const BitLockerPage(),
         ),
         Routes.installAlongside: WizardRoute(
-          builder: InstallAlongsidePage.create,
+          builder: (_) => const InstallAlongsidePage(),
           userData: InstallationStep.filesystem.index,
           onReplace: (_) => Routes.allocateDiskSpace,
           onNext: (settings) => _nextRoute(settings.arguments),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -27,7 +27,7 @@ class FilesystemPage extends StatelessWidget {
       userData: InstallationStep.values.length,
       routes: {
         Routes.installationType: WizardRoute(
-          builder: InstallationTypePage.create,
+          builder: (_) => const InstallationTypePage(),
           userData: InstallationStep.type.index,
           onNext: (settings) => _nextRoute(settings.arguments),
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -31,8 +31,8 @@ class FilesystemPage extends StatelessWidget {
           userData: InstallationStep.type.index,
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
-        Routes.bitlocker: const WizardRoute(
-          builder: BitLockerPage.create,
+        Routes.bitlocker: WizardRoute(
+          builder: (_) => const BitLockerPage(),
         ),
         Routes.installAlongside: WizardRoute(
           builder: InstallAlongsidePage.create,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -51,7 +51,7 @@ class FilesystemPage extends StatelessWidget {
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.allocateDiskSpace: WizardRoute(
-          builder: AllocateDiskSpacePage.create,
+          builder: (_) => const AllocateDiskSpacePage(),
           userData: InstallationStep.filesystem.index,
         ),
       },

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -41,7 +41,7 @@ class FilesystemPage extends StatelessWidget {
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.selectGuidedStorage: WizardRoute(
-          builder: SelectGuidedStoragePage.create,
+          builder: (_) => const SelectGuidedStoragePage(),
           userData: InstallationStep.filesystem.index,
           onNext: (settings) => _nextRoute(settings.arguments),
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/filesystem_page.dart
@@ -46,7 +46,7 @@ class FilesystemPage extends StatelessWidget {
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.securityKey: WizardRoute(
-          builder: SecurityKeyPage.create,
+          builder: (_) => const SecurityKeyPage(),
           userData: InstallationStep.filesystem.index,
           onNext: (settings) => _nextRoute(settings.arguments),
         ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_model.dart
@@ -1,10 +1,16 @@
 import 'package:collection/collection.dart' hide ListExtensions;
 import 'package:dartx/dartx.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
+
+/// Provider for [InstallAlongsideModel].
+final installAlongsideModelProvider = ChangeNotifierProvider((_) =>
+    InstallAlongsideModel(
+        getService<DiskStorageService>(), getService<ProductService>()));
 
 /// View model for [InstallAlongsidePage].
 class InstallAlongsideModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
@@ -1,11 +1,10 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -18,38 +17,26 @@ import 'storage_split_view.dart';
 part 'install_alongside_widgets.dart';
 
 /// Install alongside other OSes.
-class InstallAlongsidePage extends StatefulWidget {
-  /// Use [InstallAlongsidePage.create] instead.
-  @visibleForTesting
+class InstallAlongsidePage extends ConsumerStatefulWidget {
   const InstallAlongsidePage({super.key});
 
-  /// Creates a [InstallAlongsidePage] with [InstallAlongsideModel].
-  static Widget create(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => InstallAlongsideModel(
-        getService<DiskStorageService>(),
-        getService<ProductService>(),
-      ),
-      child: const InstallAlongsidePage(),
-    );
-  }
-
   @override
-  State<InstallAlongsidePage> createState() => _InstallAlongsidePageState();
+  ConsumerState<InstallAlongsidePage> createState() =>
+      _InstallAlongsidePageState();
 }
 
-class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
+class _InstallAlongsidePageState extends ConsumerState<InstallAlongsidePage> {
   @override
   void initState() {
     super.initState();
 
-    final model = Provider.of<InstallAlongsideModel>(context, listen: false);
+    final model = ref.read(installAlongsideModelProvider);
     model.init();
   }
 
-  static String _formatTitle(BuildContext context) {
+  static String _formatTitle(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final model = context.read<InstallAlongsideModel>();
+    final model = ref.read(installAlongsideModelProvider);
 
     switch (model.existingOS.length) {
       case 0:
@@ -72,11 +59,11 @@ class _InstallAlongsidePageState extends State<InstallAlongsidePage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<InstallAlongsideModel>(context);
+    final model = ref.watch(installAlongsideModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(
-        title: Text(_formatTitle(context)),
+        title: Text(_formatTitle(context, ref)),
       ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_widgets.dart
@@ -1,6 +1,6 @@
 part of 'install_alongside_page.dart';
 
-class _StorageSelector extends StatelessWidget {
+class _StorageSelector extends ConsumerWidget {
   const _StorageSelector({
     required this.count,
     this.selectedIndex,
@@ -11,8 +11,8 @@ class _StorageSelector extends StatelessWidget {
   final int? selectedIndex;
   final ValueChanged<int?>? onSelected;
 
-  static String formatStorage(BuildContext context, int index) {
-    final model = context.read<InstallAlongsideModel>();
+  static String formatStorage(BuildContext context, WidgetRef ref, int index) {
+    final model = ref.read(installAlongsideModelProvider);
     final partition = model.getPartition(index);
     final os = model.getOS(index);
 
@@ -26,7 +26,7 @@ class _StorageSelector extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     return Row(
       children: <Widget>[
@@ -42,7 +42,7 @@ class _StorageSelector extends StatelessWidget {
                 : null,
             onSelected: onSelected,
             itemBuilder: (context, index, child) => Text(
-              formatStorage(context, index),
+              formatStorage(context, ref, index),
               key: ValueKey(index),
             ),
           ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_model.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -32,6 +33,14 @@ enum AdvancedFeature {
   /// Use ZFS (experimental).
   zfs,
 }
+
+/// Provider for [InstallationTypeModel].
+final installationTypeModelProvider =
+    ChangeNotifierProvider((_) => InstallationTypeModel(
+          getService<DiskStorageService>(),
+          getService<TelemetryService>(),
+          getService<ProductService>(),
+        ));
 
 /// View model for [InstallationTypePage].
 class InstallationTypeModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/installation_type/installation_type_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -15,33 +15,20 @@ import 'installation_type_model.dart';
 export 'installation_type_model.dart' show AdvancedFeature, InstallationType;
 
 /// Select between guided and manual partitioning.
-class InstallationTypePage extends StatefulWidget {
-  /// Use [InstallationTypePage.create] instead.
-  @visibleForTesting
+class InstallationTypePage extends ConsumerStatefulWidget {
   const InstallationTypePage({super.key});
 
-  /// Creates a [InstallationTypePage] with [InstallationTypeModel].
-  static Widget create(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => InstallationTypeModel(
-        getService<DiskStorageService>(),
-        getService<TelemetryService>(),
-        getService<ProductService>(),
-      ),
-      child: const InstallationTypePage(),
-    );
-  }
-
   @override
-  State<InstallationTypePage> createState() => _InstallationTypePageState();
+  ConsumerState<InstallationTypePage> createState() =>
+      _InstallationTypePageState();
 }
 
-class _InstallationTypePageState extends State<InstallationTypePage> {
+class _InstallationTypePageState extends ConsumerState<InstallationTypePage> {
   @override
   void initState() {
     super.initState();
 
-    final model = Provider.of<InstallationTypeModel>(context, listen: false);
+    final model = ref.read(installationTypeModelProvider);
     model.init();
   }
 
@@ -81,7 +68,7 @@ class _InstallationTypePageState extends State<InstallationTypePage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<InstallationTypeModel>(context);
+    final model = ref.watch(installationTypeModelProvider);
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_model.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
-/// View model for [ChooseSecurityKeyPage].
+/// Provider for [SecurityKeyModel].
+final securityKeyModelProvider = ChangeNotifierProvider(
+    (_) => SecurityKeyModel(getService<DiskStorageService>()));
+
+/// View model for [SecurityKeyPage].
 class SecurityKeyModel extends SafeChangeNotifier {
   /// Creates the model with the given client.
   SecurityKeyModel(this._service) {

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_field_validator/form_field_validator.dart';
-import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -17,31 +16,18 @@ part 'security_key_widgets.dart';
 ///
 /// See also:
 /// * [SecurityKeyModel]
-class SecurityKeyPage extends StatefulWidget {
-  /// Use [create] instead.
-  @visibleForTesting
-  const SecurityKeyPage({
-    super.key,
-  });
-
-  /// Creates an instance with [SecurityKeyModel].
-  static Widget create(BuildContext context) {
-    final service = getService<DiskStorageService>();
-    return ChangeNotifierProvider(
-      create: (_) => SecurityKeyModel(service),
-      child: const SecurityKeyPage(),
-    );
-  }
+class SecurityKeyPage extends ConsumerStatefulWidget {
+  const SecurityKeyPage({super.key});
 
   @override
-  State<SecurityKeyPage> createState() => _SecurityKeyPageState();
+  ConsumerState<SecurityKeyPage> createState() => _SecurityKeyPageState();
 }
 
-class _SecurityKeyPageState extends State<SecurityKeyPage> {
+class _SecurityKeyPageState extends ConsumerState<SecurityKeyPage> {
   @override
   void initState() {
     super.initState();
-    final model = Provider.of<SecurityKeyModel>(context, listen: false);
+    final model = ref.read(securityKeyModelProvider);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       model.loadSecurityKey();
     });
@@ -89,10 +75,10 @@ class _SecurityKeyPageState extends State<SecurityKeyPage> {
           WizardAction.next(
             context,
             root: true,
-            enabled: context
-                .select<SecurityKeyModel, bool>((model) => model.isValid),
-            onNext: context.read<SecurityKeyModel>().saveSecurityKey,
-            onBack: context.read<SecurityKeyModel>().loadSecurityKey,
+            enabled: ref.watch(
+                securityKeyModelProvider.select((model) => model.isValid)),
+            onNext: ref.read(securityKeyModelProvider).saveSecurityKey,
+            onBack: ref.read(securityKeyModelProvider).loadSecurityKey,
           ),
         ],
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_widgets.dart
@@ -1,17 +1,17 @@
 part of 'security_key_page.dart';
 
-class _SecurityKeyFormField extends StatelessWidget {
+class _SecurityKeyFormField extends ConsumerWidget {
   const _SecurityKeyFormField({this.fieldWidth});
 
   final double? fieldWidth;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final securityKey =
-        context.select<SecurityKeyModel, String>((model) => model.securityKey);
-    final showSecurityKey = context
-        .select<SecurityKeyModel, bool>((model) => model.showSecurityKey);
+    final securityKey = ref
+        .watch(securityKeyModelProvider.select((model) => model.securityKey));
+    final showSecurityKey = ref.watch(
+        securityKeyModelProvider.select((model) => model.showSecurityKey));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -23,27 +23,27 @@ class _SecurityKeyFormField extends StatelessWidget {
         errorText: lang.chooseSecurityKeyRequired,
       ),
       onChanged: (value) {
-        final model = Provider.of<SecurityKeyModel>(context, listen: false);
+        final model = ref.read(securityKeyModelProvider);
         model.securityKey = value;
       },
     );
   }
 }
 
-class _ConfirmSecurityKeyFormField extends StatelessWidget {
+class _ConfirmSecurityKeyFormField extends ConsumerWidget {
   const _ConfirmSecurityKeyFormField({required this.fieldWidth});
 
   final double? fieldWidth;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final securityKey =
-        context.select<SecurityKeyModel, String>((model) => model.securityKey);
-    final confirmedSecurityKey = context.select<SecurityKeyModel, String>(
-        (model) => model.confirmedSecurityKey);
-    final showSecurityKey = context
-        .select<SecurityKeyModel, bool>((model) => model.showSecurityKey);
+    final securityKey = ref
+        .watch(securityKeyModelProvider.select((model) => model.securityKey));
+    final confirmedSecurityKey = ref.watch(
+        securityKeyModelProvider.select((model) => model.confirmedSecurityKey));
+    final showSecurityKey = ref.watch(
+        securityKeyModelProvider.select((model) => model.showSecurityKey));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -58,27 +58,27 @@ class _ConfirmSecurityKeyFormField extends StatelessWidget {
         errorText: lang.chooseSecurityKeyMismatch,
       ),
       onChanged: (value) {
-        final model = Provider.of<SecurityKeyModel>(context, listen: false);
+        final model = ref.read(securityKeyModelProvider);
         model.confirmedSecurityKey = value;
       },
     );
   }
 }
 
-class _SecurityKeyShowButton extends StatelessWidget {
+class _SecurityKeyShowButton extends ConsumerWidget {
   const _SecurityKeyShowButton();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final showSecurityKey = context
-        .select<SecurityKeyModel, bool>((model) => model.showSecurityKey);
+    final showSecurityKey = ref.watch(
+        securityKeyModelProvider.select((model) => model.showSecurityKey));
 
     return YaruCheckButton(
       value: showSecurityKey,
       title: Text(lang.showSecurityKey),
       onChanged: (value) {
-        context.read<SecurityKeyModel>().showSecurityKey = value!;
+        ref.read(securityKeyModelProvider).showSecurityKey = value!;
       },
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_model.dart
@@ -1,9 +1,14 @@
 import 'package:dartx/dartx.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
+
+/// Provider for [SelectGuidedStorageModel].
+final selectGuidedStorageModelProvider = ChangeNotifierProvider(
+    (_) => SelectGuidedStorageModel(getService<DiskStorageService>()));
 
 /// View model for [SelectGuidedStoragePage].
 class SelectGuidedStorageModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/select_guided_storage/select_guided_storage_page.dart
@@ -1,10 +1,9 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -13,31 +12,21 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'select_guided_storage_model.dart';
 
 /// Select a storage for guided partitioning.
-class SelectGuidedStoragePage extends StatefulWidget {
-  /// Use [SelectGuidedStoragePage.create] instead.
-  @visibleForTesting
+class SelectGuidedStoragePage extends ConsumerStatefulWidget {
   const SelectGuidedStoragePage({super.key});
 
-  /// Creates a [SelectGuidedStoragePage] with [SelectGuidedStorageModel].
-  static Widget create(BuildContext context) {
-    final service = getService<DiskStorageService>();
-    return ChangeNotifierProvider(
-      create: (context) => SelectGuidedStorageModel(service),
-      child: const SelectGuidedStoragePage(),
-    );
-  }
-
   @override
-  State<SelectGuidedStoragePage> createState() =>
+  ConsumerState<SelectGuidedStoragePage> createState() =>
       _SelectGuidedStoragePageState();
 }
 
-class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
+class _SelectGuidedStoragePageState
+    extends ConsumerState<SelectGuidedStoragePage> {
   @override
   void initState() {
     super.initState();
 
-    final model = Provider.of<SelectGuidedStorageModel>(context, listen: false);
+    final model = ref.read(selectGuidedStorageModelProvider);
     model.loadGuidedStorage();
   }
 
@@ -58,7 +47,7 @@ class _SelectGuidedStoragePageState extends State<SelectGuidedStoragePage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<SelectGuidedStorageModel>(context);
+    final model = ref.watch(selectGuidedStorageModelProvider);
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return WizardPage(

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
   path: ^1.8.0
   platform: ^3.1.0
   progress_indicators: ^1.0.0
-  provider: ^6.0.0
   safe_change_notifier: ^0.2.0
   scroll_to_index: ^3.0.0
   split_view: ^3.2.1

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_dialogs_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/allocate_disk_space_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/allocate_disk_space_model.dart';
@@ -29,8 +29,8 @@ void main() {
     registerMockService<UdevService>(MockUdevService());
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [allocateDiskSpaceModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
@@ -77,8 +77,8 @@ void main() {
     registerMockService<UdevService>(MockUdevService());
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [allocateDiskSpaceModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
@@ -113,8 +113,8 @@ void main() {
     registerMockService<UdevService>(MockUdevService());
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [allocateDiskSpaceModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );
@@ -182,8 +182,8 @@ void main() {
     registerMockService<UdevService>(MockUdevService());
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [allocateDiskSpaceModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const AllocateDiskSpacePage()),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/allocate_disk_space/allocate_disk_space_page_test.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/allocate_disk_space/allocate_disk_space_model.dart';
@@ -17,7 +17,6 @@ import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../test_utils.dart';
-import 'allocate_disk_space_model_test.mocks.dart';
 import 'allocate_disk_space_page_test.mocks.dart';
 
 final selection = StreamController.broadcast();
@@ -117,8 +116,8 @@ void main() {
     when(udev.bySysname('sdb')).thenReturn(sdb);
     registerMockService<UdevService>(udev);
 
-    return ChangeNotifierProvider<AllocateDiskSpaceModel>.value(
-      value: model,
+    return ProviderScope(
+      overrides: [allocateDiskSpaceModelProvider.overrideWith((_) => model)],
       child: const AllocateDiskSpacePage(),
     );
   }
@@ -359,24 +358,5 @@ void main() {
       ),
       findsOneWidget,
     );
-  });
-
-  testWidgets('creates a model', (tester) async {
-    final storage = MockDiskStorageService();
-    when(storage.getStorage()).thenAnswer((_) async => testDisks);
-    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
-    when(storage.needRoot).thenReturn(false);
-    when(storage.needBoot).thenReturn(false);
-    registerMockService<DiskStorageService>(storage);
-    registerMockService<UdevService>(MockUdevService());
-
-    await tester.pumpWidget(tester.buildApp(AllocateDiskSpacePage.create));
-
-    final page = find.byType(AllocateDiskSpacePage);
-    expect(page, findsOneWidget);
-
-    final context = tester.element(page);
-    final model = Provider.of<AllocateDiskSpaceModel>(context, listen: false);
-    expect(model, isNotNull);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/bitlocker/bitlocker_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/bitlocker/bitlocker_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -22,8 +22,8 @@ void main() {
     when(model.reboot()).thenAnswer((_) async {});
 
     await tester.pumpWidget(
-      Provider<BitLockerModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [bitLockerModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const BitLockerPage()),
       ),
     );
@@ -59,8 +59,8 @@ void main() {
     registerMockService<UrlLauncher>(urlLauncher);
 
     await tester.pumpWidget(
-      Provider<BitLockerModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [bitLockerModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const BitLockerPage()),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/bitlocker/bitlocker_page_test.mocks.dart
@@ -4,11 +4,12 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
+import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_desktop_installer/pages/filesystem/bitlocker/bitlocker_model.dart'
     as _i2;
-import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i4;
+import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -30,6 +31,16 @@ class MockBitLockerModel extends _i1.Mock implements _i2.BitLockerModel {
   }
 
   @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
+  @override
   _i3.Future<void> reboot() => (super.noSuchMethod(
         Invocation.method(
           #reboot,
@@ -38,12 +49,44 @@ class MockBitLockerModel extends _i1.Mock implements _i2.BitLockerModel {
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
+  @override
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [UrlLauncher].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUrlLauncher extends _i1.Mock implements _i4.UrlLauncher {
+class MockUrlLauncher extends _i1.Mock implements _i5.UrlLauncher {
   MockUrlLauncher() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/ubuntu_desktop_installer/test/filesystem/install_alongside/install_alongside_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/install_alongside/install_alongside_page_test.dart
@@ -1,22 +1,18 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:split_view/split_view.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/install_alongside/install_alongside_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/install_alongside/install_alongside_page.dart';
-import 'package:ubuntu_desktop_installer/services/disk_storage_service.dart';
 import 'package:ubuntu_desktop_installer/services/product_service.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 import '../../test_utils.dart';
 import 'install_alongside_model_test.dart';
-import 'install_alongside_model_test.mocks.dart';
 import 'install_alongside_page_test.mocks.dart';
 
 @GenerateMocks([InstallAlongsideModel])
@@ -64,8 +60,8 @@ void main() {
   }
 
   Widget buildPage(InstallAlongsideModel model) {
-    return ChangeNotifierProvider<InstallAlongsideModel>.value(
-      value: model,
+    return ProviderScope(
+      overrides: [installAlongsideModelProvider.overrideWith((_) => model)],
       child: const InstallAlongsidePage(),
     );
   }
@@ -201,25 +197,5 @@ void main() {
       find.text(tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10')),
       findsOneWidget,
     );
-  });
-
-  testWidgets('creates a model', (tester) async {
-    final storage = MockDiskStorageService();
-    when(storage.existingOS).thenReturn([]);
-    when(storage.useEncryption).thenReturn(false);
-    when(storage.getStorage()).thenAnswer((_) async => []);
-    when(storage.getGuidedStorage())
-        .thenAnswer((_) async => fakeGuidedStorageResponse());
-    registerMockService<DiskStorageService>(storage);
-    registerMockService<ProductService>(ProductService());
-
-    await tester.pumpWidget(tester.buildApp(InstallAlongsidePage.create));
-
-    final page = find.byType(InstallAlongsidePage);
-    expect(page, findsOneWidget);
-
-    final context = tester.element(page);
-    final model = Provider.of<InstallAlongsideModel>(context, listen: false);
-    expect(model, isNotNull);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_dialogs_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_page.dart';
@@ -21,8 +21,8 @@ void main() {
     when(model.encryption).thenReturn(false);
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<InstallationTypeModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [installationTypeModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );
@@ -58,8 +58,8 @@ void main() {
     when(model.isDone).thenReturn(false);
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<InstallationTypeModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [installationTypeModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );
@@ -91,8 +91,8 @@ void main() {
     when(model.isDone).thenReturn(false);
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<InstallationTypeModel>.value(
-        value: model,
+      ProviderScope(
+        overrides: [installationTypeModelProvider.overrideWith((_) => model)],
         child: tester.buildApp((_) => const InstallationTypePage()),
       ),
     );

--- a/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/installation_type/installation_type_page_test.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/installation_type/installation_type_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -42,8 +41,8 @@ void main() {
   }
 
   Widget buildPage(InstallationTypeModel model) {
-    return ChangeNotifierProvider<InstallationTypeModel>.value(
-      value: model,
+    return ProviderScope(
+      overrides: [installationTypeModelProvider.overrideWith((_) => model)],
       child: const InstallationTypePage(),
     );
   }
@@ -385,27 +384,5 @@ void main() {
 
     await tester.tap(nextButton);
     verify(model.save()).called(1);
-  });
-
-  testWidgets('creates a model', (tester) async {
-    final client = MockSubiquityClient();
-    when(client.getGuidedStorageV2())
-        .thenAnswer((_) async => fakeGuidedStorageResponse());
-    when(client.getStorageV2()).thenAnswer((_) async => fakeStorageResponse());
-    when(client.hasRst()).thenAnswer((_) async => false);
-    when(client.hasBitLocker()).thenAnswer((_) async => false);
-    registerMockService<SubiquityClient>(client);
-    registerMockService<DiskStorageService>(DiskStorageService(client));
-    registerMockService<ProductService>(ProductService());
-    registerMockService<TelemetryService>(TelemetryService());
-
-    await tester.pumpWidget(tester.buildApp(InstallationTypePage.create));
-
-    final page = find.byType(InstallationTypePage);
-    expect(page, findsOneWidget);
-
-    final context = tester.element(page);
-    final model = Provider.of<InstallationTypeModel>(context, listen: false);
-    expect(model, isNotNull);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/filesystem/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/security_key/security_key_page_test.dart
@@ -1,15 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/security_key/security_key_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/security_key/security_key_page.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 
 import '../../test_utils.dart';
-import 'security_key_model_test.mocks.dart';
 import 'security_key_page_test.mocks.dart';
 
 @GenerateMocks([SecurityKeyModel])
@@ -29,8 +27,8 @@ void main() {
   }
 
   Widget buildPage(SecurityKeyModel model) {
-    return ChangeNotifierProvider<SecurityKeyModel>.value(
-      value: model,
+    return ProviderScope(
+      overrides: [securityKeyModelProvider.overrideWith((_) => model)],
       child: const SecurityKeyPage(),
     );
   }
@@ -91,20 +89,5 @@ void main() {
 
     await tester.tap(nextButton);
     verify(model.saveSecurityKey()).called(1);
-  });
-
-  testWidgets('creates a model', (tester) async {
-    final service = MockDiskStorageService();
-    when(service.securityKey).thenReturn(null);
-    registerMockService<DiskStorageService>(service);
-
-    await tester.pumpWidget(tester.buildApp(SecurityKeyPage.create));
-
-    final page = find.byType(SecurityKeyPage);
-    expect(page, findsOneWidget);
-
-    final context = tester.element(page);
-    final model = Provider.of<SecurityKeyModel>(context, listen: false);
-    expect(model, isNotNull);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/filesystem/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/filesystem/select_guided_storage/select_guided_storage_page_test.dart
@@ -1,20 +1,18 @@
 import 'package:dartx/dartx.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/select_guided_storage/select_guided_storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/filesystem/select_guided_storage/select_guided_storage_page.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 import '../../test_utils.dart';
-import 'select_guided_storage_model_test.mocks.dart';
 import 'select_guided_storage_page_test.mocks.dart';
 
 @GenerateMocks([SelectGuidedStorageModel])
@@ -51,8 +49,8 @@ void main() {
   }
 
   Widget buildPage(SelectGuidedStorageModel model) {
-    return ChangeNotifierProvider<SelectGuidedStorageModel>.value(
-      value: model,
+    return ProviderScope(
+      overrides: [selectGuidedStorageModelProvider.overrideWith((_) => model)],
       child: const SelectGuidedStoragePage(),
     );
   }
@@ -121,23 +119,5 @@ void main() {
 
     await tester.tap(nextButton);
     verify(model.saveGuidedStorage()).called(1);
-  });
-
-  testWidgets('creates a model', (tester) async {
-    final service = MockDiskStorageService();
-    when(service.getStorage()).thenAnswer((_) async => []);
-    when(service.useEncryption).thenReturn(false);
-    when(service.getGuidedStorage())
-        .thenAnswer((_) async => fakeGuidedStorageResponse());
-    registerMockService<DiskStorageService>(service);
-
-    await tester.pumpWidget(tester.buildApp(SelectGuidedStoragePage.create));
-
-    final page = find.byType(SelectGuidedStoragePage);
-    expect(page, findsOneWidget);
-
-    final context = tester.element(page);
-    final model = Provider.of<SelectGuidedStorageModel>(context, listen: false);
-    expect(model, isNotNull);
   });
 }


### PR DESCRIPTION
Continuation of #1918.
Migrates the remaining view models of the `filesystem`-related pages to riverpod.