### PR TITLE
refactor(installer): remove UdiApp in favor of WizardApp

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -3,12 +3,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import '../test/test_utils.dart';
@@ -568,7 +568,7 @@ Future<void> takeScreenshot(WidgetTester tester, String screenshot) async {
   await tester.pumpAndSettle();
 
   await expectLater(
-    find.byType(UbuntuDesktopInstallerApp),
+    find.byType(WizardApp),
     matchesGoldenFile('screenshots/$screenshot.png'),
   );
 }

--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -112,8 +112,14 @@ Future<void> runInstallerApp(
     runApp(ProviderScope(
       child: SlidesContext(
         slides: slides ?? defaultSlides,
-        child: UbuntuDesktopInstallerApp(
-          flavor: flavor,
+        child: WizardApp(
+          appName: 'ubuntu_desktop_installer',
+          flavor: flavor ?? const FlavorData(name: 'Ubuntu'),
+          onGenerateTitle: (context, flavor) {
+            return AppLocalizations.of(context).windowTitle(flavor.name);
+          },
+          localizationsDelegates: localizationsDelegates,
+          supportedLocales: supportedLocales,
           home: UbuntuDesktopInstallerWizard(
             welcome: options['welcome'],
           ),
@@ -153,41 +159,6 @@ Future<bool> _closeInstallerApp() async {
   await getService<SubiquityServer>().stop();
   await getService<DesktopService>().close();
   return true;
-}
-
-class UbuntuDesktopInstallerApp extends StatelessWidget {
-  UbuntuDesktopInstallerApp({
-    super.key,
-    FlavorData? flavor,
-    required this.home,
-  }) : flavor = flavor ?? defaultFlavor;
-
-  final FlavorData flavor;
-  final Widget home;
-
-  static FlavorData get defaultFlavor {
-    return const FlavorData(name: 'Ubuntu');
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return WizardApp(
-      appName: 'ubuntu_desktop_installer',
-      flavor: flavor,
-      onGenerateTitle: (context, flavor) {
-        final lang = AppLocalizations.of(context);
-        final window = YaruWindow.of(context);
-        window.setTitle(lang.windowTitle(flavor.name));
-        return lang.appTitle;
-      },
-      localizationsDelegates: <LocalizationsDelegate>[
-        ...localizationsDelegates,
-        ...?flavor.localizationsDelegates,
-      ],
-      supportedLocales: supportedLocales,
-      home: home,
-    );
-  }
 }
 
 enum InstallationStep {

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -6,9 +6,11 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/installer.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
+import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import 'install/test_install.dart';
@@ -127,7 +129,10 @@ extension on WidgetTester {
       child: InheritedLocale(
         child: SlidesContext(
           slides: [(_) => const SizedBox.shrink()],
-          child: UbuntuDesktopInstallerApp(
+          child: WizardApp(
+            appName: 'ubuntu_desktop_installer',
+            localizationsDelegates: localizationsDelegates,
+            supportedLocales: supportedLocales,
             home: const UbuntuDesktopInstallerWizard(),
           ),
         ),


### PR DESCRIPTION
This change removes the last remaining bits of the old monolithic `UbuntuDesktopInstallerApp` and uses the new more generic `WizardApp` directly to eliminate an unnecessary layer of indirection, property drilling, and some minor code duplication, too, because `WizardApp` takes care handling localization delegates for flavors.