### PR TITLE
ci: use different branch names for generated l10n & mocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       with:
         title: 'Regenerate mocks'
         commit-message: 'Regenerate mocks'
+        branch: create-pull-request/mocks
 
   l10n:
     runs-on: ubuntu-22.04
@@ -83,6 +84,7 @@ jobs:
       with:
         title: 'Regenerate l10n'
         commit-message: 'Regenerate l10n'
+        branch: create-pull-request/l10n
 
   snap:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The default `create-pull-request/patch` branch name conflicts between the l10n & mock generation jobs and PRs sometimes get prematurely closed depending on the order of completion:

- https://github.com/canonical/ubuntu-desktop-installer/pull/1966
- https://github.com/canonical/ubuntu-desktop-installer/pull/1944
- ...