### PR TITLE
fix(locale_page): await applyLocale before proceeding

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/locale/locale_page.dart
@@ -75,9 +75,9 @@ class LocalePage extends ConsumerWidget {
         trailing: [
           WizardButton.next(
             context,
-            onNext: () {
+            onNext: () async {
               final locale = model.locale(model.selectedLanguageIndex);
-              model.applyLocale(locale);
+              await model.applyLocale(locale);
               tryGetService<TelemetryService>()
                   ?.addMetric('Language', locale.languageCode);
             },


### PR DESCRIPTION
This ensures that the `LocalePage` finishes setting the locale before proceeding to the next page. In the welcome wizard this is necessary because the `KeyboardPage` uses the system locale to show a localized list of keyboard layouts.