### PR TITLE
refactor: move Subiquity-specific --dry-run CLI argument

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -28,6 +28,9 @@ Future<void> runInstallerApp(
   List<WidgetBuilder>? slides,
 }) async {
   final options = parseCommandLine(args, onPopulateOptions: (parser) {
+    parser.addFlag('dry-run',
+        defaultsTo: Platform.environment['LIVE_RUN'] != '1',
+        help: 'Run Subiquity server in dry-run mode');
     parser.addOption('machine-config',
         valueHelp: 'path',
         defaultsTo: 'examples/simple.json',
@@ -41,7 +44,7 @@ Future<void> runInstallerApp(
   })!;
   setupLogger(options, path: '/var/log/installer');
 
-  final bool liveRun = isLiveRun(options);
+  final liveRun = options['dry-run'] != true;
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final subiquityPath = await getSubiquityPath()
       .then((dir) => Directory(dir).existsSync() ? dir : null);

--- a/packages/ubuntu_wizard/lib/app.dart
+++ b/packages/ubuntu_wizard/lib/app.dart
@@ -13,10 +13,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 /// @internal
 final log = Logger(_appName);
 
-bool isLiveRun(ArgResults? options) {
-  return options != null && options['dry-run'] != true;
-}
-
 /// Initializes and runs the given [app].
 ///
 /// Optionally, the Subiquity client and server may be overridden for building
@@ -75,9 +71,6 @@ ArgResults? parseCommandLine(
 }) {
   final parser = ArgParser();
   parser.addFlag('help', abbr: 'h', negatable: false);
-  parser.addFlag('dry-run',
-      defaultsTo: io.Platform.environment['LIVE_RUN'] != '1',
-      help: 'Run Subiquity server in dry-run mode');
   onPopulateOptions?.call(parser);
 
   ArgResults? options;

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -93,6 +93,9 @@ void main() {
 
     final dryRun = parseCommandLine(
       ['--dry-run'],
+      onPopulateOptions: (parser) {
+        parser.addFlag('dry-run');
+      },
       exit: (exitCode) => didExit = exitCode,
     );
     expect(didExit, isNull);

--- a/packages/ubuntu_wsl_setup/lib/args_common.dart
+++ b/packages/ubuntu_wsl_setup/lib/args_common.dart
@@ -1,6 +1,11 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 
 void addCommonCliOptions(ArgParser parser) {
+  parser.addFlag('dry-run',
+      defaultsTo: Platform.environment['LIVE_RUN'] != '1',
+      help: 'Run Subiquity server in dry-run mode');
   parser.addFlag('reconfigure');
   parser.addOption(
     'prefill',

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -27,7 +27,7 @@ Future<void> main(List<String> args) async {
   final appModel = ValueNotifier<AppModel>(
     AppModel(routeFromOptions: options['initial-route']),
   );
-  final liveRun = isLiveRun(options);
+  final liveRun = options['dry-run'] != true;
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final subiquityPath = await getSubiquityPath()
       .then((dir) => Directory(dir).existsSync() ? dir : null);

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -38,7 +38,7 @@ Future<void> main(List<String> args) async {
   })!;
   setupLogger(options);
 
-  final liveRun = isLiveRun(options);
+  final liveRun = options['dry-run'] != true;
   final isReconf = options['reconfigure'] == true;
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final tcpService = TcpSocketService();


### PR DESCRIPTION
The desktop installer and WSL setup both have a `--dry-run` argument which is why it was included in the shared command-line parsing method but the same does not apply to non-Subiquity-based wizards...