### PR TITLE
refactor(locale): fetch initial value from the service

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_model.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart' show KeySearchX;
+import 'package:ubuntu_wizard/utils.dart';
 
 /// @internal
 final log = Logger('locale');
@@ -44,12 +45,15 @@ class LocaleModel extends SafeChangeNotifier {
   var _languageList = <LocalizedLanguage>[];
 
   /// Loads available languages.
-  Future<void> loadLanguages() async {
+  Future<void> init() async {
     assert(_languageList.isEmpty);
     final languages = await loadLocalizedLanguages(supportedLocales);
     _languageList = List.of(languages);
     log.info('Loaded ${_languageList.length} languages');
-    notifyListeners();
+    return _locale.getLocale().then((v) {
+      selectLocale(parseLocale(v));
+      notifyListeners();
+    });
   }
 
   /// Returns the locale for the given language [index].

--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
@@ -23,8 +23,8 @@ class _LocalePageState extends ConsumerState<LocalePage> {
     super.initState();
 
     final model = ref.read(localeModelProvider);
-    model.loadLanguages().then((_) {
-      model.selectLocale(InheritedLocale.of(context));
+    model.init().then((_) {
+      _selectLanguage(model.selectedLanguageIndex);
       model.playWelcomeSound();
     });
   }

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -87,10 +87,13 @@ extension on WidgetTester {
     when(journal.start(any, output: anyNamed('output')))
         .thenAnswer((_) => const Stream.empty());
 
+    final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
+
     registerMockService<DesktopService>(MockDesktopService());
     registerMockService<StorageService>(StorageService(client));
     registerMockService<JournalService>(journal);
-    registerMockService<LocaleService>(MockLocaleService());
+    registerMockService<LocaleService>(locale);
     registerMockService<ProductService>(ProductService());
     registerMockService<TelemetryService>(TelemetryService());
 

--- a/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_model_test.dart
@@ -13,19 +13,26 @@ import 'locale_model_test.mocks.dart';
 void main() {
   test('load languages', () async {
     final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     final sound = MockSoundService();
 
     final model = LocaleModel(locale: locale, sound: sound);
-    await model.loadLanguages();
+    await model.init();
     expect(model.languageCount, greaterThan(1));
+    expect(model.selectedLanguageIndex, isPositive);
+
+    final selected = model.locale(model.selectedLanguageIndex);
+    expect(selected.languageCode, 'en');
+    expect(selected.countryCode, 'US');
   });
 
   test('sort languages', () async {
     final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     final sound = MockSoundService();
 
     final model = LocaleModel(locale: locale, sound: sound);
-    await model.loadLanguages();
+    await model.init();
 
     final languages = List.generate(model.languageCount, model.language);
     expect(languages.length, greaterThan(1));
@@ -37,12 +44,13 @@ void main() {
 
   test('select locale', () async {
     final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     final sound = MockSoundService();
 
     final model = LocaleModel(locale: locale, sound: sound);
-    await model.loadLanguages();
+    await model.init();
     expect(model.languageCount, greaterThan(1));
-    expect(model.selectedLanguageIndex, equals(0));
+    expect(model.selectedLanguageIndex, isPositive);
 
     // falls back to the base locale (en_US)
     model.selectLocale(const Locale('foo'));
@@ -91,10 +99,11 @@ void main() {
 
   test('search language', () async {
     final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     final sound = MockSoundService();
 
     final model = LocaleModel(locale: locale, sound: sound);
-    await model.loadLanguages();
+    await model.init();
 
     final english = model.searchLanguage('eng');
     expect(model.language(english), equals('English'));

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_model.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -18,8 +19,11 @@ import 'locale_page_test.mocks.dart';
 @GenerateMocks([TelemetryService])
 void main() {
   LocaleModel buildModel() {
+    final locale = MockLocaleService();
+    when(locale.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
+
     return LocaleModel(
-      locale: MockLocaleService(),
+      locale: locale,
       sound: MockSoundService(),
     );
   }


### PR DESCRIPTION
Allow the service to decide which locale is initially selected.