### PR TITLE
refactor(wsl): add runWslSetupApp()

### DIFF
--- a/packages/ubuntu_wsl_setup/lib/app.dart
+++ b/packages/ubuntu_wsl_setup/lib/app.dart
@@ -1,14 +1,79 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:subiquity_client/subiquity_server.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wsl_setup/app_model.dart';
 import 'package:ubuntu_wsl_setup/splash_screen.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'installing_state.dart';
+import 'is_locale_set.dart';
 import 'l10n.dart';
 import 'routes.dart';
 import 'wizard.dart';
+
+final log = Logger(p.basename(Platform.resolvedExecutable));
+
+Future<void> runWslSetupApp({
+  required ValueNotifier<AppModel> appModel,
+  required List<String>? serverArgs,
+  required Map<String, String>? serverEnvironment,
+}) async {
+  final subiquityClient = getService<SubiquityClient>();
+  final subiquityServer = getService<SubiquityServer>();
+  final subiquityMonitor = getService<SubiquityStatusMonitor>();
+
+  subiquityServer
+      .start(args: serverArgs, environment: serverEnvironment)
+      .then((endpoint) async {
+    subiquityClient.open(endpoint);
+    return subiquityMonitor.start(endpoint);
+  });
+
+  return runZonedGuarded(() async {
+    FlutterError.onError = (error) {
+      log.error('Unhandled exception', error.exception, error.stack);
+    };
+
+    final window = await YaruWindow.ensureInitialized();
+    await window.onClose(() async {
+      await subiquityMonitor.stop();
+      await subiquityClient.close();
+      await subiquityServer.stop();
+      return true;
+    });
+
+    await setupAppLocalizations();
+
+    runApp(ValueListenableProvider<AppModel>.value(
+      value: appModel,
+      child: const UbuntuWslSetupApp(),
+    ));
+
+    await subiquityClient.getVariant().then((value) {
+      if (value == Variant.WSL_SETUP) {
+        isLocaleSet(subiquityClient).then(
+          (isSet) => appModel.value = appModel.value
+              .copyWith(variant: value, languageAlreadySet: isSet),
+        );
+        final subiquityMonitor = getService<SubiquityStatusMonitor>();
+        subiquityMonitor.onStatusChanged.listen((status) {
+          window.setClosable(status?.state.isInstalling != true);
+        });
+      } else {
+        appModel.value = appModel.value.copyWith(variant: value);
+      }
+    });
+  }, (error, stack) => log.error('Unhandled exception', error, stack));
+}
 
 class UbuntuWslSetupApp extends StatelessWidget {
   const UbuntuWslSetupApp({

--- a/packages/ubuntu_wsl_setup/lib/main.dart
+++ b/packages/ubuntu_wsl_setup/lib/main.dart
@@ -1,19 +1,15 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_wizard/app.dart';
 import 'package:ubuntu_wizard/utils.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'app.dart';
 import 'app_model.dart';
 import 'args_common.dart';
-import 'installing_state.dart';
-import 'is_locale_set.dart';
 import 'services/language_fallback.dart';
 
 Future<void> main(List<String> args) async {
@@ -23,11 +19,8 @@ Future<void> main(List<String> args) async {
   })!;
   setupLogger(options);
 
-  final window = await YaruWindow.ensureInitialized();
-  final appModel = ValueNotifier<AppModel>(
-    AppModel(routeFromOptions: options['initial-route']),
-  );
   final liveRun = options['dry-run'] != true;
+  final isReconf = options['reconfigure'] == true;
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final subiquityPath = await getSubiquityPath()
       .then((dir) => Directory(dir).existsSync() ? dir : null);
@@ -37,40 +30,20 @@ Future<void> main(List<String> args) async {
     serverMode: serverMode,
     subiquityPath: subiquityPath,
   );
-  final serverArgs = serverArgsFromOptions(options);
 
   registerService(SubiquityClient.new);
   registerService(() => SubiquityServer(process: process, endpoint: endpoint));
   registerService(SubiquityStatusMonitor.new);
   registerService(UrlLauncher.new);
   registerService(LanguageFallbackService.linux);
-  await runWizardApp(
-    ValueListenableProvider<AppModel>.value(
-      value: appModel,
-      child: const UbuntuWslSetupApp(),
+
+  return runWslSetupApp(
+    appModel: ValueNotifier<AppModel>(
+      AppModel(routeFromOptions: options['initial-route']),
     ),
-    options: options,
-    subiquityClient: getService<SubiquityClient>(),
-    subiquityServer: getService<SubiquityServer>(),
-    subiquityMonitor: getService<SubiquityStatusMonitor>(),
-    serverArgs: serverArgs,
+    serverArgs: serverArgsFromOptions(options),
     serverEnvironment: {
-      if (!liveRun && options['reconfigure'] == true) 'DRYRUN_RECONFIG': 'true',
+      if (!liveRun && isReconf) 'DRYRUN_RECONFIG': 'true',
     },
   );
-  final subiquityClient = getService<SubiquityClient>();
-  await subiquityClient.getVariant().then((value) {
-    if (value == Variant.WSL_SETUP) {
-      isLocaleSet(subiquityClient).then(
-        (isSet) => appModel.value =
-            appModel.value.copyWith(variant: value, languageAlreadySet: isSet),
-      );
-      final subiquityMonitor = getService<SubiquityStatusMonitor>();
-      subiquityMonitor.onStatusChanged.listen((status) {
-        window.setClosable(status?.state.isInstalling != true);
-      });
-    } else {
-      appModel.value = appModel.value.copyWith(variant: value);
-    }
-  });
 }

--- a/packages/ubuntu_wsl_setup/lib/main_win.dart
+++ b/packages/ubuntu_wsl_setup/lib/main_win.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
-import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -14,15 +13,11 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'app.dart';
 import 'app_model.dart';
 import 'args_common.dart';
-import 'installing_state.dart';
-import 'is_locale_set.dart';
 import 'routes.dart';
 import 'services/journal.dart';
 import 'services/named_event.dart';
 
 Future<void> main(List<String> args) async {
-  WidgetsFlutterBinding.ensureInitialized();
-  final window = await YaruWindow.ensureInitialized();
   final options = parseCommandLine(args, onPopulateOptions: (parser) {
     addCommonCliOptions(parser);
     parser.addOption(
@@ -43,6 +38,7 @@ Future<void> main(List<String> args) async {
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final tcpService = TcpSocketService();
   final socketHolder = await tcpService.getRandomPortSocket();
+  final window = await YaruWindow.ensureInitialized();
 
   final events = isReconf
       ? null
@@ -77,7 +73,6 @@ Future<void> main(List<String> args) async {
     onProcessStart: socketHolder.close,
   );
 
-  final serverArgs = serverArgsFromOptions(options);
   registerService(SubiquityClient.new);
   registerService(() => SubiquityServer(process: process, endpoint: endpoint));
   registerService(SubiquityStatusMonitor.new);
@@ -91,39 +86,16 @@ Future<void> main(List<String> args) async {
   if (!isReconf && options['initial-route'] == null) {
     initialRoute = Routes.installationSlides;
   }
-  final appModel = ValueNotifier<AppModel>(
-    AppModel(routeFromOptions: initialRoute, showSplashScreen: isReconf),
-  );
 
-  await runWizardApp(
-    ValueListenableProvider<AppModel>.value(
-      value: appModel,
-      child: const UbuntuWslSetupApp(),
+  return runWslSetupApp(
+    appModel: ValueNotifier<AppModel>(
+      AppModel(routeFromOptions: initialRoute, showSplashScreen: isReconf),
     ),
-    options: options,
-    subiquityClient: getService<SubiquityClient>(),
-    subiquityServer: getService<SubiquityServer>(),
-    subiquityMonitor: getService<SubiquityStatusMonitor>(),
-    serverArgs: serverArgs,
+    serverArgs: serverArgsFromOptions(options),
     serverEnvironment: {
       if (!liveRun && isReconf) 'DRYRUN_RECONFIG': 'true',
     },
   );
-  final subiquityClient = getService<SubiquityClient>();
-  await subiquityClient.getVariant().then((value) {
-    if (value == Variant.WSL_SETUP) {
-      isLocaleSet(subiquityClient).then(
-        (isSet) => appModel.value =
-            appModel.value.copyWith(variant: value, languageAlreadySet: isSet),
-      );
-      final subiquityMonitor = getService<SubiquityStatusMonitor>();
-      subiquityMonitor.onStatusChanged.listen((status) {
-        window.setClosable(status?.state.isInstalling != true);
-      });
-    } else {
-      appModel.value = appModel.value.copyWith(variant: value);
-    }
-  });
 }
 
 class WslSetupEvents {


### PR DESCRIPTION
This shares some more logic between the two WSL entry-points and removes the use of `runWizardApp()` which is going away because there are non-Subiquity-based wizards coming and the Subiquity dependency in the shared `ubuntu_wizard` package is being removed.