### PR TITLE
test(screenshots): jump to initialize the timezone view model

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -290,9 +290,10 @@ void main() {
   }, variant: themeVariant);
 
   testWidgets('10.timezone', (tester) async {
-    await runInstallerApp([
-      '--initial-route=${Routes.timezone}',
-    ], flavor: currentFlavor);
+    await runInstallerApp([], flavor: currentFlavor);
+    await tester.pumpAndSettle();
+
+    await tester.jumpToWizardRoute(Routes.timezone);
     await tester.pumpAndSettle();
 
     await testTimezonePage(


### PR DESCRIPTION
`--initial-route` is no longer suitable and should probably be removed because it won't pre-load the respective view model and therefore things are not initialized properly.