### PR TITLE
perf(ListWidget): add missing item extent

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/list_widget.dart
@@ -88,6 +88,7 @@ class _ListWidgetState extends State<ListWidget> {
               child: ListView.builder(
                 key: _scrollableKey,
                 controller: _scrollController,
+                itemExtent: _kTileHeight,
                 itemCount: widget.itemCount,
                 itemBuilder: (context, index) => Builder(
                   builder: (context) {


### PR DESCRIPTION
The custom scrolling position calculation relies on a fixed item extent so we might as well let ListView know about it to avoid building every item along the way to calculate their extent when scrolling to a specific target item.

> Specifying an itemExtent or an prototypeItem is more efficient than
> letting the children determine their own extent because the scrolling
> machinery can make use of the foreknowledge of the children's extent
> to save work, for example when the scroll position changes drastically.

https://api.flutter.dev/flutter/widgets/ListView-class.html