### PR TITLE
ci: specify path filters for mocks & l10n

### DIFF
--- a/.github/scripts/check-outdated-files.sh
+++ b/.github/scripts/check-outdated-files.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ -n "$(git status --porcelain)" ]; then
-  git diff
-  for f in $(git ls-files --modified); do
+  git diff -- ':!**/pubspec.lock'
+  for f in $(git ls-files --modified -- ':!**/pubspec.lock'); do
     echo "::warning ::$f may be outdated"
   done
   for f in $(git ls-files --others --exclude-standard); do

--- a/.github/scripts/check-outdated-files.sh
+++ b/.github/scripts/check-outdated-files.sh
@@ -2,11 +2,15 @@
 
 if [ -n "$(git status --porcelain)" ]; then
   git diff -- ':!**/pubspec.lock'
-  for f in $(git ls-files --modified -- ':!**/pubspec.lock'); do
+  outdated=$(git ls-files --modified -- ':!**/pubspec.lock')
+  for f in $outdated; do
     echo "::warning ::$f may be outdated"
   done
-  for f in $(git ls-files --others --exclude-standard); do
+  untracked=$(git ls-files --others --exclude-standard)
+  for f in $untracked; do
     echo "::warning ::$f may be untracked"
   done
-  exit 1
+  if [ -n "$outdated" ] || [ -n "$untracked" ]; then
+    exit 1
+  fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         title: 'chore: regenerate mocks'
         commit-message: 'chore: regenerate mocks'
         branch: create-pull-request/mocks
+        delete-branch: true
 
   l10n:
     runs-on: ubuntu-22.04
@@ -87,6 +88,7 @@ jobs:
         title: 'chore: regenerate l10n'
         commit-message: 'chore: regenerate l10n'
         branch: create-pull-request/l10n
+        delete-branch: true
 
   snap:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       if: github.event_name == 'push'
       uses: peter-evans/create-pull-request@v5
       with:
+        add-paths: '**/*.mocks.dart'
         title: 'chore: regenerate mocks'
         commit-message: 'chore: regenerate mocks'
         branch: create-pull-request/mocks
@@ -82,6 +83,7 @@ jobs:
       if: github.event_name == 'push'
       uses: peter-evans/create-pull-request@v5
       with:
+        add-paths: '**/l10n/*.dart'
         title: 'chore: regenerate l10n'
         commit-message: 'chore: regenerate l10n'
         branch: create-pull-request/l10n

--- a/.github/workflows/wsl.yaml
+++ b/.github/workflows/wsl.yaml
@@ -28,13 +28,13 @@ jobs:
         run: flutter pub upgrade
 
       - name: Create PR
+        if: github.event_name == 'push'
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: packages/ubuntu_wsl_setup/pubspec.lock
           title: 'chore: update WSL pubspec.lock'
           commit-message: 'chore: update WSL pubspec.lock'
-          base: ${{ github.head_ref || github.ref_name }}
-          branch: WSL-pubspec-${{ github.head_ref || github.ref_name }}
+          branch: create-pull-request/wsl-pubspec
           delete-branch: true
 
       - name: Build Windows Target


### PR DESCRIPTION
We've checked in `ubuntu_wsl_setup/pubspec.yaml` in:
- #2026 

The idea was to make the CI keep the lock file up to date but it resulted in the regenerated lock file being submitted as mock and l10n:

- #2031
- #2033

vs.

- #2032