### PR TITLE
refactor(timezone): prepare for model pre-loading

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_model.dart
@@ -1,27 +1,35 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 final log = Logger('timezone');
 
-final timezoneModelProvider =
-    ChangeNotifierProvider((_) => TimezoneModel(getService<TimezoneService>()));
+final timezoneModelProvider = ChangeNotifierProvider(
+  (_) => TimezoneModel(
+    getService<TimezoneService>(),
+    getService<GeoService>(),
+  ),
+);
 
-class TimezoneModel extends SafeChangeNotifier {
-  TimezoneModel(this._service);
+class TimezoneModel extends TimezoneController {
+  TimezoneModel(this._service, GeoService geo) : super(service: geo);
 
   final TimezoneService _service;
 
-  Future<String> init() async {
+  Future<void> init() async {
     return _service.getTimezone().then((timezone) async {
       log.debug('Initialized $timezone');
-      return timezone;
+      return searchTimezone(timezone).then((timezones) {
+        selectTimezone(timezones.firstOrNull);
+      });
     });
   }
 
-  Future<void> save(String? timezone) async {
+  Future<void> save() async {
+    final timezone = selectedLocation?.timezone ?? 'geoip';
     log.debug('Saved $timezone');
-    _service.setTimezone(timezone ?? 'geoip');
+    _service.setTimezone(timezone);
   }
 }

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_model_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_model_test.mocks.dart
@@ -3,10 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_desktop_installer/services/timezone_service.dart' as _i2;
+import 'package:timezone_map/src/location.dart' as _i5;
+import 'package:timezone_map/src/service.dart' as _i2;
+import 'package:timezone_map/src/source.dart' as _i3;
+import 'package:ubuntu_desktop_installer/services/timezone_service.dart' as _i6;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -19,29 +22,112 @@ import 'package:ubuntu_desktop_installer/services/timezone_service.dart' as _i2;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+/// A class which mocks [GeoService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGeoService extends _i1.Mock implements _i2.GeoService {
+  MockGeoService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  void addSource(_i3.GeoSource? source) => super.noSuchMethod(
+        Invocation.method(
+          #addSource,
+          [source],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeSource(_i3.GeoSource? source) => super.noSuchMethod(
+        Invocation.method(
+          #removeSource,
+          [source],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<_i5.GeoLocation?> lookupLocation() => (super.noSuchMethod(
+        Invocation.method(
+          #lookupLocation,
+          [],
+        ),
+        returnValue: _i4.Future<_i5.GeoLocation?>.value(),
+      ) as _i4.Future<_i5.GeoLocation?>);
+  @override
+  _i4.Future<Iterable<_i5.GeoLocation>> searchLocation(String? location) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchLocation,
+          [location],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+  @override
+  _i4.Future<Iterable<_i5.GeoLocation>> searchCoordinates(
+          _i5.LatLng? coordinates) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchCoordinates,
+          [coordinates],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+  @override
+  _i4.Future<Iterable<_i5.GeoLocation>> searchTimezone(String? timezone) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchTimezone,
+          [timezone],
+        ),
+        returnValue:
+            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+  @override
+  _i4.Future<void> cancelSearch() => (super.noSuchMethod(
+        Invocation.method(
+          #cancelSearch,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+}
+
 /// A class which mocks [TimezoneService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTimezoneService extends _i1.Mock implements _i2.TimezoneService {
+class MockTimezoneService extends _i1.Mock implements _i6.TimezoneService {
   MockTimezoneService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<String> getTimezone() => (super.noSuchMethod(
+  _i4.Future<String> getTimezone() => (super.noSuchMethod(
         Invocation.method(
           #getTimezone,
           [],
         ),
-        returnValue: _i3.Future<String>.value(''),
-      ) as _i3.Future<String>);
+        returnValue: _i4.Future<String>.value(''),
+      ) as _i4.Future<String>);
   @override
-  _i3.Future<void> setTimezone(String? timezone) => (super.noSuchMethod(
+  _i4.Future<void> setTimezone(String? timezone) => (super.noSuchMethod(
         Invocation.method(
           #setTimezone,
           [timezone],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.mocks.dart
@@ -4,15 +4,12 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
-import 'dart:ui' as _i7;
+import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:timezone_map/src/controller.dart' as _i6;
-import 'package:timezone_map/src/location.dart' as _i5;
-import 'package:timezone_map/src/service.dart' as _i2;
-import 'package:timezone_map/src/source.dart' as _i3;
+import 'package:timezone_map/timezone_map.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_model.dart'
-    as _i8;
+    as _i2;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -25,30 +22,34 @@ import 'package:ubuntu_desktop_installer/pages/timezone/timezone_model.dart'
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-/// A class which mocks [GeoService].
+/// A class which mocks [TimezoneModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGeoService extends _i1.Mock implements _i2.GeoService {
-  MockGeoService() {
+class MockTimezoneModel extends _i1.Mock implements _i2.TimezoneModel {
+  MockTimezoneModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void addSource(_i3.GeoSource? source) => super.noSuchMethod(
-        Invocation.method(
-          #addSource,
-          [source],
-        ),
-        returnValueForMissingStub: null,
-      );
+  Iterable<_i3.GeoLocation> get locations => (super.noSuchMethod(
+        Invocation.getter(#locations),
+        returnValue: <_i3.GeoLocation>[],
+      ) as Iterable<_i3.GeoLocation>);
   @override
-  void removeSource(_i3.GeoSource? source) => super.noSuchMethod(
-        Invocation.method(
-          #removeSource,
-          [source],
-        ),
-        returnValueForMissingStub: null,
-      );
+  Iterable<_i3.GeoLocation> get timezones => (super.noSuchMethod(
+        Invocation.getter(#timezones),
+        returnValue: <_i3.GeoLocation>[],
+      ) as Iterable<_i3.GeoLocation>);
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
   @override
   _i4.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
@@ -59,86 +60,16 @@ class MockGeoService extends _i1.Mock implements _i2.GeoService {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<_i5.GeoLocation?> lookupLocation() => (super.noSuchMethod(
+  _i4.Future<void> save() => (super.noSuchMethod(
         Invocation.method(
-          #lookupLocation,
-          [],
-        ),
-        returnValue: _i4.Future<_i5.GeoLocation?>.value(),
-      ) as _i4.Future<_i5.GeoLocation?>);
-  @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchLocation(String? location) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #searchLocation,
-          [location],
-        ),
-        returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
-  @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchCoordinates(
-          _i5.LatLng? coordinates) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #searchCoordinates,
-          [coordinates],
-        ),
-        returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
-  @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchTimezone(String? timezone) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #searchTimezone,
-          [timezone],
-        ),
-        returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
-  @override
-  _i4.Future<void> cancelSearch() => (super.noSuchMethod(
-        Invocation.method(
-          #cancelSearch,
+          #save,
           [],
         ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
-}
-
-/// A class which mocks [TimezoneController].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockTimezoneController extends _i1.Mock
-    implements _i6.TimezoneController {
-  MockTimezoneController() {
-    _i1.throwOnMissingStub(this);
-  }
-
   @override
-  Iterable<_i5.GeoLocation> get locations => (super.noSuchMethod(
-        Invocation.getter(#locations),
-        returnValue: <_i5.GeoLocation>[],
-      ) as Iterable<_i5.GeoLocation>);
-  @override
-  Iterable<_i5.GeoLocation> get timezones => (super.noSuchMethod(
-        Invocation.getter(#timezones),
-        returnValue: <_i5.GeoLocation>[],
-      ) as Iterable<_i5.GeoLocation>);
-  @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-      ) as bool);
-  @override
-  bool get isDisposed => (super.noSuchMethod(
-        Invocation.getter(#isDisposed),
-        returnValue: false,
-      ) as bool);
-  @override
-  void selectLocation(_i5.GeoLocation? location) => super.noSuchMethod(
+  void selectLocation(_i3.GeoLocation? location) => super.noSuchMethod(
         Invocation.method(
           #selectLocation,
           [location],
@@ -146,7 +77,7 @@ class MockTimezoneController extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void selectTimezone(_i5.GeoLocation? timezone) => super.noSuchMethod(
+  void selectTimezone(_i3.GeoLocation? timezone) => super.noSuchMethod(
         Invocation.method(
           #selectTimezone,
           [timezone],
@@ -154,38 +85,38 @@ class MockTimezoneController extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchLocation(String? location) =>
+  _i4.Future<Iterable<_i3.GeoLocation>> searchLocation(String? location) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchLocation,
           [location],
         ),
         returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+            _i4.Future<Iterable<_i3.GeoLocation>>.value(<_i3.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i3.GeoLocation>>);
   @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchCoordinates(
-          _i5.LatLng? coordinates) =>
+  _i4.Future<Iterable<_i3.GeoLocation>> searchCoordinates(
+          _i3.LatLng? coordinates) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchCoordinates,
           [coordinates],
         ),
         returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+            _i4.Future<Iterable<_i3.GeoLocation>>.value(<_i3.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i3.GeoLocation>>);
   @override
-  _i4.Future<Iterable<_i5.GeoLocation>> searchTimezone(String? timezone) =>
+  _i4.Future<Iterable<_i3.GeoLocation>> searchTimezone(String? timezone) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchTimezone,
           [timezone],
         ),
         returnValue:
-            _i4.Future<Iterable<_i5.GeoLocation>>.value(<_i5.GeoLocation>[]),
-      ) as _i4.Future<Iterable<_i5.GeoLocation>>);
+            _i4.Future<Iterable<_i3.GeoLocation>>.value(<_i3.GeoLocation>[]),
+      ) as _i4.Future<Iterable<_i3.GeoLocation>>);
   @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -193,76 +124,7 @@ class MockTimezoneController extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-}
-
-/// A class which mocks [TimezoneModel].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockTimezoneModel extends _i1.Mock implements _i8.TimezoneModel {
-  MockTimezoneModel() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-      ) as bool);
-  @override
-  bool get isDisposed => (super.noSuchMethod(
-        Invocation.getter(#isDisposed),
-        returnValue: false,
-      ) as bool);
-  @override
-  _i4.Future<String> init() => (super.noSuchMethod(
-        Invocation.method(
-          #init,
-          [],
-        ),
-        returnValue: _i4.Future<String>.value(''),
-      ) as _i4.Future<String>);
-  @override
-  _i4.Future<void> save(String? timezone) => (super.noSuchMethod(
-        Invocation.method(
-          #save,
-          [timezone],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],


### PR DESCRIPTION
The relationship between the view model and a separate controller managed by the widget state would be problematic for pre-loading the model from `WizardRoute.onLoad`. Restructure it so that we will be able to do a full init before building the page.

Ref: #1736