### PR TITLE
refactor(welcome): move avatar asset pre-caching

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -21,7 +21,6 @@ import 'routes.dart';
 import 'services.dart';
 import 'slides.dart';
 import 'theme.dart';
-import 'widgets.dart';
 
 export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
 export 'slides.dart';
@@ -176,11 +175,6 @@ class _UbuntuDesktopInstallerAppState extends State<UbuntuDesktopInstallerApp> {
       YaruWindow.of(context).setClosable(status?.isInstalling != true);
       setState(() => _subiquityStatus = status);
     });
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      MascotAvatar.precacheAsset(context);
-    });
   }
 
   @override
@@ -306,7 +300,7 @@ class _UbuntuDesktopInstallerWizard extends ConsumerWidget {
           Routes.welcome: WizardRoute(
             builder: (_) => const WelcomePage(),
             userData: InstallationStep.locale.index,
-            onLoad: (_) => WelcomePage.load(ref),
+            onLoad: (_) => WelcomePage.load(context, ref),
           ),
         Routes.rst: WizardRoute(
           builder: (_) => const RstPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_wizard/constants.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -16,8 +17,11 @@ export 'welcome_model.dart' show Option;
 class WelcomePage extends ConsumerWidget {
   const WelcomePage({super.key});
 
-  static Future<bool> load(WidgetRef ref) {
-    return ref.read(welcomeModelProvider).init().then((_) => true);
+  static Future<bool> load(BuildContext context, WidgetRef ref) {
+    return Future.wait([
+      ref.read(welcomeModelProvider).init(),
+      MascotAvatar.precacheAsset(context),
+    ]).then((_) => true);
   }
 
   @override


### PR DESCRIPTION
It's a welcome page-specific action so move it to where the welcome page is loaded instead of triggering a post-frame callback higher up in the installer wizard, and "leaking" the future in a way that it cannot be awaited.

Ref: #1736