### PR TITLE
refactor: remove 'part of' anti-pattern

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_page.dart
@@ -1,20 +1,14 @@
-import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
-import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'install_alongside_model.dart';
+import 'install_alongside_widgets.dart';
 import 'storage_split_view.dart';
-
-part 'install_alongside_widgets.dart';
 
 /// Install alongside other OSes.
 class InstallAlongsidePage extends ConsumerStatefulWidget {
@@ -68,7 +62,7 @@ class _InstallAlongsidePageState extends ConsumerState<InstallAlongsidePage> {
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          _StorageSelector(
+          StorageSelector(
             count: model.storageCount,
             selectedIndex: model.selectedIndex,
             onSelected: model.selectStorage,
@@ -91,7 +85,7 @@ class _InstallAlongsidePageState extends ConsumerState<InstallAlongsidePage> {
               ),
             ),
           const SizedBox(height: kContentSpacing / 2),
-          _HiddenPartitionLabel(
+          HiddenPartitionLabel(
             partitions: model.getAllPartitions(model.selectedIndex ?? -1) ?? [],
             onTap: () =>
                 Wizard.of(context).replace(arguments: InstallationType.manual),

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/install_alongside/install_alongside_widgets.dart
@@ -1,7 +1,18 @@
-part of 'install_alongside_page.dart';
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
-class _StorageSelector extends ConsumerWidget {
-  const _StorageSelector({
+import 'install_alongside_model.dart';
+
+class StorageSelector extends ConsumerWidget {
+  const StorageSelector({
+    super.key,
     required this.count,
     this.selectedIndex,
     this.onSelected,
@@ -52,8 +63,12 @@ class _StorageSelector extends ConsumerWidget {
   }
 }
 
-class _HiddenPartitionLabel extends StatelessWidget {
-  const _HiddenPartitionLabel({required this.partitions, required this.onTap});
+class HiddenPartitionLabel extends StatelessWidget {
+  const HiddenPartitionLabel({
+    super.key,
+    required this.partitions,
+    required this.onTap,
+  });
 
   final List<Partition> partitions;
   final VoidCallback onTap;

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:form_field_validator/form_field_validator.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -9,8 +8,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'security_key_model.dart';
-
-part 'security_key_widgets.dart';
+import 'security_key_widgets.dart';
 
 /// Choose security key page.
 ///
@@ -49,11 +47,11 @@ class _SecurityKeyPageState extends ConsumerState<SecurityKeyPage> {
         final fieldWidth = constraints.maxWidth * kContentWidthFraction;
         return ListView(
           children: <Widget>[
-            _SecurityKeyFormField(fieldWidth: fieldWidth),
+            SecurityKeyFormField(fieldWidth: fieldWidth),
             const SizedBox(height: kContentSpacing),
-            _ConfirmSecurityKeyFormField(fieldWidth: fieldWidth),
+            ConfirmSecurityKeyFormField(fieldWidth: fieldWidth),
             const SizedBox(height: kContentSpacing / 2),
-            const _SecurityKeyShowButton(),
+            const SecurityKeyShowButton(),
             const SizedBox(height: kContentSpacing),
             Align(
               alignment: Alignment.centerLeft,

--- a/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/filesystem/security_key/security_key_widgets.dart
@@ -1,7 +1,14 @@
-part of 'security_key_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_field_validator/form_field_validator.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
-class _SecurityKeyFormField extends ConsumerWidget {
-  const _SecurityKeyFormField({this.fieldWidth});
+import 'security_key_model.dart';
+
+class SecurityKeyFormField extends ConsumerWidget {
+  const SecurityKeyFormField({super.key, this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -30,8 +37,8 @@ class _SecurityKeyFormField extends ConsumerWidget {
   }
 }
 
-class _ConfirmSecurityKeyFormField extends ConsumerWidget {
-  const _ConfirmSecurityKeyFormField({required this.fieldWidth});
+class ConfirmSecurityKeyFormField extends ConsumerWidget {
+  const ConfirmSecurityKeyFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -65,8 +72,8 @@ class _ConfirmSecurityKeyFormField extends ConsumerWidget {
   }
 }
 
-class _SecurityKeyShowButton extends ConsumerWidget {
-  const _SecurityKeyShowButton();
+class SecurityKeyShowButton extends ConsumerWidget {
+  const SecurityKeyShowButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:form_field_validator/form_field_validator.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'identity_model.dart';
-
-part 'identity_widgets.dart';
+import 'identity_widgets.dart';
 
 // The horizontal indentation of the radio button.
 // const _kRadioButtonIndentation = 36.0;
@@ -45,30 +41,30 @@ class IdentityPage extends ConsumerWidget {
           children: [
             Padding(
               padding: fieldPadding,
-              child: _RealNameFormField(fieldWidth: fieldWidth),
+              child: RealNameFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _HostnameFormField(fieldWidth: fieldWidth),
+              child: HostnameFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _UsernameFormField(fieldWidth: fieldWidth),
+              child: UsernameFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _PasswordFormField(fieldWidth: fieldWidth),
+              child: PasswordFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _ConfirmPasswordFormField(fieldWidth: fieldWidth),
+              child: ConfirmPasswordFormField(fieldWidth: fieldWidth),
             ),
             const SizedBox(height: kContentSpacing / 2),
-            const _AutoLoginSwitch(),
+            const AutoLoginSwitch(),
             const SizedBox(height: kContentSpacing / 2),
             const Padding(
               padding: kContentPadding,
-              child: _UseActiveDirectoryCheckButton(),
+              child: UseActiveDirectoryCheckButton(),
             ),
           ],
         );

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_widgets.dart
@@ -1,7 +1,17 @@
-part of 'identity_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_field_validator/form_field_validator.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
-class _RealNameFormField extends ConsumerWidget {
-  const _RealNameFormField({required this.fieldWidth});
+import 'identity_model.dart';
+
+class RealNameFormField extends ConsumerWidget {
+  const RealNameFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -35,8 +45,8 @@ class _RealNameFormField extends ConsumerWidget {
   }
 }
 
-class _HostnameFormField extends ConsumerWidget {
-  const _HostnameFormField({this.fieldWidth});
+class HostnameFormField extends ConsumerWidget {
+  const HostnameFormField({super.key, this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -92,8 +102,8 @@ extension UsernameValidationL10n on UsernameValidation {
   }
 }
 
-class _UsernameFormField extends ConsumerWidget {
-  const _UsernameFormField({this.fieldWidth});
+class UsernameFormField extends ConsumerWidget {
+  const UsernameFormField({super.key, this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -133,8 +143,8 @@ class _UsernameFormField extends ConsumerWidget {
   }
 }
 
-class _PasswordFormField extends ConsumerWidget {
-  const _PasswordFormField({this.fieldWidth});
+class PasswordFormField extends ConsumerWidget {
+  const PasswordFormField({super.key, this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -154,7 +164,7 @@ class _PasswordFormField extends ConsumerWidget {
       obscureText: !showPassword,
       successWidget: PasswordStrengthLabel(strength: passwordStrength),
       initialValue: password,
-      suffixIcon: _ShowPasswordButton(
+      suffixIcon: ShowPasswordButton(
         value: showPassword,
         onChanged: (value) =>
             ref.read(identityModelProvider).showPassword = value,
@@ -170,8 +180,8 @@ class _PasswordFormField extends ConsumerWidget {
   }
 }
 
-class _ConfirmPasswordFormField extends ConsumerWidget {
-  const _ConfirmPasswordFormField({required this.fieldWidth});
+class ConfirmPasswordFormField extends ConsumerWidget {
+  const ConfirmPasswordFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -204,8 +214,12 @@ class _ConfirmPasswordFormField extends ConsumerWidget {
   }
 }
 
-class _ShowPasswordButton extends StatelessWidget {
-  const _ShowPasswordButton({required this.value, required this.onChanged});
+class ShowPasswordButton extends StatelessWidget {
+  const ShowPasswordButton({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
 
   final bool value;
   final ValueChanged<bool> onChanged;
@@ -254,8 +268,8 @@ class _ShowPasswordButton extends StatelessWidget {
   }
 }
 
-class _UseActiveDirectoryCheckButton extends ConsumerWidget {
-  const _UseActiveDirectoryCheckButton();
+class UseActiveDirectoryCheckButton extends ConsumerWidget {
+  const UseActiveDirectoryCheckButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -287,8 +301,8 @@ class _UseActiveDirectoryCheckButton extends ConsumerWidget {
   }
 }
 
-class _AutoLoginSwitch extends ConsumerWidget {
-  const _AutoLoginSwitch();
+class AutoLoginSwitch extends ConsumerWidget {
+  const AutoLoginSwitch({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_page.dart
@@ -4,12 +4,10 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/widgets.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../l10n.dart';
 import 'advanced_setup_model.dart';
-
-part 'advanced_setup_widgets.dart';
+import 'advanced_setup_widgets.dart';
 
 /// WSL Advanced setup page.
 ///
@@ -63,17 +61,17 @@ class _AdvancedSetupPageState extends State<AdvancedSetupPage> {
           children: <Widget>[
             Padding(
               padding: fieldPadding,
-              child: _MountLocationFormField(fieldWidth: fieldWidth),
+              child: MountLocationFormField(fieldWidth: fieldWidth),
             ),
             const SizedBox(height: kContentSpacing),
             Padding(
               padding: fieldPadding,
-              child: _MountOptionFormField(fieldWidth: fieldWidth),
+              child: MountOptionFormField(fieldWidth: fieldWidth),
             ),
             const SizedBox(height: kContentSpacing * 2),
-            const _HostGenerationCheckButton(),
+            const HostGenerationCheckButton(),
             const SizedBox(height: kContentSpacing),
-            const _ResolvConfGenerationCheckButton(),
+            const ResolvConfGenerationCheckButton(),
           ],
         );
       }),

--- a/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/advanced_setup/advanced_setup_widgets.dart
@@ -1,7 +1,14 @@
-part of 'advanced_setup_page.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+import 'package:ubuntu_wsl_setup/l10n.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
-class _MountLocationFormField extends StatelessWidget {
-  const _MountLocationFormField({required this.fieldWidth});
+import 'advanced_setup_model.dart';
+
+class MountLocationFormField extends StatelessWidget {
+  const MountLocationFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -28,8 +35,8 @@ class _MountLocationFormField extends StatelessWidget {
   }
 }
 
-class _MountOptionFormField extends StatelessWidget {
-  const _MountOptionFormField({required this.fieldWidth});
+class MountOptionFormField extends StatelessWidget {
+  const MountOptionFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -52,8 +59,8 @@ class _MountOptionFormField extends StatelessWidget {
   }
 }
 
-class _HostGenerationCheckButton extends StatelessWidget {
-  const _HostGenerationCheckButton();
+class HostGenerationCheckButton extends StatelessWidget {
+  const HostGenerationCheckButton({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -80,8 +87,8 @@ class _HostGenerationCheckButton extends StatelessWidget {
   }
 }
 
-class _ResolvConfGenerationCheckButton extends StatelessWidget {
-  const _ResolvConfGenerationCheckButton();
+class ResolvConfGenerationCheckButton extends StatelessWidget {
+  const ResolvConfGenerationCheckButton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:form_field_validator/form_field_validator.dart';
 import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -10,8 +9,7 @@ import 'package:ubuntu_wizard/widgets.dart';
 
 import '../../l10n.dart';
 import 'profile_setup_model.dart';
-
-part 'profile_setup_widgets.dart';
+import 'profile_setup_widgets.dart';
 
 /// WSL Profile setup page.
 ///
@@ -75,26 +73,26 @@ class _ProfileSetupPageState extends State<ProfileSetupPage> {
           children: <Widget>[
             Padding(
               padding: fieldPadding,
-              child: _RealNameFormField(fieldWidth: fieldWidth),
+              child: RealNameFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _UsernameFormField(fieldWidth: fieldWidth),
+              child: UsernameFormField(fieldWidth: fieldWidth),
             ),
             const SizedBox(height: kContentSpacing),
             Padding(
               padding: fieldPadding,
-              child: _PasswordFormField(fieldWidth: fieldWidth),
+              child: PasswordFormField(fieldWidth: fieldWidth),
             ),
             Padding(
               padding: fieldPadding,
-              child: _ConfirmPasswordFormField(fieldWidth: fieldWidth),
+              child: ConfirmPasswordFormField(fieldWidth: fieldWidth),
             ),
             // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
             //       See [ProfileSetupModel.showAdvancedOptions] for more details.
             //
             // const SizedBox(height: kContentSpacing),
-            // const _ShowAdvancedOptionsCheckButton(),
+            // const ShowAdvancedOptionsCheckButton(),
           ],
         );
       }),

--- a/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
+++ b/packages/ubuntu_wsl_setup/lib/pages/profile_setup/profile_setup_widgets.dart
@@ -1,7 +1,15 @@
-part of 'profile_setup_page.dart';
+import 'package:flutter/material.dart';
+import 'package:form_field_validator/form_field_validator.dart';
+import 'package:provider/provider.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/utils.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+import 'package:ubuntu_wsl_setup/l10n.dart';
 
-class _RealNameFormField extends StatelessWidget {
-  const _RealNameFormField({required this.fieldWidth});
+import 'profile_setup_model.dart';
+
+class RealNameFormField extends StatelessWidget {
+  const RealNameFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -46,8 +54,8 @@ extension UsernameValidationL10n on UsernameValidation {
   }
 }
 
-class _UsernameFormField extends StatelessWidget {
-  const _UsernameFormField({required this.fieldWidth});
+class UsernameFormField extends StatelessWidget {
+  const UsernameFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -84,8 +92,8 @@ class _UsernameFormField extends StatelessWidget {
   }
 }
 
-class _PasswordFormField extends StatelessWidget {
-  const _PasswordFormField({required this.fieldWidth});
+class PasswordFormField extends StatelessWidget {
+  const PasswordFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -115,8 +123,8 @@ class _PasswordFormField extends StatelessWidget {
   }
 }
 
-class _ConfirmPasswordFormField extends StatelessWidget {
-  const _ConfirmPasswordFormField({required this.fieldWidth});
+class ConfirmPasswordFormField extends StatelessWidget {
+  const ConfirmPasswordFormField({super.key, required this.fieldWidth});
 
   final double? fieldWidth;
 
@@ -150,8 +158,8 @@ class _ConfirmPasswordFormField extends StatelessWidget {
 // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
 //       See [ProfileSetupModel.showAdvancedOptions] for more details.
 //
-// class _ShowAdvancedOptionsCheckButton extends StatelessWidget {
-//   const _ShowAdvancedOptionsCheckButton();
+// class ShowAdvancedOptionsCheckButton extends StatelessWidget {
+//   const ShowAdvancedOptionsCheckButton({super.key});
 
 //   @override
 //   Widget build(BuildContext context) {


### PR DESCRIPTION
There was a time when UDI had the `public_member_api_docs` lint enabled. As a consequence of that, this dirty little trick was used to make it possible to move widgets into separate files without having to write full-blown docs for every single member just to pass the CI. :)