### PR TITLE
refactor(test): make better use of ubuntu_test helpers for buttons

### DIFF
--- a/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
@@ -123,10 +123,7 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.save()).called(1);
 
     verify(model.getJoinResult()).called(1);
@@ -140,10 +137,7 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.save()).called(1);
 
     verify(model.getJoinResult()).called(1);

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -4,6 +4,7 @@ import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/identity/identity_model.dart';
 import 'package:ubuntu_desktop_installer/pages/identity/identity_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import 'test_identity.dart';
@@ -208,10 +209,7 @@ void main() {
     final model = buildIdentityModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.save()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_widgets.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -83,18 +84,14 @@ void main() {
     final model = buildKeyboardModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isEnabled);
+    expect(find.button(tester.ulang.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildKeyboardModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isDisabled);
+    expect(find.button(tester.ulang.nextLabel), isDisabled);
   });
 
   testWidgets('key search', (tester) async {
@@ -129,9 +126,7 @@ void main() {
     final model = buildKeyboardModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    await tester.tap(nextButton);
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     verify(model.save()).called(1);

--- a/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/locale/locale_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_desktop_installer/pages/locale/locale_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
@@ -103,10 +104,7 @@ void main() {
 
     await tester.pumpWidget(tester.buildApp((_) => buildLocalePage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     expect(find.byType(LocalePage), findsNothing);

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_desktop_installer/pages/network/hidden_wifi_view.dart';
 import 'package:ubuntu_desktop_installer/pages/network/network_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_view.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -95,9 +96,7 @@ void main() {
     verify(model.init());
     verifyNever(model.cleanup());
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    await tester.tap(nextButton);
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     verify(model.cleanup()).called(1);
@@ -162,9 +161,7 @@ void main() {
     verify(model.init()).called(1);
     verifyNever(model.cleanup());
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    await tester.tap(nextButton);
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     verify(model.markConfigured()).called(1);

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/source/source_model.dart';
 import 'package:ubuntu_desktop_installer/pages/source/source_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -100,9 +101,7 @@ void main() {
     final model = buildSourceModel(sourceId: kNormalSourceId);
     await tester.pumpWidget(tester.buildApp((_) => buildSourcePage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    await tester.tap(nextButton);
+    await tester.tapNext();
     await tester.pumpAndSettle();
 
     verify(model.save()).called(1);

--- a/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_page_test.dart
@@ -6,6 +6,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/installation_type/installation_type_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/installation_type/installation_type_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import 'test_installation_type.dart';
@@ -342,11 +343,9 @@ void main() {
     final model = buildInstallationTypeModel(hasStorage: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isDisabled);
+    expect(find.button(tester.ulang.nextLabel), isDisabled);
 
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verifyNever(model.save());
   });
 
@@ -354,10 +353,7 @@ void main() {
     final model = buildInstallationTypeModel(hasStorage: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.save()).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_page_test.dart
@@ -9,6 +9,7 @@ import 'package:ubuntu_desktop_installer/pages/storage/manual/manual_storage_mod
 import 'package:ubuntu_desktop_installer/pages/storage/manual/manual_storage_page.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/manual/storage_selector.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -224,10 +225,7 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
     verifyNever(model.reformatDisk(disk));
 
-    final okButton = find.button(tester.ulang.okLabel);
-    expect(okButton, findsOneWidget);
-
-    await tester.tap(okButton);
+    await tester.tapOk();
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsNothing);
@@ -275,10 +273,7 @@ void main() {
     final model = buildManualStorageModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.setStorage()).called(1);
   });
 
@@ -286,9 +281,7 @@ void main() {
     final model = buildManualStorageModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isDisabled);
+    expect(find.button(tester.ulang.nextLabel), isDisabled);
   });
 
   testWidgets('too many primary partitions', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/storage/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/security_key/security_key_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/security_key/security_key_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/security_key/security_key_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import 'test_security_key.dart';
@@ -68,10 +69,7 @@ void main() {
     final model = buildSecurityKeyModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.saveSecurityKey()).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/storage/select_guided_storage/select_guided_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/select_guided_storage/select_guided_storage_page_test.dart
@@ -7,8 +7,8 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/select_guided_storage/select_guided_storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/select_guided_storage/select_guided_storage_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:yaru_test/yaru_test.dart';
 
 import 'test_select_guided_storage.dart';
 
@@ -92,10 +92,7 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.saveGuidedStorage()).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_page.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import 'test_timezone.dart';
@@ -13,8 +14,7 @@ void main() {
     when(model.init()).thenAnswer((_) async => '');
     await tester.pumpWidget(tester.buildApp((_) => buildTimezonePage(model)));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.save()).called(1);
   });
 

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -63,7 +63,7 @@ void main() {
 
     final windowClosed = YaruTestWindow.waitForClosed();
 
-    await tester.tap(find.button(tester.ulang.nextLabel));
+    await tester.tapNext();
     await tester.pump();
 
     await expectLater(windowClosed, completes);

--- a/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/profile_setup_page_test.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
@@ -167,18 +168,14 @@ void main() {
     final model = buildModel(isValid: true);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isEnabled);
+    expect(find.button(tester.ulang.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildModel(isValid: false);
     await tester.pumpWidget(buildApp(tester, model));
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-    expect(nextButton, isDisabled);
+    expect(find.button(tester.ulang.nextLabel), isDisabled);
   });
 
   // NOTE: The "Show advanced options" checkbox was temporarily removed (#431).
@@ -207,10 +204,7 @@ void main() {
     verify(model.loadProfileSetup()).called(1);
     verifyNever(model.saveProfileSetup());
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.saveProfileSetup()).called(1);
   });
 

--- a/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
+++ b/packages/ubuntu_wsl_setup/test/select_language_page_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:ubuntu_wsl_setup/l10n.dart';
@@ -92,10 +93,7 @@ void main() {
     verifyNever(model.getServerLocale());
     verify(model.selectLocale(const Locale('fr_FR'))).called(1);
 
-    final nextButton = find.button(tester.ulang.nextLabel);
-    expect(nextButton, findsOneWidget);
-
-    await tester.tap(nextButton);
+    await tester.tapNext();
     verify(model.applyLocale(const Locale('fr_FR'))).called(1);
   });
 


### PR DESCRIPTION
`tapNext()` and friends would fail if they were ambiguous so we can leave out the repetitive `findsOneWidget` checks.