### PR TITLE
fix(welcome): fix /welcome to land on WelcomeWizard

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -383,7 +383,7 @@ class _UbuntuDesktopInstallerWizardState
               widget.welcome == true ? Routes.welcome : Routes.keyboard,
         ),
         Routes.welcome: WizardRoute(
-          builder: (_) => const WelcomePage(),
+          builder: (_) => const WelcomeWizard(),
           userData: InstallationStep.locale.index,
         ),
         Routes.keyboard: WizardRoute(


### PR DESCRIPTION
Fixes an issue exposed by the screenshot test:
```
ERROR ubuntu_desktop_installer: Unhandled exception
	_AssertionError: 'package:wizard_router/src/controller.dart': Failed assertion: line 128 pos 12: 'routes.keys.contains(route)': `Wizard.jump()` called with an unknown route /rst.
```
https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4915060792/jobs/8777105687