### PR TITLE
fix(test): switch to pumpAndSettle() in expectPage()

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -557,7 +557,7 @@ Future<void> expectPage(
   String Function(AppLocalizations lang) title,
 ) async {
   await tester.pumpUntil(find.byType(page));
-  await tester.pump(kThemeAnimationDuration);
+  await tester.pumpAndSettle();
 
   expect(find.byType(page), findsOneWidget);
   expect(find.widgetWithText(AppBar, title(tester.lang)), findsOneWidget);


### PR DESCRIPTION
`pump(kAnimationThemeDuration)` does not seem to be reliable in the CI - try `pumpAndSettle()` instead.