### PR TITLE
fix(test): revise pumpUntil()

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -557,6 +557,8 @@ Future<void> expectPage(
   String Function(AppLocalizations lang) title,
 ) async {
   await tester.pumpUntil(find.byType(page));
+  await tester.pump(kThemeAnimationDuration);
+
   expect(find.byType(page), findsOneWidget);
   expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);
 }


### PR DESCRIPTION
`IntegrationTester.pumpUntil()` has started randomly failing in the CI quite often lately. 