### PR TITLE
test: rename tapBack/Previous() & tapContinue/Next()

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -36,7 +36,7 @@ Future<void> testLocalePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testWelcomePage(
@@ -57,7 +57,7 @@ Future<void> testWelcomePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testKeyboardPage(
@@ -100,7 +100,7 @@ Future<void> testKeyboardPage(
     await tester.pumpAndSettle();
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testNetworkPage(
@@ -120,7 +120,7 @@ Future<void> testNetworkPage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testSourcePage(
@@ -140,7 +140,7 @@ Future<void> testSourcePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testNotEnoughDiskSpacePage(
@@ -202,7 +202,7 @@ Future<void> testInstallationTypePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testSecurityKeyPage(
@@ -228,7 +228,7 @@ Future<void> testSecurityKeyPage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testAllocateDiskSpacePage(
@@ -282,7 +282,7 @@ Future<void> testAllocateDiskSpacePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testSelectGuidedStoragePage(
@@ -296,7 +296,7 @@ Future<void> testSelectGuidedStoragePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testInstallAlongsidePage(
@@ -330,7 +330,7 @@ Future<void> testInstallAlongsidePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testConfirmPage(
@@ -428,7 +428,7 @@ Future<void> testTimezonePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testIdentityPage(
@@ -473,7 +473,7 @@ Future<void> testIdentityPage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testActiveDirectoryPage(
@@ -510,7 +510,7 @@ Future<void> testActiveDirectoryPage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testThemePage(
@@ -531,7 +531,7 @@ Future<void> testThemePage(
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testInstallPage(

--- a/packages/ubuntu_desktop_installer/test/source/source_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_wizard_test.dart
@@ -22,26 +22,26 @@ void main() {
     expect(find.text('first route'), findsOneWidget);
 
     // first -> source
-    await tester.tapContinue();
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourcePage), findsOneWidget);
 
     // source -> last
-    await tester.tapContinue();
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     expect(find.byType(NotEnoughDiskSpacePage), findsNothing);
     expect(find.text('last route'), findsOneWidget);
 
     // last -> source
-    await tester.tapBack();
+    await tester.tapPrevious();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourcePage), findsOneWidget);
 
     // source -> first
-    await tester.tapBack();
+    await tester.tapPrevious();
     await tester.pumpAndSettle();
 
     expect(find.text('first route'), findsOneWidget);
@@ -53,26 +53,26 @@ void main() {
     expect(find.text('first route'), findsOneWidget);
 
     // first -> source
-    await tester.tapContinue();
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourcePage), findsOneWidget);
 
     // source -> not enough disk space
-    await tester.tapContinue();
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     expect(find.byType(NotEnoughDiskSpacePage), findsOneWidget);
     expect(find.text('last route'), findsNothing);
 
     // not enough disk space -> source
-    await tester.tapBack();
+    await tester.tapPrevious();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourcePage), findsOneWidget);
 
     // source -> first
-    await tester.tapBack();
+    await tester.tapPrevious();
     await tester.pumpAndSettle();
 
     expect(find.text('first route'), findsOneWidget);

--- a/packages/ubuntu_test/lib/src/integration_test.dart
+++ b/packages/ubuntu_test/lib/src/integration_test.dart
@@ -49,11 +49,11 @@ Future<void> verifyGoldenFile(String fileName, String goldenName) async {
 
 /// Helpers for interacting with widgets.
 extension IntegrationTester on WidgetTester {
-  /// Taps a "Go Back" button.
-  Future<void> tapBack() => tapButton(ulang.previousLabel);
+  /// Taps a "Previous" button.
+  Future<void> tapPrevious() => tapButton(ulang.previousLabel);
 
-  /// Taps a "Continue" button.
-  Future<void> tapContinue() => tapButton(ulang.nextLabel);
+  /// Taps a "Next" button.
+  Future<void> tapNext() => tapButton(ulang.nextLabel);
 
   /// Taps a button specified by its [label]. The button can be any
   /// [ButtonStyleButton] subclass, such as [OutlinedButton], [ElevatedButton],

--- a/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
+++ b/packages/ubuntu_wsl_setup/integration_test/test_pages.dart
@@ -56,7 +56,7 @@ Future<void> testSelectYourLanguagePage(
     value: false,
   );
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testProfileSetupPage(
@@ -98,7 +98,7 @@ Future<void> testProfileSetupPage(
   );
   await tester.pumpAndSettle();
 
-  await tester.tapContinue();
+  await tester.tapNext();
 }
 
 Future<void> testAdvancedSetupPage(


### PR DESCRIPTION
The former _Back_ & _Continue_ wizard buttons were changed to _Previous_ & _Next_ last minute before the UI freeze, deliberately keeping the changes to a minimum. This PR adapts the remaining tap helper methods to ensure consistent naming in tests.

- #1644