### PR TITLE
refactor(installer): remove unsupported --initial-route

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -100,7 +100,6 @@ Future<void> runInstallerApp(
           child: UbuntuDesktopInstallerApp(
             flavor: flavor,
             home: UbuntuDesktopInstallerWizard(
-              initialRoute: options['initial-route'],
               welcome: options['welcome'],
             ),
           ),
@@ -233,11 +232,9 @@ enum InstallationStep {
 class UbuntuDesktopInstallerWizard extends ConsumerStatefulWidget {
   const UbuntuDesktopInstallerWizard({
     super.key,
-    this.initialRoute,
     this.welcome,
   });
 
-  final String? initialRoute;
   final bool? welcome;
 
   @override
@@ -274,23 +271,19 @@ class _UbuntuDesktopInstallerWizardState
     }
     return _subiquityStatus?.interactive == false
         ? _UbuntuDesktopAutoinstallWizard(status: _subiquityStatus)
-        : _UbuntuDesktopInstallWizard(
-            initialRoute: widget.initialRoute,
-            welcome: widget.welcome,
-          );
+        : _UbuntuDesktopInstallWizard(welcome: widget.welcome);
   }
 }
 
 class _UbuntuDesktopInstallWizard extends ConsumerWidget {
-  const _UbuntuDesktopInstallWizard({this.initialRoute, this.welcome});
+  const _UbuntuDesktopInstallWizard({this.welcome});
 
-  final String? initialRoute;
   final bool? welcome;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Wizard(
-      initialRoute: initialRoute ?? Routes.initial,
+      initialRoute: Routes.initial,
       userData: InstallationStep.values.length,
       routes: <String, WizardRoute>{
         Routes.loading: WizardRoute(

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -78,7 +78,6 @@ ArgResults? parseCommandLine(
   parser.addFlag('dry-run',
       defaultsTo: io.Platform.environment['LIVE_RUN'] != '1',
       help: 'Run Subiquity server in dry-run mode');
-  parser.addOption('initial-route', hide: true);
   onPopulateOptions?.call(parser);
 
   ArgResults? options;

--- a/packages/ubuntu_wsl_setup/lib/args_common.dart
+++ b/packages/ubuntu_wsl_setup/lib/args_common.dart
@@ -11,6 +11,7 @@ feeds the installer with partial information to prefill the
 screens, yet allowing user to overwrite any of those during setup.
   ''',
   );
+  parser.addOption('initial-route', hide: true);
 }
 
 List<String>? serverArgsFromOptions(ArgResults options) {


### PR DESCRIPTION
The hidden `--initial-route` argument which was previously used for testing is no longer supported because `WizardRoute.onLoad` would not get called. Remove handling from UDI and demote the command-line option from the shared package to WSL setup.