### PR TITLE
Support the correct product name for Lenovo platforms (#2085)

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -216,12 +216,24 @@ class IdentityModel extends PropertyStreamNotifier {
 /// The DMI product name file. Available for testing.
 @visibleForTesting
 const kDMIProductNameFile = '/sys/devices/virtual/dmi/id/product_name';
+@visibleForTesting
+const kDMIProductVersionFile = '/sys/devices/virtual/dmi/id/product_version';
 
-Future<String> _readProductName() {
-  return File(kDMIProductNameFile)
+Future<String> _readDmiFile(String path) {
+  return File(path)
       .readAsString()
       .then((value) => value.trim().sanitize())
       .catchError((_) => '');
+}
+
+Future<String> _readProductName() async {
+  /// Lenovo uses product_version as product name
+  /// and it's empty on HP and DELL
+  var productName = await _readDmiFile(kDMIProductVersionFile);
+  if (productName.isEmpty) {
+    productName = await _readDmiFile(kDMIProductNameFile);
+  }
+  return productName;
 }
 
 extension _IdentityDescription on IdentityData {


### PR DESCRIPTION
Installed the daily image on ThinkPad, ThinkCentre or ThinkStaion, I found the hostname is wrong, and in 20.04 it could get the correct name like 'ThinkPad P17 Gen 1' while not '20SNZ5GNUS'.

$ cat /sys/devices/virtual/dmi/id/bios_vendor
LENOVO
$ cat /sys/devices/virtual/dmi/id/product_name
20SNZ5GNUS
$ cat /sys/devices/virtual/dmi/id/product_version
ThinkPad P17 Gen 1

https://github.com/canonical/ubuntu-desktop-installer/issues/2085