### PR TITLE
refactor(installer): use SubiquityClient.monitorStatus()

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -92,7 +92,6 @@ Future<void> runInstallerApp(
   tryRegisterService(SubiquityClient.new);
   tryRegisterService(
       () => SubiquityServer(process: process, endpoint: endpoint));
-  tryRegisterService(SubiquityStatusMonitor.new);
   tryRegisterService(TelemetryService.new);
   tryRegisterService<TimezoneService>(
       () => SubiquityTimezoneService(getService<SubiquityClient>()));
@@ -115,7 +114,6 @@ Future<void> runInstallerApp(
     options: options,
     subiquityClient: getService<SubiquityClient>(),
     subiquityServer: getService<SubiquityServer>(),
-    subiquityMonitor: getService<SubiquityStatusMonitor>(),
     serverArgs: [
       if (options['machine-config'] != null)
         '--machine-config=${options['machine-config']}',
@@ -182,9 +180,8 @@ class _UbuntuDesktopInstallerAppState extends State<UbuntuDesktopInstallerApp> {
   void initState() {
     super.initState();
 
-    final monitor = getService<SubiquityStatusMonitor>();
-    _subiquityStatus = monitor.status;
-    _subiquityStatusChange = monitor.onStatusChanged.listen((status) {
+    final client = getService<SubiquityClient>();
+    _subiquityStatusChange = client.monitorStatus().listen((status) {
       YaruWindow.of(context).setClosable(status?.isInstalling != true);
       setState(() => _subiquityStatus = status);
     });

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -64,6 +64,7 @@ extension on WidgetTester {
 
     final client = MockSubiquityClient();
     when(client.getStatus()).thenAnswer((_) async => status);
+    when(client.monitorStatus()).thenAnswer((_) => Stream.value(status));
     when(client.getStatus(current: ApplicationState.RUNNING))
         .thenAnswer((_) async => done);
     when(client.hasRst()).thenAnswer((_) async => false);
@@ -77,11 +78,6 @@ extension on WidgetTester {
     when(client.getSource()).thenAnswer((_) async =>
         const SourceSelectionAndSetting(
             sources: [], currentId: kNormalSourceId, searchDrivers: false));
-
-    final monitor = MockSubiquityStatusMonitor();
-    when(monitor.status).thenReturn(status);
-    when(monitor.onStatusChanged).thenAnswer((_) => const Stream.empty());
-    registerMockService<SubiquityStatusMonitor>(monitor);
 
     final journal = MockJournalService();
     when(journal.start(any, output: anyNamed('output')))


### PR DESCRIPTION
One thing less to abstract away in non-Subiquity mode.