### PR TITLE
refactor(installer): add view model for the top-level wizard

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
@@ -13,13 +12,13 @@ import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'installer/installer_wizard.dart';
 import 'l10n.dart';
-import 'pages.dart';
-import 'routes.dart';
 import 'services.dart';
 import 'slides.dart';
 
 export 'package:ubuntu_wizard/widgets.dart' show FlavorData;
+export 'installer/installer_wizard.dart';
 export 'slides.dart';
 
 Future<void> runInstallerApp(
@@ -120,7 +119,7 @@ Future<void> runInstallerApp(
           },
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
-          home: UbuntuDesktopInstallerWizard(
+          home: InstallerWizard(
             welcome: options['welcome'],
           ),
         ),
@@ -159,207 +158,4 @@ Future<bool> _closeInstallerApp() async {
   await getService<SubiquityServer>().stop();
   await getService<DesktopService>().close();
   return true;
-}
-
-enum InstallationStep {
-  locale,
-  keyboard,
-  network,
-  source,
-  type,
-  filesystem,
-  timezone,
-  identity,
-  theme,
-}
-
-class UbuntuDesktopInstallerWizard extends ConsumerStatefulWidget {
-  const UbuntuDesktopInstallerWizard({
-    super.key,
-    this.welcome,
-  });
-
-  final bool? welcome;
-
-  @override
-  ConsumerState<UbuntuDesktopInstallerWizard> createState() =>
-      _UbuntuDesktopInstallerWizardState();
-}
-
-class _UbuntuDesktopInstallerWizardState
-    extends ConsumerState<UbuntuDesktopInstallerWizard> {
-  ApplicationStatus? _subiquityStatus;
-  StreamSubscription<ApplicationStatus?>? _subiquityStatusChange;
-
-  @override
-  void initState() {
-    super.initState();
-
-    final client = getService<SubiquityClient>();
-    _subiquityStatusChange = client.monitorStatus().listen((status) {
-      YaruWindow.of(context).setClosable(status?.isInstalling != true);
-      setState(() => _subiquityStatus = status);
-    });
-  }
-
-  @override
-  void dispose() {
-    _subiquityStatusChange?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_subiquityStatus?.state == ApplicationState.ERROR) {
-      return const _UbuntuDesktopErrorWizard();
-    }
-    return _subiquityStatus?.interactive == false
-        ? _UbuntuDesktopAutoinstallWizard(status: _subiquityStatus)
-        : _UbuntuDesktopInstallWizard(welcome: widget.welcome);
-  }
-}
-
-class _UbuntuDesktopInstallWizard extends ConsumerWidget {
-  const _UbuntuDesktopInstallWizard({this.welcome});
-
-  final bool? welcome;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Wizard(
-      initialRoute: Routes.initial,
-      userData: InstallationStep.values.length,
-      routes: <String, WizardRoute>{
-        Routes.loading: WizardRoute(
-          builder: (_) => const LoadingPage(),
-        ),
-        Routes.locale: WizardRoute(
-          builder: (_) => const LocalePage(),
-          userData: InstallationStep.locale.index,
-          onLoad: (_) => LocalePage.load(context, ref),
-        ),
-        if (welcome == true)
-          Routes.welcome: WizardRoute(
-            builder: (_) => const WelcomePage(),
-            userData: InstallationStep.locale.index,
-            onLoad: (_) => WelcomePage.load(context, ref),
-          ),
-        Routes.rst: WizardRoute(
-          builder: (_) => const RstPage(),
-          onLoad: (_) => RstPage.load(ref),
-        ),
-        Routes.keyboard: WizardRoute(
-          builder: (_) => const KeyboardPage(),
-          userData: InstallationStep.keyboard.index,
-          onLoad: (settings) => KeyboardPage.load(ref),
-        ),
-        Routes.network: WizardRoute(
-          builder: (_) => const NetworkPage(),
-          userData: InstallationStep.network.index,
-          onLoad: (_) => NetworkPage.load(ref),
-        ),
-        Routes.source: WizardRoute(
-          builder: (_) => const SourceWizard(),
-          userData: InstallationStep.source.index,
-          onLoad: (_) => SourcePage.load(ref),
-        ),
-        Routes.secureBoot: WizardRoute(
-          builder: (_) => const SecureBootPage(),
-          userData: InstallationStep.type.index,
-          onLoad: (_) => SecureBootPage.load(ref),
-        ),
-        Routes.filesystem: WizardRoute(
-          builder: (_) => const FilesystemPage(),
-          userData: InstallationStep.filesystem.index,
-          onLoad: (_) => FilesystemPage.load(ref),
-        ),
-        Routes.confirm: WizardRoute(
-          builder: (_) => const ConfirmPage(),
-          userData: InstallationStep.filesystem.index,
-          onLoad: (_) => ConfirmPage.load(ref),
-        ),
-        Routes.timezone: WizardRoute(
-          builder: (_) => const TimezonePage(),
-          userData: InstallationStep.timezone.index,
-          onLoad: (_) => TimezonePage.load(context, ref),
-        ),
-        Routes.identity: WizardRoute(
-          builder: (_) => const IdentityPage(),
-          userData: InstallationStep.identity.index,
-          onLoad: (_) => IdentityPage.load(ref),
-          onNext: (settings) => settings.arguments == true
-              ? Routes.activeDirectory
-              : Routes.theme,
-        ),
-        Routes.activeDirectory: WizardRoute(
-          builder: (_) => const ActiveDirectoryPage(),
-          userData: InstallationStep.identity.index,
-          onLoad: (_) => ActiveDirectoryPage.load(ref),
-        ),
-        Routes.theme: WizardRoute(
-          builder: (_) => const ThemePage(),
-          userData: InstallationStep.theme.index,
-        ),
-        Routes.install: WizardRoute(
-          builder: (_) => const InstallPage(),
-          onLoad: (_) => InstallPage.load(context, ref),
-        ),
-      },
-      observers: [
-        _UbuntuDesktopInstallerWizardObserver(getService<TelemetryService>())
-      ],
-    );
-  }
-}
-
-class _UbuntuDesktopInstallerWizardObserver extends NavigatorObserver {
-  _UbuntuDesktopInstallerWizardObserver(this._telemetryService);
-
-  final TelemetryService _telemetryService;
-
-  @override
-  void didPush(Route route, Route? previousRoute) {
-    if (route.settings.name != null) {
-      _telemetryService.addStage(route.settings.name!.removePrefix('/'));
-    }
-  }
-}
-
-class _UbuntuDesktopAutoinstallWizard extends StatelessWidget {
-  const _UbuntuDesktopAutoinstallWizard({this.status});
-
-  final ApplicationStatus? status;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wizard(
-      routes: <String, WizardRoute>{
-        Routes.loading: WizardRoute(
-          builder: (_) => const LoadingPage(),
-        ),
-        Routes.confirm: WizardRoute(
-          builder: (_) => const ConfirmPage(),
-          onLoad: (_) => status?.isInstalling != true,
-        ),
-        Routes.install: WizardRoute(
-          builder: (_) => const InstallPage(),
-        ),
-      },
-    );
-  }
-}
-
-class _UbuntuDesktopErrorWizard extends StatelessWidget {
-  const _UbuntuDesktopErrorWizard();
-
-  @override
-  Widget build(BuildContext context) {
-    return Wizard(
-      routes: <String, WizardRoute>{
-        Routes.install: WizardRoute(
-          builder: (_) => const InstallPage(),
-        ),
-      },
-    );
-  }
 }

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_model.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+
+final installerModelProvider = ChangeNotifierProvider(
+  (_) => InstallerModel(getService<SubiquityClient>()),
+);
+
+class InstallerModel extends SafeChangeNotifier {
+  InstallerModel(this._client);
+
+  final SubiquityClient _client;
+
+  ApplicationStatus? _status;
+  StreamSubscription<ApplicationStatus?>? _statusChange;
+
+  ApplicationStatus? get status => _status;
+  bool get isInstalling => status?.isInstalling == true;
+
+  Future<void> init() async {
+    _statusChange = _client.monitorStatus().listen((status) {
+      _status = status;
+      notifyListeners();
+    });
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _statusChange?.cancel();
+    _statusChange = null;
+    super.dispose();
+  }
+}

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -1,0 +1,201 @@
+import 'package:dartx/dartx.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/pages.dart';
+import 'package:ubuntu_desktop_installer/routes.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import 'installer_model.dart';
+
+enum InstallationStep {
+  locale,
+  keyboard,
+  network,
+  source,
+  type,
+  filesystem,
+  timezone,
+  identity,
+  theme,
+}
+
+class InstallerWizard extends ConsumerStatefulWidget {
+  const InstallerWizard({
+    super.key,
+    this.welcome,
+  });
+
+  final bool? welcome;
+
+  @override
+  ConsumerState<InstallerWizard> createState() => _InstallerWizardState();
+}
+
+class _InstallerWizardState extends ConsumerState<InstallerWizard> {
+  @override
+  void initState() {
+    super.initState();
+
+    final model = ref.read(installerModelProvider);
+    model
+      ..addListener(() => YaruWindow.setClosable(context, !model.isInstalling))
+      ..init();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = ref.watch(installerModelProvider.select((m) => m.status));
+    if (status?.state == ApplicationState.ERROR) {
+      return const _ErrorWizard();
+    }
+    return status?.interactive == false
+        ? _AutoinstallWizard(status: status)
+        : _InstallWizard(welcome: widget.welcome);
+  }
+}
+
+class _InstallWizard extends ConsumerWidget {
+  const _InstallWizard({this.welcome});
+
+  final bool? welcome;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Wizard(
+      initialRoute: Routes.initial,
+      userData: InstallationStep.values.length,
+      routes: <String, WizardRoute>{
+        Routes.loading: WizardRoute(
+          builder: (_) => const LoadingPage(),
+        ),
+        Routes.locale: WizardRoute(
+          builder: (_) => const LocalePage(),
+          userData: InstallationStep.locale.index,
+          onLoad: (_) => LocalePage.load(context, ref),
+        ),
+        if (welcome == true)
+          Routes.welcome: WizardRoute(
+            builder: (_) => const WelcomePage(),
+            userData: InstallationStep.locale.index,
+            onLoad: (_) => WelcomePage.load(context, ref),
+          ),
+        Routes.rst: WizardRoute(
+          builder: (_) => const RstPage(),
+          onLoad: (_) => RstPage.load(ref),
+        ),
+        Routes.keyboard: WizardRoute(
+          builder: (_) => const KeyboardPage(),
+          userData: InstallationStep.keyboard.index,
+          onLoad: (settings) => KeyboardPage.load(ref),
+        ),
+        Routes.network: WizardRoute(
+          builder: (_) => const NetworkPage(),
+          userData: InstallationStep.network.index,
+          onLoad: (_) => NetworkPage.load(ref),
+        ),
+        Routes.source: WizardRoute(
+          builder: (_) => const SourceWizard(),
+          userData: InstallationStep.source.index,
+          onLoad: (_) => SourcePage.load(ref),
+        ),
+        Routes.secureBoot: WizardRoute(
+          builder: (_) => const SecureBootPage(),
+          userData: InstallationStep.type.index,
+          onLoad: (_) => SecureBootPage.load(ref),
+        ),
+        Routes.filesystem: WizardRoute(
+          builder: (_) => const FilesystemPage(),
+          userData: InstallationStep.filesystem.index,
+          onLoad: (_) => FilesystemPage.load(ref),
+        ),
+        Routes.confirm: WizardRoute(
+          builder: (_) => const ConfirmPage(),
+          userData: InstallationStep.filesystem.index,
+          onLoad: (_) => ConfirmPage.load(ref),
+        ),
+        Routes.timezone: WizardRoute(
+          builder: (_) => const TimezonePage(),
+          userData: InstallationStep.timezone.index,
+          onLoad: (_) => TimezonePage.load(context, ref),
+        ),
+        Routes.identity: WizardRoute(
+          builder: (_) => const IdentityPage(),
+          userData: InstallationStep.identity.index,
+          onLoad: (_) => IdentityPage.load(ref),
+          onNext: (settings) => settings.arguments == true
+              ? Routes.activeDirectory
+              : Routes.theme,
+        ),
+        Routes.activeDirectory: WizardRoute(
+          builder: (_) => const ActiveDirectoryPage(),
+          userData: InstallationStep.identity.index,
+          onLoad: (_) => ActiveDirectoryPage.load(ref),
+        ),
+        Routes.theme: WizardRoute(
+          builder: (_) => const ThemePage(),
+          userData: InstallationStep.theme.index,
+        ),
+        Routes.install: WizardRoute(
+          builder: (_) => const InstallPage(),
+          onLoad: (_) => InstallPage.load(context, ref),
+        ),
+      },
+      observers: [_InstallerObserver(getService<TelemetryService>())],
+    );
+  }
+}
+
+class _InstallerObserver extends NavigatorObserver {
+  _InstallerObserver(this._telemetryService);
+
+  final TelemetryService _telemetryService;
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    if (route.settings.name != null) {
+      _telemetryService.addStage(route.settings.name!.removePrefix('/'));
+    }
+  }
+}
+
+class _AutoinstallWizard extends StatelessWidget {
+  const _AutoinstallWizard({this.status});
+
+  final ApplicationStatus? status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wizard(
+      routes: <String, WizardRoute>{
+        Routes.loading: WizardRoute(
+          builder: (_) => const LoadingPage(),
+        ),
+        Routes.confirm: WizardRoute(
+          builder: (_) => const ConfirmPage(),
+          onLoad: (_) => status?.isInstalling != true,
+        ),
+        Routes.install: WizardRoute(
+          builder: (_) => const InstallPage(),
+        ),
+      },
+    );
+  }
+}
+
+class _ErrorWizard extends StatelessWidget {
+  const _ErrorWizard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Wizard(
+      routes: <String, WizardRoute>{
+        Routes.install: WizardRoute(
+          builder: (_) => const InstallPage(),
+        ),
+      },
+    );
+  }
+}

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -133,7 +133,7 @@ extension on WidgetTester {
             appName: 'ubuntu_desktop_installer',
             localizationsDelegates: localizationsDelegates,
             supportedLocales: supportedLocales,
-            home: const UbuntuDesktopInstallerWizard(),
+            home: const InstallerWizard(),
           ),
         ),
       ),

--- a/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
@@ -323,7 +323,7 @@ extension on WidgetTester {
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
           theme: yaruLight,
-          home: UbuntuDesktopInstallerWizard(welcome: welcome),
+          home: InstallerWizard(welcome: welcome),
         ),
       ),
     );


### PR DESCRIPTION
So far, it controls the Subiquity status stream instead of doing it straight from the widget tree. Later on, this separation also helps in implementing the logic for semi-automated installations.