### PR TITLE
fix(ubuntu_wizard): show spinner during onActivated

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
@@ -133,6 +133,9 @@ class WizardButton extends StatefulWidget {
 }
 
 class _WizardButtonState extends State<WizardButton> {
+  bool activating = false;
+  bool get loading => activating || (widget.loading ?? false);
+
   @override
   Widget build(BuildContext context) {
     if (widget.visible == false) {
@@ -141,15 +144,17 @@ class _WizardButtonState extends State<WizardButton> {
 
     final maybeActivate = widget.enabled ?? true
         ? () async {
+            setState(() => activating = true);
             await widget.onActivated?.call();
+            setState(() => activating = false);
             if (mounted) widget.execute?.call();
           }
         : null;
 
     return FutureBuilder(
-      key: ValueKey(widget.loading),
-      future: widget.loading == true
-          ? Future.delayed(_kLoadingDelay, () => widget.loading)
+      key: ValueKey(loading),
+      future: loading == true
+          ? Future.delayed(_kLoadingDelay, () => loading)
           : null,
       builder: (context, snapshot) {
         final child = snapshot.data == true


### PR DESCRIPTION
This makes sure `WizardButton` shows the loading indicator while awaiting the result of the `onActivated` callback.