### PR TITLE
fix(install): move slide asset pre-caching to a safer place

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/install/install_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install/install_page.dart
@@ -43,6 +43,11 @@ class _InstallPageState extends ConsumerState<InstallPage> {
 
     final model = ref.read(installModelProvider);
     model.init();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      model.precacheSlideImages(context);
+    });
   }
 
   @override
@@ -66,17 +71,6 @@ class _SlidePage extends ConsumerStatefulWidget {
 
 class _SlidePageState extends ConsumerState<_SlidePage> {
   final _slideController = ValueNotifier(0);
-
-  @override
-  void initState() {
-    super.initState();
-
-    final model = ref.read(installModelProvider);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      model.precacheSlideImages(context);
-    });
-  }
 
   @override
   void dispose() {


### PR DESCRIPTION
On the same level as it was before #1936. This should help to fix:

```
  ERROR ubuntu_desktop_installer: Unhandled exception
  	FlutterError: Looking up a deactivated widget's ancestor is unsafe.
  At this point the state of the widget's element tree is no longer stable.
  To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.
```
https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4925614953/jobs/8800949653?pr=1946