### PR TITLE
feat(keyboard): add canDetectLayout

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_model.dart
@@ -29,6 +29,9 @@ class KeyboardModel extends SafeChangeNotifier {
   /// The number of available keyboard layouts.
   int get layoutCount => _layouts.length;
 
+  /// Whether the service supports keyboard layout detection.
+  bool get canDetectLayout => _service.canDetectLayout;
+
   /// Returns the name of the keyboard layout at [index].
   ///
   /// Note: the index must be valid.

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_page.dart
@@ -36,17 +36,19 @@ class KeyboardPage extends ConsumerWidget {
             Row(
               children: [
                 Expanded(child: Text(lang.chooseYourKeyboardLayout)),
-                const SizedBox(width: kContentSpacing),
-                OutlinedButton(
-                  child: Text(lang.detectButtonText),
-                  onPressed: () async {
-                    final result = await showDetectKeyboardDialog(context);
-                    if (result != null) {
-                      model.trySelectLayoutVariant(
-                          result.layout, result.variant);
-                    }
-                  },
-                ),
+                if (model.canDetectLayout) ...[
+                  const SizedBox(width: kContentSpacing),
+                  OutlinedButton(
+                    child: Text(lang.detectButtonText),
+                    onPressed: () async {
+                      final result = await showDetectKeyboardDialog(context);
+                      if (result != null) {
+                        model.trySelectLayoutVariant(
+                            result.layout, result.variant);
+                      }
+                    },
+                  ),
+                ],
               ],
             ),
             const SizedBox(height: kContentSpacing),

--- a/packages/ubuntu_desktop_installer/lib/services/keyboard_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/keyboard_service.dart
@@ -16,6 +16,7 @@ abstract class KeyboardService {
   Future<void> setKeyboard(KeyboardSetting setting);
   Future<void> setInputSource(KeyboardSetting setting, {String? user});
   Future<AnyStep> getKeyboardStep([String step = '0']);
+  bool get canDetectLayout;
 }
 
 class SubiquityKeyboardService implements KeyboardService {
@@ -40,4 +41,7 @@ class SubiquityKeyboardService implements KeyboardService {
   Future<AnyStep> getKeyboardStep([String step = '0']) {
     return _subiquity.getKeyboardStep(step);
   }
+
+  @override
+  bool get canDetectLayout => true;
 }

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -71,6 +71,14 @@ void main() {
     verify(model.trySelectLayoutVariant('layout', 'variant'));
   });
 
+  testWidgets('keyboard detection unsupported', (tester) async {
+    final model = buildKeyboardModel(canDetectLayout: false);
+    await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
+
+    final detectButton = find.button(tester.lang.detectButtonText);
+    expect(detectButton, findsNothing);
+  });
+
   testWidgets('valid input', (tester) async {
     final model = buildKeyboardModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));

--- a/packages/ubuntu_desktop_installer/test/keyboard/test_keyboard.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/test_keyboard.dart
@@ -17,6 +17,7 @@ MockKeyboardModel buildKeyboardModel({
   int? selectedLayoutIndex,
   List<String>? variants,
   int? selectedVariantIndex,
+  bool? canDetectLayout,
 }) {
   final model = MockKeyboardModel();
   when(model.isValid).thenReturn(isValid ?? true);
@@ -30,6 +31,7 @@ MockKeyboardModel buildKeyboardModel({
     when(model.variantName(i)).thenReturn(variants![i]);
   }
   when(model.selectedVariantIndex).thenReturn(selectedVariantIndex ?? 0);
+  when(model.canDetectLayout).thenReturn(canDetectLayout ?? true);
   return model;
 }
 

--- a/packages/ubuntu_desktop_installer/test/keyboard/test_keyboard.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/test_keyboard.mocks.dart
@@ -35,6 +35,11 @@ class MockKeyboardModel extends _i1.Mock implements _i2.KeyboardModel {
         returnValue: 0,
       ) as int);
   @override
+  bool get canDetectLayout => (super.noSuchMethod(
+        Invocation.getter(#canDetectLayout),
+        returnValue: false,
+      ) as bool);
+  @override
   int get selectedLayoutIndex => (super.noSuchMethod(
         Invocation.getter(#selectedLayoutIndex),
         returnValue: 0,

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -563,6 +563,11 @@ class MockKeyboardService extends _i1.Mock implements _i18.KeyboardService {
   }
 
   @override
+  bool get canDetectLayout => (super.noSuchMethod(
+        Invocation.getter(#canDetectLayout),
+        returnValue: false,
+      ) as bool);
+  @override
   _i8.Future<_i2.KeyboardSetup> getKeyboard() => (super.noSuchMethod(
         Invocation.method(
           #getKeyboard,


### PR DESCRIPTION
Split off from #2072:

Makes keyboard layout detection an optional feature of the `KeyboardModel` and hides the 'Detect' button in the UI if layout detection is not supported