### PR TITLE
refactor(network): move model providers

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/network/connect_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/connect_model.dart
@@ -1,8 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal
 final log = Logger('network');
+
+final noConnectModelProvider = ChangeNotifierProvider((_) => NoConnectModel());
 
 enum ConnectMode {
   none,

--- a/packages/ubuntu_desktop_installer/lib/pages/network/connect_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/connect_view.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'connect_model.dart';
 import 'ethernet_model.dart';
-import 'network_page.dart';
 import 'wifi_model.dart';
 
 class NoConnectView extends ConsumerWidget {
@@ -20,9 +20,9 @@ class NoConnectView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final ethernet = ref.watch(NetworkPage.ethernetModelProvider
+    final ethernet = ref.watch(ethernetModelProvider
         .select((EthernetModel m) => m.isEnabled && m.devices.isNotEmpty));
-    final wifi = ref.watch(NetworkPage.wifiModelProvider
+    final wifi = ref.watch(wifiModelProvider
         .select((WifiModel m) => m.isEnabled && m.devices.isNotEmpty));
 
     return YaruRadioButton<ConnectMode>(

--- a/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_model.dart
@@ -1,8 +1,12 @@
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'connect_model.dart';
 import 'network_device.dart';
+
+final ethernetModelProvider = ChangeNotifierProvider((_) =>
+    EthernetModel(getService<NetworkService>(), getService<UdevService>()));
 
 /// "Use wired connection"
 class EthernetModel extends NetworkDeviceModel<EthernetDevice> {

--- a/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/ethernet_view.dart
@@ -4,7 +4,8 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import 'network_page.dart';
+import 'connect_model.dart';
+import 'ethernet_model.dart';
 import 'network_tile.dart';
 
 class EthernetRadioButton extends ConsumerWidget {
@@ -19,7 +20,7 @@ class EthernetRadioButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(NetworkPage.ethernetModelProvider);
+    final model = ref.watch(ethernetModelProvider);
     final lang = AppLocalizations.of(context);
     if (!model.isEnabled || model.devices.isEmpty) {
       return NetworkTile(
@@ -53,7 +54,7 @@ class EthernetView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = AppLocalizations.of(context);
-    final model = ref.watch(NetworkPage.ethernetModelProvider);
+    final model = ref.watch(ethernetModelProvider);
     if (model.devices.isNotEmpty && !model.isEnabled) {
       return NetworkTile(
         subtitle: Column(

--- a/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_model.dart
@@ -1,9 +1,13 @@
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'connect_model.dart';
 import 'network_device.dart';
 import 'wifi_model.dart';
+
+final hiddenWifiModelProvider = ChangeNotifierProvider((_) =>
+    HiddenWifiModel(getService<NetworkService>(), getService<UdevService>()));
 
 class HiddenWifiModel extends NetworkDeviceModel<WifiDevice> {
   HiddenWifiModel(super.service, [super.udev]);

--- a/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/hidden_wifi_view.dart
@@ -7,7 +7,8 @@ import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import 'network_page.dart';
+import 'connect_model.dart';
+import 'hidden_wifi_model.dart';
 import 'wifi_model.dart';
 
 class HiddenWifiRadioButton extends ConsumerWidget {
@@ -22,7 +23,7 @@ class HiddenWifiRadioButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(NetworkPage.hiddenWifiModelProvider);
+    final model = ref.watch(hiddenWifiModelProvider);
     if (!model.isEnabled || model.devices.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -75,7 +76,7 @@ class _HiddenWifiViewState extends ConsumerState<HiddenWifiView> {
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
-    final model = ref.watch(NetworkPage.hiddenWifiModelProvider);
+    final model = ref.watch(hiddenWifiModelProvider);
     if (!model.isEnabled || model.devices.isEmpty) {
       return const SizedBox.shrink();
     }

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_model.dart
@@ -1,8 +1,13 @@
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
 import 'connect_model.dart';
+
+final networkModelProvider = ChangeNotifierProvider((_) {
+  return NetworkModel(getService<NetworkService>());
+});
 
 /// A proxy model for the currently selected [ConnectModel] (eth, wifi, none).
 class NetworkModel extends SafeChangeNotifier implements ConnectModel {

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -21,18 +20,6 @@ export 'connect_model.dart' show ConnectMode;
 class NetworkPage extends ConsumerStatefulWidget {
   const NetworkPage({super.key});
 
-  static final networkModelProvider = ChangeNotifierProvider((_) {
-    return NetworkModel(getService<NetworkService>());
-  });
-  static final ethernetModelProvider = ChangeNotifierProvider((_) =>
-      EthernetModel(getService<NetworkService>(), getService<UdevService>()));
-  static final wifiModelProvider = ChangeNotifierProvider((_) =>
-      WifiModel(getService<NetworkService>(), getService<UdevService>()));
-  static final hiddenWifiModelProvider = ChangeNotifierProvider((_) =>
-      HiddenWifiModel(getService<NetworkService>(), getService<UdevService>()));
-  static final noConnectModelProvider =
-      ChangeNotifierProvider((_) => NoConnectModel());
-
   @override
   ConsumerState<NetworkPage> createState() => _NetworkPageState();
 }
@@ -42,18 +29,18 @@ class _NetworkPageState extends ConsumerState<NetworkPage> {
   void initState() {
     super.initState();
 
-    final model = ref.read(NetworkPage.networkModelProvider);
-    model.addConnectMode(ref.read(NetworkPage.ethernetModelProvider));
-    model.addConnectMode(ref.read(NetworkPage.wifiModelProvider));
-    model.addConnectMode(ref.read(NetworkPage.hiddenWifiModelProvider));
-    model.addConnectMode(ref.read(NetworkPage.noConnectModelProvider));
+    final model = ref.read(networkModelProvider);
+    model.addConnectMode(ref.read(ethernetModelProvider));
+    model.addConnectMode(ref.read(wifiModelProvider));
+    model.addConnectMode(ref.read(hiddenWifiModelProvider));
+    model.addConnectMode(ref.read(noConnectModelProvider));
 
     model.init().then((_) => model.selectConnectMode());
   }
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(NetworkPage.networkModelProvider);
+    final model = ref.watch(networkModelProvider);
     final lang = AppLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -15,6 +16,9 @@ const kWifiScanInterval = Duration(seconds: 15);
 
 @visibleForTesting
 const kWifiScanTimeout = Duration(seconds: 3);
+
+final wifiModelProvider = ChangeNotifierProvider(
+    (_) => WifiModel(getService<NetworkService>(), getService<UdevService>()));
 
 /// "Connect to Wi-Fi network"
 class WifiModel extends NetworkDeviceModel<WifiDevice> {

--- a/packages/ubuntu_desktop_installer/lib/pages/network/wifi_view.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/wifi_view.dart
@@ -6,7 +6,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import 'network_page.dart';
+import 'connect_model.dart';
 import 'network_tile.dart';
 import 'wifi_model.dart';
 
@@ -27,7 +27,7 @@ class WifiRadioButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(NetworkPage.wifiModelProvider);
+    final model = ref.watch(wifiModelProvider);
     final lang = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.only(top: 8),
@@ -70,14 +70,14 @@ class _WifiViewState extends ConsumerState<WifiView> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(NetworkPage.wifiModelProvider).startPeriodicScanning();
+      ref.read(wifiModelProvider).startPeriodicScanning();
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
-    final model = ref.watch(NetworkPage.wifiModelProvider);
+    final model = ref.watch(wifiModelProvider);
     if (!model.isEnabled) {
       return NetworkTile(
         subtitle: Column(
@@ -124,7 +124,7 @@ class WifiListView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final model = ref.watch(NetworkPage.wifiModelProvider);
+    final model = ref.watch(wifiModelProvider);
 
     return YaruBorderContainer(
       clipBehavior: Clip.antiAlias,

--- a/packages/ubuntu_desktop_installer/test/network/connect_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/connect_view_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/connect_view.dart';
-import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
+import 'package:ubuntu_desktop_installer/pages/network/ethernet_model.dart';
+import 'package:ubuntu_desktop_installer/pages/network/wifi_model.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -26,8 +28,8 @@ void main() {
       tester.buildApp(
         (_) => ProviderScope(
           overrides: [
-            NetworkPage.ethernetModelProvider.overrideWith((_) => ethernet),
-            NetworkPage.wifiModelProvider.overrideWith((_) => wifi),
+            ethernetModelProvider.overrideWith((_) => ethernet),
+            wifiModelProvider.overrideWith((_) => wifi),
           ],
           child: NoConnectView(value: ConnectMode.none, onChanged: (_) {}),
         ),

--- a/packages/ubuntu_desktop_installer/test/network/ethernet_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/ethernet_view_test.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/ethernet_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/ethernet_view.dart';
-import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -27,7 +27,7 @@ void main() {
       tester.buildApp(
         (_) => ProviderScope(
           overrides: [
-            NetworkPage.ethernetModelProvider.overrideWith((_) => model)
+            ethernetModelProvider.overrideWith((_) => model),
           ],
           child: Material(
             child: EthernetRadioButton(
@@ -56,7 +56,7 @@ void main() {
       tester.buildApp(
         (_) => ProviderScope(
           overrides: [
-            NetworkPage.ethernetModelProvider.overrideWith((_) => model)
+            ethernetModelProvider.overrideWith((_) => model),
           ],
           child: Column(
             children: [
@@ -94,7 +94,7 @@ void main() {
       tester.buildApp(
         (_) => ProviderScope(
           overrides: [
-            NetworkPage.ethernetModelProvider.overrideWith((_) => model)
+            ethernetModelProvider.overrideWith((_) => model),
           ],
           child: Column(
             children: [

--- a/packages/ubuntu_desktop_installer/test/network/hidden_wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/hidden_wifi_view_test.dart
@@ -6,7 +6,6 @@ import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/network/hidden_wifi_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/hidden_wifi_view.dart';
-import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_model.dart';
 import 'package:ubuntu_test/utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
@@ -25,7 +24,7 @@ void main() {
         localizationsDelegates: localizationsDelegates,
         home: ProviderScope(
           overrides: [
-            NetworkPage.hiddenWifiModelProvider.overrideWith((_) => model)
+            hiddenWifiModelProvider.overrideWith((_) => model),
           ],
           child: Material(
             child: Column(

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -97,13 +97,11 @@ void main() {
 
     return ProviderScope(
       overrides: [
-        NetworkPage.networkModelProvider.overrideWith((_) => model),
-        NetworkPage.ethernetModelProvider.overrideWith((_) => ethernetModel),
-        NetworkPage.wifiModelProvider.overrideWith((_) => wifiModel),
-        NetworkPage.hiddenWifiModelProvider
-            .overrideWith((_) => hiddenWifiModel),
-        NetworkPage.noConnectModelProvider
-            .overrideWith((_) => NoConnectModel()),
+        networkModelProvider.overrideWith((_) => model),
+        ethernetModelProvider.overrideWith((_) => ethernetModel),
+        wifiModelProvider.overrideWith((_) => wifiModel),
+        hiddenWifiModelProvider.overrideWith((_) => hiddenWifiModel),
+        noConnectModelProvider.overrideWith((_) => NoConnectModel()),
       ],
       child: const NetworkPage(),
     );

--- a/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
@@ -59,7 +59,9 @@ void main() {
     await tester.pumpWidget(
       tester.buildApp(
         (_) => ProviderScope(
-          overrides: [NetworkPage.wifiModelProvider.overrideWith((_) => model)],
+          overrides: [
+            wifiModelProvider.overrideWith((_) => model),
+          ],
           child: Material(
             child: Column(
               children: [
@@ -125,7 +127,9 @@ void main() {
     await tester.pumpWidget(
       tester.buildApp(
         (_) => ProviderScope(
-          overrides: [NetworkPage.wifiModelProvider.overrideWith((_) => model)],
+          overrides: [
+            wifiModelProvider.overrideWith((_) => model),
+          ],
           child: Column(
             children: [
               WifiRadioButton(
@@ -164,7 +168,9 @@ void main() {
     await tester.pumpWidget(
       tester.buildApp(
         (_) => ProviderScope(
-          overrides: [NetworkPage.wifiModelProvider.overrideWith((_) => model)],
+          overrides: [
+            wifiModelProvider.overrideWith((_) => model),
+          ],
           child: Column(
             children: [
               WifiRadioButton(
@@ -196,7 +202,9 @@ void main() {
     await tester.pumpWidget(
       tester.buildApp(
         (_) => ProviderScope(
-          overrides: [NetworkPage.wifiModelProvider.overrideWith((_) => model)],
+          overrides: [
+            wifiModelProvider.overrideWith((_) => model),
+          ],
           child: WifiView(
             expanded: true,
             onEnabled: () {},


### PR DESCRIPTION
Same as #1952 but for the remaining network models.