### PR TITLE
chore: add flutter_lints to the top-level pubspec

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   glob:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,5 +2,7 @@ name: ubuntu_desktop_installer_workspace
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
+
 dev_dependencies:
+  flutter_lints: ^2.0.0
   melos: ^3.0.1


### PR DESCRIPTION
This fixes the issue that VS Code keeps complaining about:
```yaml
include: package:flutter_lints/flutter.yaml
```
in the shared [`analysis_options.yaml`](https://github.com/canonical/ubuntu-desktop-installer/blob/main/analysis_options.yaml). Now that we have a top-level `pubspec.yaml` thanks to Melos 3, we may add the `flutter_lints` dependency there as well to make tooling happy.

| Before | After |
|---|---|
| ![Screenshot from 2023-05-17 14-36-45](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/00760d5a-205e-43ed-b278-c3c3c81546d8) | ![Screenshot from 2023-05-17 14-36-25](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/cc42a72d-b769-41b2-8ecf-64fe464c7577) |
