### PR TITLE
refactor: move model providers

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_model.dart
@@ -1,7 +1,12 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+
+final activeDirectoryModelProvider = ChangeNotifierProvider(
+  (_) => ActiveDirectoryModel(getService<ActiveDirectoryService>()),
+);
 
 class ActiveDirectoryModel extends SafeChangeNotifier {
   ActiveDirectoryModel(this._service) {

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
@@ -13,10 +13,6 @@ import 'active_directory_widgets.dart';
 class ActiveDirectoryPage extends ConsumerStatefulWidget {
   const ActiveDirectoryPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider(
-    (_) => ActiveDirectoryModel(getService<ActiveDirectoryService>()),
-  );
-
   @override
   ConsumerState<ActiveDirectoryPage> createState() =>
       _ActiveDirectoryPageState();
@@ -27,7 +23,7 @@ class _ActiveDirectoryPageState extends ConsumerState<ActiveDirectoryPage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(ActiveDirectoryPage.modelProvider);
+    final model = ref.read(activeDirectoryModelProvider);
     model.init();
   }
 
@@ -50,9 +46,8 @@ class _ActiveDirectoryPageState extends ConsumerState<ActiveDirectoryPage> {
             Align(
               alignment: AlignmentDirectional.centerStart,
               child: OutlinedButton(
-                onPressed: ref
-                    .read(ActiveDirectoryPage.modelProvider)
-                    .pingDomainController,
+                onPressed:
+                    ref.read(activeDirectoryModelProvider).pingDomainController,
                 child: Text(lang.activeDirectoryTestConnection),
               ),
             ),
@@ -68,10 +63,10 @@ class _ActiveDirectoryPageState extends ConsumerState<ActiveDirectoryPage> {
         trailing: [
           WizardAction.next(
             context,
-            enabled: ref.watch(
-                ActiveDirectoryPage.modelProvider.select((m) => m.isValid)),
+            enabled: ref
+                .watch(activeDirectoryModelProvider.select((m) => m.isValid)),
             onNext: () async {
-              final model = ref.read(ActiveDirectoryPage.modelProvider);
+              final model = ref.read(activeDirectoryModelProvider);
               await model.save();
               model.getJoinResult().then((result) {
                 if (mounted &&

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_widgets.dart
@@ -6,7 +6,7 @@ import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import 'active_directory_l10n.dart';
-import 'active_directory_page.dart';
+import 'active_directory_model.dart';
 
 class DomainNameFormField extends ConsumerWidget {
   const DomainNameFormField({super.key, this.fieldWidth});
@@ -16,10 +16,10 @@ class DomainNameFormField extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final domainName = ref
-        .watch(ActiveDirectoryPage.modelProvider.select((m) => m.domainName));
-    final validation = ref.watch(ActiveDirectoryPage.modelProvider
-        .select((m) => m.domainNameValidation));
+    final domainName =
+        ref.watch(activeDirectoryModelProvider.select((m) => m.domainName));
+    final validation = ref.watch(
+        activeDirectoryModelProvider.select((m) => m.domainNameValidation));
 
     return ValidatedFormField(
       autofocus: true,
@@ -33,9 +33,9 @@ class DomainNameFormField extends ConsumerWidget {
             validation.singleOrNull == AdDomainNameValidation.OK,
         errorText: validation?.firstOrNull?.localize(lang) ?? '',
       ),
-      onChanged: ref.read(ActiveDirectoryPage.modelProvider).setDomainName,
+      onChanged: ref.read(activeDirectoryModelProvider).setDomainName,
       onEditingComplete:
-          ref.read(ActiveDirectoryPage.modelProvider).pingDomainController,
+          ref.read(activeDirectoryModelProvider).pingDomainController,
     );
   }
 }
@@ -49,9 +49,9 @@ class AdminNameFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final adminName =
-        ref.read(ActiveDirectoryPage.modelProvider.select((m) => m.adminName));
+        ref.read(activeDirectoryModelProvider.select((m) => m.adminName));
     final validation = ref.watch(
-        ActiveDirectoryPage.modelProvider.select((m) => m.adminNameValidation));
+        activeDirectoryModelProvider.select((m) => m.adminNameValidation));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -62,7 +62,7 @@ class AdminNameFormField extends ConsumerWidget {
         (_) => validation == AdAdminNameValidation.OK,
         errorText: validation?.localize(lang) ?? '',
       ),
-      onChanged: ref.read(ActiveDirectoryPage.modelProvider).setAdminName,
+      onChanged: ref.read(activeDirectoryModelProvider).setAdminName,
     );
   }
 }
@@ -76,9 +76,9 @@ class PasswordFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final password =
-        ref.watch(ActiveDirectoryPage.modelProvider.select((m) => m.password));
+        ref.watch(activeDirectoryModelProvider.select((m) => m.password));
     final validation = ref.watch(
-        ActiveDirectoryPage.modelProvider.select((m) => m.passwordValidation));
+        activeDirectoryModelProvider.select((m) => m.passwordValidation));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -89,7 +89,7 @@ class PasswordFormField extends ConsumerWidget {
         (_) => validation == AdPasswordValidation.OK,
         errorText: validation?.localize(lang) ?? '',
       ),
-      onChanged: ref.read(ActiveDirectoryPage.modelProvider).setPassword,
+      onChanged: ref.read(activeDirectoryModelProvider).setPassword,
     );
   }
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_model.dart
@@ -1,9 +1,13 @@
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show Disk, Partition;
+
+final confirmModelProvider = ChangeNotifierProvider((_) =>
+    ConfirmModel(getService<SubiquityClient>(), getService<StorageService>()));
 
 /// View model for [ConfirmPage].
 class ConfirmModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -18,9 +17,6 @@ final log = Logger('confirm');
 class ConfirmPage extends ConsumerStatefulWidget {
   const ConfirmPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider((_) => ConfirmModel(
-      getService<SubiquityClient>(), getService<StorageService>()));
-
   @override
   ConsumerState<ConfirmPage> createState() => _ConfirmPageState();
 }
@@ -30,7 +26,7 @@ class _ConfirmPageState extends ConsumerState<ConfirmPage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(ConfirmPage.modelProvider);
+    final model = ref.read(confirmModelProvider);
     model.init();
   }
 
@@ -45,7 +41,7 @@ class _ConfirmPageState extends ConsumerState<ConfirmPage> {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
-    final model = ref.watch(ConfirmPage.modelProvider);
+    final model = ref.watch(confirmModelProvider);
     return WizardPage(
       title: YaruWindowTitleBar(
         title: Text(lang.writeChangesToDisk),

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -29,6 +30,16 @@ const kMaxHostnameLength = 64;
 
 /// The maximum length for valid usernames
 const kMaxUsernameLength = 32;
+
+final identityModelProvider = ChangeNotifierProvider(
+  (_) => IdentityModel(
+    client: getService<SubiquityClient>(),
+    activeDirectory: getService<ActiveDirectoryService>(),
+    config: getService<ConfigService>(),
+    network: getService<NetworkService>(),
+    telemetry: getService<TelemetryService>(),
+  ),
+);
 
 /// [IdentityPage]'s view model.
 class IdentityModel extends PropertyStreamNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -23,16 +22,6 @@ class IdentityPage extends ConsumerStatefulWidget {
   /// Creates a the installer page for setting up the user data.
   const IdentityPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider(
-    (_) => IdentityModel(
-      client: getService<SubiquityClient>(),
-      activeDirectory: getService<ActiveDirectoryService>(),
-      config: getService<ConfigService>(),
-      network: getService<NetworkService>(),
-      telemetry: getService<TelemetryService>(),
-    ),
-  );
-
   @override
   ConsumerState<IdentityPage> createState() => _IdentityPageState();
 }
@@ -42,7 +31,7 @@ class _IdentityPageState extends ConsumerState<IdentityPage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(IdentityPage.modelProvider);
+    final model = ref.read(identityModelProvider);
     model.init();
   }
 
@@ -98,11 +87,10 @@ class _IdentityPageState extends ConsumerState<IdentityPage> {
         trailing: [
           WizardAction.next(
             context,
-            enabled:
-                ref.watch(IdentityPage.modelProvider.select((m) => m.isValid)),
+            enabled: ref.watch(identityModelProvider.select((m) => m.isValid)),
             arguments: ref.watch(
-                IdentityPage.modelProvider.select((m) => m.useActiveDirectory)),
-            onNext: ref.read(IdentityPage.modelProvider).save,
+                identityModelProvider.select((m) => m.useActiveDirectory)),
+            onNext: ref.read(identityModelProvider).save,
           ),
         ],
       ),

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_widgets.dart
@@ -9,7 +9,7 @@ class _RealNameFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final realName =
-        ref.watch(IdentityPage.modelProvider.select((model) => model.realName));
+        ref.watch(identityModelProvider.select((model) => model.realName));
 
     return ValidatedFormField(
       autofocus: true,
@@ -27,7 +27,7 @@ class _RealNameFormField extends ConsumerWidget {
         ),
       ]),
       onChanged: (value) async {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.realName = value;
         await model.validate();
       },
@@ -44,7 +44,7 @@ class _HostnameFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final hostname =
-        ref.watch(IdentityPage.modelProvider.select((model) => model.hostname));
+        ref.watch(identityModelProvider.select((model) => model.hostname));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -66,7 +66,7 @@ class _HostnameFormField extends ConsumerWidget {
         )
       ]),
       onChanged: (value) {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.hostname = value;
       },
     );
@@ -101,10 +101,10 @@ class _UsernameFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final username =
-        ref.watch(IdentityPage.modelProvider.select((model) => model.username));
+        ref.watch(identityModelProvider.select((model) => model.username));
     final validation = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.usernameValidation));
-    final model = ref.read(IdentityPage.modelProvider);
+        identityModelProvider.select((model) => model.usernameValidation));
+    final model = ref.read(identityModelProvider);
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -125,7 +125,7 @@ class _UsernameFormField extends ConsumerWidget {
         ),
       ]),
       onChanged: (value) async {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.username = value;
         await model.validate();
       },
@@ -142,11 +142,11 @@ class _PasswordFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final password =
-        ref.watch(IdentityPage.modelProvider.select((model) => model.password));
-    final passwordStrength = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.passwordStrength));
-    final showPassword = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.showPassword));
+        ref.watch(identityModelProvider.select((model) => model.password));
+    final passwordStrength = ref
+        .watch(identityModelProvider.select((model) => model.passwordStrength));
+    final showPassword =
+        ref.watch(identityModelProvider.select((model) => model.showPassword));
 
     return ValidatedFormField(
       fieldWidth: fieldWidth,
@@ -157,13 +157,13 @@ class _PasswordFormField extends ConsumerWidget {
       suffixIcon: _ShowPasswordButton(
         value: showPassword,
         onChanged: (value) =>
-            ref.read(IdentityPage.modelProvider).showPassword = value,
+            ref.read(identityModelProvider).showPassword = value,
       ),
       validator: RequiredValidator(
         errorText: lang.whoAreYouPagePasswordRequired,
       ),
       onChanged: (value) {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.password = value;
       },
     );
@@ -179,11 +179,11 @@ class _ConfirmPasswordFormField extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
     final password =
-        ref.watch(IdentityPage.modelProvider.select((model) => model.password));
+        ref.watch(identityModelProvider.select((model) => model.password));
     final confirmedPassword = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.confirmedPassword));
-    final showPassword = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.showPassword));
+        identityModelProvider.select((model) => model.confirmedPassword));
+    final showPassword =
+        ref.watch(identityModelProvider.select((model) => model.showPassword));
 
     return ValidatedFormField(
       obscureText: !showPassword,
@@ -197,7 +197,7 @@ class _ConfirmPasswordFormField extends ConsumerWidget {
         errorText: lang.whoAreYouPagePasswordMismatch,
       ),
       onChanged: (value) {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.confirmedPassword = value;
       },
     );
@@ -260,12 +260,12 @@ class _UseActiveDirectoryCheckButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final hasActiveDirectorySupport = ref.watch(IdentityPage.modelProvider
+    final hasActiveDirectorySupport = ref.watch(identityModelProvider
         .select((model) => model.hasActiveDirectorySupport));
     final useActiveDirectory = ref.watch(
-        IdentityPage.modelProvider.select((model) => model.useActiveDirectory));
-    final isConnected = ref
-        .watch(IdentityPage.modelProvider.select((model) => model.isConnected));
+        identityModelProvider.select((model) => model.useActiveDirectory));
+    final isConnected =
+        ref.watch(identityModelProvider.select((model) => model.isConnected));
 
     return Visibility(
       visible: hasActiveDirectorySupport != false,
@@ -273,8 +273,7 @@ class _UseActiveDirectoryCheckButton extends ConsumerWidget {
         value: useActiveDirectory,
         title: Text(lang.activeDirectoryOption),
         onChanged: isConnected && hasActiveDirectorySupport == true
-            ? (v) =>
-                ref.read(IdentityPage.modelProvider).useActiveDirectory = v!
+            ? (v) => ref.read(identityModelProvider).useActiveDirectory = v!
             : null,
         subtitle: Text(
           lang.activeDirectoryInfo,
@@ -294,15 +293,15 @@ class _AutoLoginSwitch extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final autoLogin = ref
-        .watch(IdentityPage.modelProvider.select((model) => model.autoLogin));
+    final autoLogin =
+        ref.watch(identityModelProvider.select((model) => model.autoLogin));
 
     return YaruSwitchButton(
       title: Text(lang.whoAreYouPageRequirePassword),
       contentPadding: kContentPadding,
       value: !autoLogin,
       onChanged: (value) {
-        final model = ref.read(IdentityPage.modelProvider);
+        final model = ref.read(identityModelProvider);
         model.autoLogin = !value;
       },
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dartx/dartx.dart';
 import 'package:diacritic/diacritic.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
@@ -11,6 +12,9 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 /// @internal
 final log = Logger('keyboard');
+
+final keyboardModelProvider =
+    ChangeNotifierProvider((_) => KeyboardModel(getService<KeyboardService>()));
 
 /// Implements the business logic of the Keyboard page.
 class KeyboardModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -13,9 +12,6 @@ import 'keyboard_model.dart';
 class KeyboardPage extends ConsumerStatefulWidget {
   const KeyboardPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider(
-      (_) => KeyboardModel(getService<KeyboardService>()));
-
   @override
   ConsumerState<KeyboardPage> createState() => _KeyboardPageState();
 }
@@ -25,7 +21,7 @@ class _KeyboardPageState extends ConsumerState<KeyboardPage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(KeyboardPage.modelProvider);
+    final model = ref.read(keyboardModelProvider);
     model.init().then((_) => model.updateInputSource());
   }
 
@@ -36,7 +32,7 @@ class _KeyboardPageState extends ConsumerState<KeyboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(KeyboardPage.modelProvider);
+    final model = ref.watch(keyboardModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -8,6 +9,13 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart' show KeySearchX;
 
 /// @internal
 final log = Logger('locale');
+
+final localeModelProvider = ChangeNotifierProvider((ref) {
+  return LocaleModel(
+    locale: getService<LocaleService>(),
+    sound: tryGetService<SoundService>(),
+  );
+});
 
 /// Implements the business logic of the locale page.
 class LocaleModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
@@ -13,13 +13,6 @@ import 'locale_model.dart';
 class LocalePage extends ConsumerStatefulWidget {
   const LocalePage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider((ref) {
-    return LocaleModel(
-      locale: getService<LocaleService>(),
-      sound: tryGetService<SoundService>(),
-    );
-  });
-
   @override
   ConsumerState<LocalePage> createState() => _LocalePageState();
 }
@@ -29,7 +22,7 @@ class _LocalePageState extends ConsumerState<LocalePage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(LocalePage.modelProvider);
+    final model = ref.read(localeModelProvider);
     model.loadLanguages().then((_) {
       model.selectLocale(InheritedLocale.of(context));
       model.playWelcomeSound();
@@ -39,7 +32,7 @@ class _LocalePageState extends ConsumerState<LocalePage> {
   void _selectLanguage(int index) {
     if (index == -1) return;
 
-    final model = ref.read(LocalePage.modelProvider);
+    final model = ref.read(localeModelProvider);
     model.selectedLanguageIndex = index;
 
     InheritedLocale.apply(context, model.locale(index));
@@ -48,7 +41,7 @@ class _LocalePageState extends ConsumerState<LocalePage> {
   @override
   Widget build(BuildContext context) {
     final flavor = Flavor.of(context);
-    final model = ref.watch(LocalePage.modelProvider);
+    final model = ref.watch(localeModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_model.dart
@@ -1,6 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 
 enum SecureBootMode { turnOff, dontInstall }
+
+final secureBootModelProvider = ChangeNotifierProvider(
+    (_) => SecureBootModel(secureBootMode: SecureBootMode.turnOff));
 
 class SecureBootModel extends SafeChangeNotifier {
   SecureBootModel({

--- a/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_page.dart
@@ -11,9 +11,6 @@ import 'secure_boot_widgets.dart';
 class SecureBootPage extends ConsumerStatefulWidget {
   const SecureBootPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider(
-      (_) => SecureBootModel(secureBootMode: SecureBootMode.turnOff));
-
   @override
   ConsumerState<SecureBootPage> createState() => _SecureBootPageState();
 }
@@ -21,7 +18,7 @@ class SecureBootPage extends ConsumerStatefulWidget {
 class _SecureBootPageState extends ConsumerState<SecureBootPage> {
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(SecureBootPage.modelProvider);
+    final model = ref.watch(secureBootModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/secure_boot/secure_boot_widgets.dart
@@ -5,7 +5,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
-import 'secure_boot_page.dart';
+import 'secure_boot_model.dart';
 
 class SecurityKeyFormField extends ConsumerWidget {
   const SecurityKeyFormField({
@@ -17,7 +17,7 @@ class SecurityKeyFormField extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(SecureBootPage.modelProvider);
+    final model = ref.watch(secureBootModelProvider);
     final lang = AppLocalizations.of(context);
     return Padding(
       padding: kContentIndentation,
@@ -47,7 +47,7 @@ class SecurityKeyConfirmFormField extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(SecureBootPage.modelProvider);
+    final model = ref.watch(secureBootModelProvider);
     final lang = AppLocalizations.of(context);
     return Padding(
       padding: kContentIndentation,

--- a/packages/ubuntu_desktop_installer/lib/pages/source/not_enough_disk_space/not_enough_disk_space_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/not_enough_disk_space/not_enough_disk_space_model.dart
@@ -1,9 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services/storage_service.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 
 /// @internal
 final log = Logger('not_enough_disk_space');
+
+final notEnoughDiskSpaceModelProvider =
+    ChangeNotifierProvider<NotEnoughDiskSpaceModel>(
+        (_) => NotEnoughDiskSpaceModel(getService<StorageService>()));
 
 class NotEnoughDiskSpaceModel extends SafeChangeNotifier {
   NotEnoughDiskSpaceModel(this._service) {

--- a/packages/ubuntu_desktop_installer/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -4,7 +4,6 @@ import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -15,12 +14,9 @@ import 'not_enough_disk_space_model.dart';
 class NotEnoughDiskSpacePage extends ConsumerWidget {
   const NotEnoughDiskSpacePage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider<NotEnoughDiskSpaceModel>(
-      (_) => NotEnoughDiskSpaceModel(getService<StorageService>()));
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(modelProvider);
+    final model = ref.watch(notEnoughDiskSpaceModelProvider);
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     return Scaffold(

--- a/packages/ubuntu_desktop_installer/lib/pages/source/source_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/source_model.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -9,6 +10,15 @@ final log = Logger('source');
 
 const kNormalSourceId = 'ubuntu-desktop';
 const kMinimalSourceId = 'ubuntu-desktop-minimal';
+
+final sourceModelProvider = ChangeNotifierProvider(
+  (_) => SourceModel(
+    client: getService<SubiquityClient>(),
+    power: getService<PowerService>(),
+    network: getService<NetworkService>(),
+    storage: getService<StorageService>(),
+  ),
+);
 
 class SourceModel extends PropertyStreamNotifier {
   // ignore: public_member_api_docs

--- a/packages/ubuntu_desktop_installer/lib/pages/source/source_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/source_page.dart
@@ -16,13 +16,6 @@ export 'source_model.dart' show kNormalSourceId, kMinimalSourceId;
 class SourcePage extends ConsumerStatefulWidget {
   const SourcePage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider((_) => SourceModel(
-        client: getService<SubiquityClient>(),
-        power: getService<PowerService>(),
-        network: getService<NetworkService>(),
-        storage: getService<StorageService>(),
-      ));
-
   @override
   ConsumerState<SourcePage> createState() => _SourcePageState();
 }
@@ -31,13 +24,13 @@ class _SourcePageState extends ConsumerState<SourcePage> {
   @override
   void initState() {
     super.initState();
-    final model = ref.read(SourcePage.modelProvider);
+    final model = ref.read(sourceModelProvider);
     model.init();
   }
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(SourcePage.modelProvider);
+    final model = ref.watch(sourceModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_model.dart
@@ -1,8 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 final log = Logger('timezone');
+
+final timezoneModelProvider =
+    ChangeNotifierProvider((_) => TimezoneModel(getService<TimezoneService>()));
 
 class TimezoneModel extends SafeChangeNotifier {
   TimezoneModel(this._service);

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/rst/rst_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/rst/rst_model.dart
@@ -1,9 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal
 final log = Logger('RST');
+
+final rstModelProvider = ChangeNotifierProvider<RstModel>(
+    (_) => RstModel(getService<SubiquityClient>()));
 
 /// View model for [RstPage].
 class RstModel extends SafeChangeNotifier {

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/rst/rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/rst/rst_page.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -16,12 +14,9 @@ import 'rst_model.dart';
 class RstPage extends ConsumerWidget {
   const RstPage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider<RstModel>(
-      (_) => RstModel(getService<SubiquityClient>()));
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(modelProvider);
+    final model = ref.watch(rstModelProvider);
     final lang = AppLocalizations.of(context);
     return Scaffold(
       body: WizardPage(

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -1,6 +1,7 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -8,6 +9,13 @@ import 'package:ubuntu_wizard/utils.dart';
 
 /// @internal
 final log = Logger('welcome');
+
+final welcomeModelProvider = ChangeNotifierProvider(
+  (_) => WelcomeModel(
+    client: getService<SubiquityClient>(),
+    network: getService<NetworkService>(),
+  ),
+);
 
 /// The available options on the welcome page.
 enum Option {

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -18,10 +16,6 @@ export 'welcome_model.dart' show Option;
 class WelcomePage extends ConsumerStatefulWidget {
   const WelcomePage({super.key});
 
-  static final modelProvider = ChangeNotifierProvider((_) => WelcomeModel(
-        client: getService<SubiquityClient>(),
-        network: getService<NetworkService>(),
-      ));
   @override
   WelcomePageState createState() => WelcomePageState();
 }
@@ -30,13 +24,13 @@ class WelcomePageState extends ConsumerState<WelcomePage> {
   @override
   void initState() {
     super.initState();
-    final model = ref.read(WelcomePage.modelProvider);
+    final model = ref.read(welcomeModelProvider);
     model.init();
   }
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(WelcomePage.modelProvider);
+    final model = ref.watch(welcomeModelProvider);
     final lang = AppLocalizations.of(context);
     final flavor = Flavor.of(context);
     final brightness = Theme.of(context).brightness;

--- a/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
@@ -52,7 +52,7 @@ void main() {
 
   Widget buildPage(ActiveDirectoryModel model) {
     return ProviderScope(
-      overrides: [ActiveDirectoryPage.modelProvider.overrideWith((_) => model)],
+      overrides: [activeDirectoryModelProvider.overrideWith((_) => model)],
       child: const ActiveDirectoryPage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
@@ -111,7 +111,7 @@ void main() {
 
     return ProviderScope(
       overrides: [
-        ConfirmPage.modelProvider.overrideWith((_) => model),
+        confirmModelProvider.overrideWith((_) => model),
       ],
       child: const ConfirmPage(),
     );

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -51,7 +51,7 @@ void main() {
 
   Widget buildPage(IdentityModel model) {
     return ProviderScope(
-      overrides: [IdentityPage.modelProvider.overrideWith((_) => model)],
+      overrides: [identityModelProvider.overrideWith((_) => model)],
       child: const IdentityPage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -51,7 +51,7 @@ void main() {
     registerMockService<SubiquityClient>(client);
 
     return ProviderScope(
-      overrides: [KeyboardPage.modelProvider.overrideWith((_) => model)],
+      overrides: [keyboardModelProvider.overrideWith((_) => model)],
       child: const KeyboardPage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -42,7 +42,7 @@ void main() {
     );
     await tester.pumpWidget(
       ProviderScope(overrides: [
-        LocalePage.modelProvider.overrideWith(
+        localeModelProvider.overrideWith(
           (_) => LocaleModel(
               locale: MockLocaleService(), sound: MockSoundService()),
         ),

--- a/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   Widget buildPage(SecureBootModel model) {
     return ProviderScope(
-      overrides: [SecureBootPage.modelProvider.overrideWith((_) => model)],
+      overrides: [secureBootModelProvider.overrideWith((_) => model)],
       child: const SecureBootPage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/source/not_enough_disk_space/not_enough_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/not_enough_disk_space/not_enough_disk_space_page_test.dart
@@ -31,7 +31,7 @@ void main() {
   Widget buildPage(NotEnoughDiskSpaceModel model) {
     return ProviderScope(
       overrides: [
-        NotEnoughDiskSpacePage.modelProvider.overrideWith((_) => model),
+        notEnoughDiskSpaceModelProvider.overrideWith((_) => model),
       ],
       child: const NotEnoughDiskSpacePage(),
     );

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -59,7 +59,7 @@ void main() {
     registerMockService<TelemetryService>(MockTelemetryService());
 
     return ProviderScope(
-      overrides: [SourcePage.modelProvider.overrideWith((_) => model)],
+      overrides: [sourceModelProvider.overrideWith((_) => model)],
       child: const SourcePage(),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -42,10 +42,9 @@ void main() {
   ) {
     return ProviderScope(
       overrides: [
-        TimezonePage.controllerProvider.overrideWith((_) => controller),
-        TimezonePage.modelProvider.overrideWith((_) => model),
+        timezoneModelProvider.overrideWith((_) => model),
       ],
-      child: const TimezonePage(),
+      child: TimezonePage(controller: controller),
     );
   }
 

--- a/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/rst/rst_page_test.dart
@@ -23,7 +23,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          RstPage.modelProvider.overrideWith((_) => model),
+          rstModelProvider.overrideWith((_) => model),
         ],
         child: tester.buildApp((_) => const RstPage()),
       ),
@@ -64,7 +64,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          RstPage.modelProvider.overrideWith((_) => model),
+          rstModelProvider.overrideWith((_) => model),
         ],
         child: tester.buildApp((_) => const RstPage()),
       ),

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -69,7 +69,7 @@ void main() {
 
     await tester.pumpWidget(ProviderScope(
       overrides: [
-        WelcomePage.modelProvider.overrideWith((_) => model),
+        welcomeModelProvider.overrideWith((_) => model),
       ],
       child: InheritedLocale(child: app),
     ));


### PR DESCRIPTION
We started with page-scoped static providers:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1918

But ended up with a more idiomatic riverpod approach:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1926

This PR applies the latter approach to the providers added in the former.