### PR TITLE
feat: add semi-automated autoinstall support

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -292,6 +292,23 @@ void main() {
     await testKeyboardPage(tester);
     await tester.pumpAndSettle();
   });
+
+  testWidgets('semi-automated autoinstall', (tester) async {
+    await app.main(<String>[
+      '--',
+      '--autoinstall=examples/autoinstall-interactive.yaml',
+    ]);
+    await tester.pumpAndSettle();
+
+    await testNetworkPage(tester);
+    await tester.pumpAndSettle();
+
+    await testConfirmPage(tester);
+    await tester.pumpAndSettle();
+
+    await testInstallPage(tester);
+    await tester.pumpAndSettle();
+  });
 }
 
 Future<void> verifyConfig({

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dartx/dartx.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -14,6 +15,7 @@ class InstallerModel extends SafeChangeNotifier {
 
   final SubiquityClient _client;
 
+  List<String>? _interactiveSections;
   ApplicationStatus? _status;
   StreamSubscription<ApplicationStatus?>? _statusChange;
 
@@ -21,10 +23,15 @@ class InstallerModel extends SafeChangeNotifier {
   bool get isInstalling => status?.isInstalling == true;
 
   Future<void> init() async {
+    _interactiveSections = await _client.getInteractiveSections();
     _statusChange = _client.monitorStatus().listen((status) {
       _status = status;
       notifyListeners();
     });
+  }
+
+  bool hasRoute(String route) {
+    return _interactiveSections?.contains(route.removePrefix('/')) != false;
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -64,6 +64,89 @@ class _InstallWizard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final preInstall = <String, WizardRoute>{
+      Routes.locale: WizardRoute(
+        builder: (_) => const LocalePage(),
+        userData: InstallationStep.locale.index,
+        onLoad: (_) => LocalePage.load(context, ref),
+      ),
+      if (welcome == true)
+        Routes.welcome: WizardRoute(
+          builder: (_) => const WelcomePage(),
+          userData: InstallationStep.locale.index,
+          onLoad: (_) => WelcomePage.load(context, ref),
+        ),
+      Routes.rst: WizardRoute(
+        builder: (_) => const RstPage(),
+        onLoad: (_) => RstPage.load(ref),
+      ),
+      Routes.keyboard: WizardRoute(
+        builder: (_) => const KeyboardPage(),
+        userData: InstallationStep.keyboard.index,
+        onLoad: (settings) => KeyboardPage.load(ref),
+      ),
+      Routes.network: WizardRoute(
+        builder: (_) => const NetworkPage(),
+        userData: InstallationStep.network.index,
+        onLoad: (_) => NetworkPage.load(ref),
+      ),
+      Routes.source: WizardRoute(
+        builder: (_) => const SourceWizard(),
+        userData: InstallationStep.source.index,
+        onLoad: (_) => SourcePage.load(ref),
+      ),
+      Routes.secureBoot: WizardRoute(
+        builder: (_) => const SecureBootPage(),
+        userData: InstallationStep.type.index,
+        onLoad: (_) => SecureBootPage.load(ref),
+      ),
+      Routes.storage: WizardRoute(
+        builder: (_) => const StorageWizard(),
+        userData: InstallationStep.storage.index,
+        onLoad: (_) => StorageWizard.load(ref),
+      ),
+    };
+
+    final postInstall = <String, WizardRoute>{
+      Routes.timezone: WizardRoute(
+        builder: (_) => const TimezonePage(),
+        userData: InstallationStep.timezone.index,
+        onLoad: (_) => TimezonePage.load(context, ref),
+      ),
+      Routes.identity: WizardRoute(
+        builder: (_) => const IdentityPage(),
+        userData: InstallationStep.identity.index,
+        onLoad: (_) => IdentityPage.load(ref),
+      ),
+      Routes.activeDirectory: WizardRoute(
+        builder: (_) => const ActiveDirectoryPage(),
+        userData: InstallationStep.identity.index,
+        onLoad: (_) => ActiveDirectoryPage.load(ref),
+      ),
+      Routes.theme: WizardRoute(
+        builder: (_) => const ThemePage(),
+        userData: InstallationStep.theme.index,
+      ),
+    };
+
+    final model = ref.watch(installerModelProvider);
+
+    MapEntry<String, WizardRoute> guardRoute(String name, WizardRoute route) {
+      return MapEntry(
+        name,
+        WizardRoute(
+          builder: route.builder,
+          userData: route.userData,
+          onLoad: (settings) async {
+            return model.hasRoute(name) &&
+                (await route.onLoad?.call(settings) ?? true);
+          },
+          onNext: route.onNext,
+          onBack: route.onBack,
+        ),
+      );
+    }
+
     return Wizard(
       initialRoute: Routes.initial,
       userData: InstallationStep.values.length,
@@ -71,70 +154,13 @@ class _InstallWizard extends ConsumerWidget {
         Routes.loading: WizardRoute(
           builder: (_) => const LoadingPage(),
         ),
-        Routes.locale: WizardRoute(
-          builder: (_) => const LocalePage(),
-          userData: InstallationStep.locale.index,
-          onLoad: (_) => LocalePage.load(context, ref),
-        ),
-        if (welcome == true)
-          Routes.welcome: WizardRoute(
-            builder: (_) => const WelcomePage(),
-            userData: InstallationStep.locale.index,
-            onLoad: (_) => WelcomePage.load(context, ref),
-          ),
-        Routes.rst: WizardRoute(
-          builder: (_) => const RstPage(),
-          onLoad: (_) => RstPage.load(ref),
-        ),
-        Routes.keyboard: WizardRoute(
-          builder: (_) => const KeyboardPage(),
-          userData: InstallationStep.keyboard.index,
-          onLoad: (settings) => KeyboardPage.load(ref),
-        ),
-        Routes.network: WizardRoute(
-          builder: (_) => const NetworkPage(),
-          userData: InstallationStep.network.index,
-          onLoad: (_) => NetworkPage.load(ref),
-        ),
-        Routes.source: WizardRoute(
-          builder: (_) => const SourceWizard(),
-          userData: InstallationStep.source.index,
-          onLoad: (_) => SourcePage.load(ref),
-        ),
-        Routes.secureBoot: WizardRoute(
-          builder: (_) => const SecureBootPage(),
-          userData: InstallationStep.type.index,
-          onLoad: (_) => SecureBootPage.load(ref),
-        ),
-        Routes.storage: WizardRoute(
-          builder: (_) => const StorageWizard(),
-          userData: InstallationStep.storage.index,
-          onLoad: (_) => StorageWizard.load(ref),
-        ),
+        ...preInstall.map(guardRoute),
         Routes.confirm: WizardRoute(
           builder: (_) => const ConfirmPage(),
           userData: InstallationStep.storage.index,
           onLoad: (_) => ConfirmPage.load(ref),
         ),
-        Routes.timezone: WizardRoute(
-          builder: (_) => const TimezonePage(),
-          userData: InstallationStep.timezone.index,
-          onLoad: (_) => TimezonePage.load(context, ref),
-        ),
-        Routes.identity: WizardRoute(
-          builder: (_) => const IdentityPage(),
-          userData: InstallationStep.identity.index,
-          onLoad: (_) => IdentityPage.load(ref),
-        ),
-        Routes.activeDirectory: WizardRoute(
-          builder: (_) => const ActiveDirectoryPage(),
-          userData: InstallationStep.identity.index,
-          onLoad: (_) => ActiveDirectoryPage.load(ref),
-        ),
-        Routes.theme: WizardRoute(
-          builder: (_) => const ThemePage(),
-          userData: InstallationStep.theme.index,
-        ),
+        ...postInstall.map(guardRoute),
         Routes.install: WizardRoute(
           builder: (_) => const InstallPage(),
           onLoad: (_) => InstallPage.load(context, ref),

--- a/packages/ubuntu_desktop_installer/test/installer_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_model_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_desktop_installer/installer/installer_model.dart';
+
+void main() {
+  test('interactive sections', () async {
+    final client = MockSubiquityClient();
+    when(client.getInteractiveSections()).thenAnswer((_) async => ['a', 'b']);
+    when(client.monitorStatus()).thenAnswer((_) => const Stream.empty());
+
+    final model = InstallerModel(client);
+    await model.init();
+
+    expect(model.hasRoute('a'), isTrue);
+    expect(model.hasRoute('b'), isTrue);
+    expect(model.hasRoute('c'), isFalse);
+  });
+
+  test('no interactive sections', () async {
+    final client = MockSubiquityClient();
+    when(client.getInteractiveSections()).thenAnswer((_) async => null);
+    when(client.monitorStatus()).thenAnswer((_) => const Stream.empty());
+
+    final model = InstallerModel(client);
+    await model.init();
+
+    expect(model.hasRoute('a'), isTrue);
+    expect(model.hasRoute('b'), isTrue);
+    expect(model.hasRoute('c'), isTrue);
+  });
+}

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -62,6 +62,7 @@ void main() {
     when(client.getLocale()).thenAnswer((_) async => 'en_US.UTF-8');
     when(client.monitorStatus()).thenAnswer(
         (_) => Stream.value(fakeApplicationStatus(ApplicationState.RUNNING)));
+    when(client.getInteractiveSections()).thenAnswer((_) async => null);
     registerMockService<SubiquityClient>(client);
 
     final server = MockSubiquityServer();
@@ -105,6 +106,7 @@ extension on WidgetTester {
     when(client.getStatus(current: ApplicationState.RUNNING))
         .thenAnswer((_) async => done);
     when(client.monitorStatus()).thenAnswer((_) => Stream.value(status));
+    when(client.getInteractiveSections()).thenAnswer((_) async => null);
     when(client.getStorageV2()).thenAnswer((_) async => fakeStorageResponse());
     when(client.getOriginalStorageV2())
         .thenAnswer((_) async => fakeStorageResponse());


### PR DESCRIPTION
Page routes have been divided into pre- and post-install routes that are shown before and after the confirmation screen.

- loading
- pre-install (1)
- confirm
- post-install (2)
- install

Where the pre- and post-install routes are filtered based on Subiquity's list of [interactive sections](https://github.com/canonical/subiquity/pull/1682).

1. pre-install
   - locale
   - welcome
   - rst
   - keyboard
   - network
   - source
   - secureBoot
   - storage

2. post-install
   - timezone
   - identity
   - activeDirectory
   - theme

Here's a fake dry-run with `keyboard`, `network`, and `identity` listed as interactive sections (not sure why `storage` changes are not reported on the confirmation screen - to be discussed with the Subiquity team):

[Screencast from 2023-06-12 13-59-24.webm](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/b7156993-b71a-4468-968f-0431349aaa68)