### PR TITLE
refactor(active-directory): de-couple from navigation

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -321,6 +321,12 @@ void main() {
   }, variant: themeVariant);
 
   testWidgets('12.active-directory', (tester) async {
+    final client = FakeSubiquityClient();
+    registerServiceInstance<SubiquityClient>(client);
+
+    final service = FakeActiveDirectoryService(client);
+    registerServiceInstance<ActiveDirectoryService>(service);
+
     await runInstallerApp([], flavor: currentFlavor);
     await tester.pumpAndSettle();
 
@@ -372,7 +378,8 @@ void main() {
   }, variant: themeVariant);
 
   testWidgets('15.complete', (tester) async {
-    registerService<SubiquityClient>(FakeSubiquityClient.new);
+    registerService<SubiquityClient>(
+        () => FakeSubiquityClient(ApplicationState.DONE));
 
     await runInstallerApp([], flavor: currentFlavor);
     await tester.pumpAndSettle();
@@ -385,6 +392,13 @@ void main() {
       screenshot: '$currentThemeName/15.complete',
     );
   }, variant: themeVariant);
+}
+
+class FakeActiveDirectoryService extends SubiquityActiveDirectoryService {
+  FakeActiveDirectoryService(super.client);
+
+  @override
+  Future<bool> isUsed() async => true;
 }
 
 class FakeDesktopService implements DesktopService {
@@ -404,9 +418,13 @@ class FakeProductService implements ProductService {
 }
 
 class FakeSubiquityClient extends SubiquityClient {
+  FakeSubiquityClient([this.state = ApplicationState.WAITING]);
+
+  final ApplicationState state;
+
   @override
   Future<ApplicationStatus> getStatus({ApplicationState? current}) async {
-    return fakeApplicationStatus(ApplicationState.DONE);
+    return fakeApplicationStatus(state);
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -125,9 +125,6 @@ class _InstallWizard extends ConsumerWidget {
           builder: (_) => const IdentityPage(),
           userData: InstallationStep.identity.index,
           onLoad: (_) => IdentityPage.load(ref),
-          onNext: (settings) => settings.arguments == true
-              ? Routes.activeDirectory
-              : Routes.theme,
         ),
         Routes.activeDirectory: WizardRoute(
           builder: (_) => const ActiveDirectoryPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_model.dart
@@ -86,8 +86,12 @@ class ActiveDirectoryModel extends SafeChangeNotifier {
 
   bool get isValid => isDomainNameValid && isAdminNameValid && isPasswordValid;
 
-  Future<void> init() {
-    return _service.getConnectionInfo().then((info) {
+  Future<bool> init() async {
+    if (!await _service.isUsed()) {
+      return false;
+    }
+
+    await _service.getConnectionInfo().then((info) {
       _domainName.value = info.domainName;
       _adminName.value = info.adminName;
       _password.value = info.password;
@@ -98,6 +102,7 @@ class ActiveDirectoryModel extends SafeChangeNotifier {
         validatePassword(),
       ]),
     );
+    return true;
   }
 
   Future<void> save() {

--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_page.dart
@@ -14,7 +14,7 @@ class ActiveDirectoryPage extends ConsumerStatefulWidget {
   const ActiveDirectoryPage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
-    return ref.read(activeDirectoryModelProvider).init().then((_) => true);
+    return ref.read(activeDirectoryModelProvider).init();
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -173,6 +173,7 @@ class IdentityModel extends PropertyStreamNotifier {
 
     _autoLogin.value = await _config.get(kAutoLoginUser) != null;
     _hasActiveDirectorySupport.value = await _activeDirectory.hasSupport();
+    _useActiveDirectory.value = await _activeDirectory.isUsed();
   }
 
   /// The auto-login user config key for testing purposes.
@@ -198,14 +199,11 @@ class IdentityModel extends PropertyStreamNotifier {
     }
 
     _telemetry?.addMetric('UseActiveDirectory', useActiveDirectory);
-    if (!useActiveDirectory) {
-      // the active directory endpoint is not optional so we need to explicitly
-      // mark it as configured even if not used to avoid subiquity getting stuck
-      // at waiting for it to be configured.
-      await _activeDirectory.markConfigured();
-    }
 
-    return _service.setIdentity(identity);
+    await Future.wait([
+      _service.setIdentity(identity),
+      _activeDirectory.setUsed(useActiveDirectory),
+    ]);
   }
 
   /// Defines if the password is shown or obscured.

--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_page.dart
@@ -75,8 +75,6 @@ class IdentityPage extends ConsumerWidget {
           WizardButton.next(
             context,
             enabled: ref.watch(identityModelProvider.select((m) => m.isValid)),
-            arguments: ref.watch(
-                identityModelProvider.select((m) => m.useActiveDirectory)),
             onNext: ref.read(identityModelProvider).save,
           ),
         ],

--- a/packages/ubuntu_desktop_installer/test/active_directory/test_active_directory.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/test_active_directory.dart
@@ -12,6 +12,7 @@ export 'test_active_directory.mocks.dart';
 
 @GenerateMocks([ActiveDirectoryModel])
 ActiveDirectoryModel buildActiveDirectoryModel({
+  bool? isUsed,
   bool? isValid,
   String? domainName,
   String? adminName,
@@ -22,6 +23,7 @@ ActiveDirectoryModel buildActiveDirectoryModel({
   AdJoinResult? joinResult,
 }) {
   final model = MockActiveDirectoryModel();
+  when(model.init()).thenAnswer((_) async => isUsed ?? false);
   when(model.isValid).thenReturn(isValid ?? false);
   when(model.domainName).thenReturn(domainName ?? '');
   when(model.adminName).thenReturn(adminName ?? '');

--- a/packages/ubuntu_desktop_installer/test/active_directory/test_active_directory.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/test_active_directory.mocks.dart
@@ -142,14 +142,13 @@ class MockActiveDirectoryModel extends _i1.Mock
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
   @override
-  _i3.Future<void> init() => (super.noSuchMethod(
+  _i3.Future<bool> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i3.Future<bool>.value(false),
+      ) as _i3.Future<bool>);
   @override
   _i3.Future<void> save() => (super.noSuchMethod(
         Invocation.method(

--- a/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
@@ -30,6 +30,7 @@ void main() {
     when(service.getIdentity()).thenAnswer((_) async => identity);
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -68,6 +69,7 @@ void main() {
     when(service.getIdentity()).thenAnswer((_) async => const IdentityData());
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -101,6 +103,7 @@ void main() {
     when(service.getIdentity()).thenAnswer((_) async => identity);
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -134,6 +137,7 @@ void main() {
     when(service.getIdentity()).thenAnswer((_) async => identity);
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -198,7 +202,7 @@ void main() {
     await model.save(salt: 'test');
 
     verify(service.setIdentity(identity)).called(1);
-    verify(activeDirectory.markConfigured()).called(1);
+    verify(activeDirectory.setUsed(false)).called(1);
     verify(telemetry.addMetric('UseActiveDirectory', false)).called(1);
   });
 
@@ -445,6 +449,7 @@ void main() {
     });
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     final config = MockConfigService();
@@ -513,6 +518,7 @@ void main() {
     when(service.getIdentity()).thenAnswer((_) async => const IdentityData());
 
     final activeDirectory = MockActiveDirectoryService();
+    when(activeDirectory.isUsed()).thenAnswer((_) async => true);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => true);
 
     final config = MockConfigService();
@@ -531,14 +537,18 @@ void main() {
       network: network,
       telemetry: telemetry,
     );
+    expect(model.useActiveDirectory, isFalse);
     expect(model.hasActiveDirectorySupport, isNull);
 
     await model.init();
+    expect(model.useActiveDirectory, isTrue);
     expect(model.hasActiveDirectorySupport, isTrue);
 
+    when(activeDirectory.isUsed()).thenAnswer((_) async => false);
     when(activeDirectory.hasSupport()).thenAnswer((_) async => false);
 
     await model.init();
+    expect(model.useActiveDirectory, isFalse);
     expect(model.hasActiveDirectorySupport, isFalse);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
@@ -108,6 +108,7 @@ void main() {
     final confirmModel = buildConfirmModel();
     final timezoneModel = buildTimezoneModel();
     final identityModel = buildIdentityModel(isValid: true);
+    final activeDirectoryModel = buildActiveDirectoryModel();
     final installModel = buildInstallModel(isDone: true);
 
     registerMockService<AppService>(MockAppService());
@@ -133,6 +134,8 @@ void main() {
           confirmModelProvider.overrideWith((_) => confirmModel),
           timezoneModelProvider.overrideWith((_) => timezoneModel),
           identityModelProvider.overrideWith((_) => identityModel),
+          activeDirectoryModelProvider
+              .overrideWith((_) => activeDirectoryModel),
           installModelProvider.overrideWith((_) => installModel),
         ],
         child: tester.buildTestWizard(welcome: true),
@@ -284,7 +287,7 @@ void main() {
     final localeModel = buildLocaleModel();
     final identityModel =
         buildIdentityModel(useActiveDirectory: true, isValid: true);
-    final activeDirectoryModel = buildActiveDirectoryModel();
+    final activeDirectoryModel = buildActiveDirectoryModel(isUsed: true);
 
     registerMockService<AppService>(MockAppService());
     registerMockService<TelemetryService>(MockTelemetryService());

--- a/packages/ubuntu_desktop_installer/test/services/active_directory_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/active_directory_service_test.dart
@@ -94,15 +94,24 @@ void main() {
       verify(client.getActiveDirectoryJoinResult()).called(1);
     });
 
-    test('mark configured', () async {
+    test('is used', () async {
       final client = MockSubiquityClient();
       when(client.markConfigured(['active_directory']))
           .thenAnswer((_) async {});
 
       final service = SubiquityActiveDirectoryService(client);
 
-      await service.markConfigured();
+      expect(await service.isUsed(), isFalse);
+
+      await service.setUsed(true);
+      verifyNever(client.markConfigured(['active_directory']));
+
+      expect(await service.isUsed(), isTrue);
+
+      await service.setUsed(false);
       verify(client.markConfigured(['active_directory'])).called(1);
+
+      expect(await service.isUsed(), isFalse);
     });
   });
 }

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -173,6 +173,23 @@ class MockActiveDirectoryService extends _i1.Mock
         returnValue: _i4.Future<bool>.value(false),
       ) as _i4.Future<bool>);
   @override
+  _i4.Future<bool> isUsed() => (super.noSuchMethod(
+        Invocation.method(
+          #isUsed,
+          [],
+        ),
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
+  @override
+  _i4.Future<void> setUsed(bool? used) => (super.noSuchMethod(
+        Invocation.method(
+          #setUsed,
+          [used],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   _i4.Future<_i2.AdConnectionInfo> getConnectionInfo() => (super.noSuchMethod(
         Invocation.method(
           #getConnectionInfo,
@@ -248,15 +265,6 @@ class MockActiveDirectoryService extends _i1.Mock
         ),
         returnValue: _i4.Future<_i2.AdJoinResult>.value(_i2.AdJoinResult.OK),
       ) as _i4.Future<_i2.AdJoinResult>);
-  @override
-  _i4.Future<void> markConfigured() => (super.noSuchMethod(
-        Invocation.method(
-          #markConfigured,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
 }
 
 /// A class which mocks [AppService].


### PR DESCRIPTION
Previously, Active Directory would not be used by default but it would be up to the user to interactively toggle it on the identity page, the preceding page in manual installation flow:

| Identity | Active Directory |
|---|---|
| ![image](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/404a720b-20e8-4ea8-9c14-f28d816f178a) | ![image](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/e2f7e9de-e331-4344-b1ba-94bafa928ce2) |

The selection would be passed as an argument for the router to make a decision on whether to navigate to the Active Directory page or jump over it. This approach was fine in manual installation flows but doesn't work when doing semi-automated installations because then it's up to Subiquity to decide whether the Active Directory page is shown. Therefore, this PR moves the logic to the service level and removes the navigation argument so that the Active Directory page can be shown independently of the identity page.