### PR TITLE
fix(locale_service): don't close the service

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services/locale_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/locale_service.dart
@@ -28,7 +28,6 @@ class XdgLocaleService implements LocaleService {
   Future<String> getLocale() async {
     await _client.connect();
     final locale = _client.locale['LANG']!;
-    await _client.close();
     return locale;
   }
 


### PR DESCRIPTION
`close()` terminates the DBus connection, so that any subsequent method calls will throw an exception.