### PR TITLE
refactor(confirm): loosen coupling with subiquity

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/ubuntu_desktop_installer_test.dart
@@ -4,7 +4,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/main.dart' as app;
 import 'package:ubuntu_desktop_installer/pages.dart';

--- a/packages/ubuntu_desktop_installer/lib/services/installer_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/installer_service.dart
@@ -30,6 +30,8 @@ class InstallerService {
     return monitorStatus().firstWhere((s) => s?.isLoading == false);
   }
 
+  Future<void> start() => _client.confirm('/dev/tty1');
+
   Stream<ApplicationStatus?> monitorStatus() => _client.monitorStatus();
 
   bool hasRoute(String route) {

--- a/packages/ubuntu_desktop_installer/lib/services/storage_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/storage_service.dart
@@ -3,6 +3,9 @@ import 'dart:math' as math;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
+export 'package:subiquity_client/subiquity_client.dart'
+    show Disk, DiskX, Partition;
+
 /// @internal
 final log = Logger('storage');
 

--- a/packages/ubuntu_desktop_installer/test/confirm/confirm_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/confirm/confirm_model_test.dart
@@ -56,19 +56,19 @@ void main() {
   ];
 
   test('get storage', () async {
-    final client = MockSubiquityClient();
-    final service = MockStorageService();
-    when(service.guidedTarget).thenReturn(null);
-    when(service.getStorage()).thenAnswer((_) async => testDisks);
-    when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
+    final installer = MockInstallerService();
+    final storage = MockStorageService();
+    when(storage.guidedTarget).thenReturn(null);
+    when(storage.getStorage()).thenAnswer((_) async => testDisks);
+    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
 
-    final model = ConfirmModel(client, service);
+    final model = ConfirmModel(installer, storage);
     await model.init();
     verifyInOrder([
-      service.getStorage(),
-      service.getOriginalStorage(),
+      storage.getStorage(),
+      storage.getOriginalStorage(),
     ]);
-    verifyNever(service.setGuidedStorage());
+    verifyNever(storage.setGuidedStorage());
 
     expect(model.disks, equals(modifiedDisks));
     expect(
@@ -94,33 +94,33 @@ void main() {
     const target =
         GuidedStorageTarget.reformat(diskId: 'sda', capabilities: []);
 
-    final client = MockSubiquityClient();
-    final service = MockStorageService();
-    when(service.guidedTarget).thenReturn(target);
-    when(service.getStorage()).thenAnswer((_) async => testDisks);
-    when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
-    when(service.setGuidedStorage())
+    final installer = MockInstallerService();
+    final storage = MockStorageService();
+    when(storage.guidedTarget).thenReturn(target);
+    when(storage.getStorage()).thenAnswer((_) async => testDisks);
+    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
+    when(storage.setGuidedStorage())
         .thenAnswer((_) async => fakeGuidedStorageResponse());
 
-    final model = ConfirmModel(client, service);
+    final model = ConfirmModel(installer, storage);
     await model.init();
-    verify(service.setGuidedStorage()).called(1);
+    verify(storage.setGuidedStorage()).called(1);
   });
 
   test('start installation', () async {
-    final client = MockSubiquityClient();
-    final service = MockStorageService();
-    when(service.guidedTarget).thenReturn(null);
-    when(service.getStorage()).thenAnswer((_) async => testDisks);
-    when(service.getOriginalStorage()).thenAnswer((_) async => testDisks);
-    when(service.setStorage()).thenAnswer((_) async => modifiedDisks);
+    final installer = MockInstallerService();
+    final storage = MockStorageService();
+    when(storage.guidedTarget).thenReturn(null);
+    when(storage.getStorage()).thenAnswer((_) async => testDisks);
+    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
+    when(storage.setStorage()).thenAnswer((_) async => modifiedDisks);
 
-    final model = ConfirmModel(client, service);
+    final model = ConfirmModel(installer, storage);
     await model.init();
     await model.startInstallation();
 
-    verifyNever(service.setStorage());
-    verify(service.securityKey = null).called(1);
-    verify(client.confirm('/dev/tty1')).called(1);
+    verifyNever(storage.setStorage());
+    verify(storage.securityKey = null).called(1);
+    verify(installer.start()).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/confirm/test_confirm.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/confirm/test_confirm.mocks.dart
@@ -7,9 +7,9 @@ import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/pages/confirm/confirm_model.dart'
     as _i2;
+import 'package:ubuntu_desktop_installer/services.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values

--- a/packages/ubuntu_desktop_installer/test/services/installer_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/installer_service_test.dart
@@ -136,4 +136,14 @@ void main() {
     expect(service.hasRoute('b'), isTrue);
     expect(service.hasRoute('c'), isTrue);
   });
+
+  test('start installation', () async {
+    final client = MockSubiquityClient();
+    when(client.confirm('/dev/tty1')).thenAnswer((_) async {});
+
+    final service = InstallerService(client);
+    await service.start();
+
+    verify(client.confirm('/dev/tty1')).called(1);
+  });
 }

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -531,6 +531,15 @@ class MockInstallerService extends _i1.Mock implements _i16.InstallerService {
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
   @override
+  _i8.Future<void> start() => (super.noSuchMethod(
+        Invocation.method(
+          #start,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
   _i8.Stream<_i2.ApplicationStatus?> monitorStatus() => (super.noSuchMethod(
         Invocation.method(
           #monitorStatus,


### PR DESCRIPTION
Call `InstallerService.start()` instead of `SubiquityClient.confirm('/dev/tty1')` (:woozy_face:) and export relevant storage types from the storage service to get rid of the `subiquity_client.dart` import in `confirm_model.dart`.