### PR TITLE
fix(loading): fix back button to be disabled after the loading screen

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/loading/loading_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/loading/loading_page.dart
@@ -20,7 +20,7 @@ class _LoadingPageState extends ConsumerState<LoadingPage> {
     super.initState();
 
     final model = ref.read(loadingModelProvider);
-    model.init().then((_) => Wizard.of(context).next());
+    model.init().then((_) => Wizard.of(context).replace());
   }
 
   @override


### PR DESCRIPTION
Fixes the following broken screenshot updates:
- https://github.com/canonical/ubuntu-desktop-installer-screenshots/pull/86
- https://github.com/canonical/ubuntu-desktop-installer-screenshots/pull/87
- https://github.com/canonical/ubuntu-desktop-installer-screenshots/pull/88
- https://github.com/canonical/ubuntu-desktop-installer-screenshots/pull/89