### PR TITLE
chore(ci): add jira synchronization

### DIFF
--- a/.github/sync-gh-jira.yaml
+++ b/.github/sync-gh-jira.yaml
@@ -1,0 +1,12 @@
+name: Sync GitHub issues to Jira
+on: [issues, issue_comment]
+
+jobs:
+  sync-issues:
+    name: Sync issues to Jira
+    runs-on: ubuntu-latest
+    steps:
+      - uses: canonical/sync-issues-github-jira@v1
+        with:
+          webhook-url: ${{ secrets.JIRA_WEBHOOK_URL }}
+          component: 'S-Flutter'


### PR DESCRIPTION
Adds jira synchronization using https://github.com/canonical/sync-issues-github-jira.
