### PR TITLE
feat(ubuntu_wizard): add Wizard[Route]Data class

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -5,6 +5,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -73,13 +74,13 @@ class _InstallWizard extends ConsumerWidget {
     final preInstall = <String, WizardRoute>{
       Routes.locale: WizardRoute(
         builder: (_) => const LocalePage(),
-        userData: InstallationStep.locale.index,
+        userData: WizardRouteData(step: InstallationStep.locale.index),
         onLoad: (_) => LocalePage.load(context, ref),
       ),
       if (welcome == true)
         Routes.welcome: WizardRoute(
           builder: (_) => const WelcomePage(),
-          userData: InstallationStep.locale.index,
+          userData: WizardRouteData(step: InstallationStep.locale.index),
           onLoad: (_) => WelcomePage.load(context, ref),
         ),
       Routes.rst: WizardRoute(
@@ -88,27 +89,27 @@ class _InstallWizard extends ConsumerWidget {
       ),
       Routes.keyboard: WizardRoute(
         builder: (_) => const KeyboardPage(),
-        userData: InstallationStep.keyboard.index,
+        userData: WizardRouteData(step: InstallationStep.keyboard.index),
         onLoad: (settings) => KeyboardPage.load(ref),
       ),
       Routes.network: WizardRoute(
         builder: (_) => const NetworkPage(),
-        userData: InstallationStep.network.index,
+        userData: WizardRouteData(step: InstallationStep.network.index),
         onLoad: (_) => NetworkPage.load(ref),
       ),
       Routes.source: WizardRoute(
         builder: (_) => const SourceWizard(),
-        userData: InstallationStep.source.index,
+        userData: WizardRouteData(step: InstallationStep.source.index),
         onLoad: (_) => SourcePage.load(ref),
       ),
       Routes.secureBoot: WizardRoute(
         builder: (_) => const SecureBootPage(),
-        userData: InstallationStep.type.index,
+        userData: WizardRouteData(step: InstallationStep.type.index),
         onLoad: (_) => SecureBootPage.load(ref),
       ),
       Routes.storage: WizardRoute(
         builder: (_) => const StorageWizard(),
-        userData: InstallationStep.storage.index,
+        userData: WizardRouteData(step: InstallationStep.storage.index),
         onLoad: (_) => StorageWizard.load(ref),
       ),
     };
@@ -116,22 +117,22 @@ class _InstallWizard extends ConsumerWidget {
     final postInstall = <String, WizardRoute>{
       Routes.timezone: WizardRoute(
         builder: (_) => const TimezonePage(),
-        userData: InstallationStep.timezone.index,
+        userData: WizardRouteData(step: InstallationStep.timezone.index),
         onLoad: (_) => TimezonePage.load(context, ref),
       ),
       Routes.identity: WizardRoute(
         builder: (_) => const IdentityPage(),
-        userData: InstallationStep.identity.index,
+        userData: WizardRouteData(step: InstallationStep.identity.index),
         onLoad: (_) => IdentityPage.load(ref),
       ),
       Routes.activeDirectory: WizardRoute(
         builder: (_) => const ActiveDirectoryPage(),
-        userData: InstallationStep.identity.index,
+        userData: WizardRouteData(step: InstallationStep.identity.index),
         onLoad: (_) => ActiveDirectoryPage.load(ref),
       ),
       Routes.theme: WizardRoute(
         builder: (_) => const ThemePage(),
-        userData: InstallationStep.theme.index,
+        userData: WizardRouteData(step: InstallationStep.theme.index),
       ),
     };
 
@@ -154,7 +155,7 @@ class _InstallWizard extends ConsumerWidget {
 
     return Wizard(
       initialRoute: Routes.initial,
-      userData: InstallationStep.values.length,
+      userData: WizardData(totalSteps: InstallationStep.values.length),
       routes: <String, WizardRoute>{
         Routes.loading: WizardRoute(
           builder: (_) => const LoadingPage(),
@@ -162,7 +163,7 @@ class _InstallWizard extends ConsumerWidget {
         ...preInstall.map(guardRoute),
         Routes.confirm: WizardRoute(
           builder: (_) => const ConfirmPage(),
-          userData: InstallationStep.storage.index,
+          userData: WizardRouteData(step: InstallationStep.storage.index),
           onLoad: (_) => ConfirmPage.load(ref),
         ),
         ...postInstall.map(guardRoute),

--- a/packages/ubuntu_desktop_installer/lib/pages/source/source_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/source_wizard.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import 'not_enough_disk_space/not_enough_disk_space_page.dart';
@@ -15,11 +16,11 @@ class SourceWizard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wizard(
-      userData: InstallationStep.values.length,
+      userData: WizardData(totalSteps: InstallationStep.values.length),
       routes: {
         Navigator.defaultRouteName: WizardRoute(
           builder: (_) => const SourcePage(),
-          userData: InstallationStep.source.index,
+          userData: WizardRouteData(step: InstallationStep.source.index),
         ),
         Routes.notEnoughDiskSpace: WizardRoute(
           builder: (_) => const NotEnoughDiskSpacePage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/storage_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/storage_wizard.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/installer.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import 'bitlocker/bitlocker_page.dart';
@@ -31,11 +32,11 @@ class StorageWizard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Wizard(
-      userData: InstallationStep.values.length,
+      userData: WizardData(totalSteps: InstallationStep.values.length),
       routes: {
         Routes.installationType: WizardRoute(
           builder: (_) => const InstallationTypePage(),
-          userData: InstallationStep.type.index,
+          userData: WizardRouteData(step: InstallationStep.type.index),
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.bitlocker: WizardRoute(
@@ -43,26 +44,26 @@ class StorageWizard extends ConsumerWidget {
         ),
         Routes.installAlongside: WizardRoute(
           builder: (_) => const InstallAlongsidePage(),
-          userData: InstallationStep.storage.index,
+          userData: WizardRouteData(step: InstallationStep.storage.index),
           onLoad: (_) => InstallAlongsidePage.load(ref),
           onReplace: (_) => StorageRoutes.manual,
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.selectGuidedStorage: WizardRoute(
           builder: (_) => const SelectGuidedStoragePage(),
-          userData: InstallationStep.storage.index,
+          userData: WizardRouteData(step: InstallationStep.storage.index),
           onLoad: (_) => SelectGuidedStoragePage.load(ref),
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         Routes.securityKey: WizardRoute(
           builder: (_) => const SecurityKeyPage(),
-          userData: InstallationStep.storage.index,
+          userData: WizardRouteData(step: InstallationStep.storage.index),
           onLoad: (_) => SecurityKeyPage.load(ref),
           onNext: (settings) => _nextRoute(settings.arguments),
         ),
         StorageRoutes.manual: WizardRoute(
           builder: (_) => const ManualStoragePage(),
-          userData: InstallationStep.storage.index,
+          userData: WizardRouteData(step: InstallationStep.storage.index),
           onLoad: (_) => ManualStoragePage.load(ref),
         ),
       },

--- a/packages/ubuntu_welcome/lib/welcome_wizard.dart
+++ b/packages/ubuntu_welcome/lib/welcome_wizard.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/pages.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -41,22 +42,30 @@ class _WelcomeWizardState extends ConsumerState<WelcomeWizard> {
         ),
         WelcomeRoutes.locale: WizardRoute(
           builder: (_) => const LocalePage(),
-          userData: WelcomeStep.locale.index,
+          userData: WizardRouteData(
+            step: WelcomeStep.locale.index,
+          ),
           onLoad: (_) => LocalePage.load(context, ref),
         ),
         WelcomeRoutes.keyboard: WizardRoute(
           builder: (_) => const KeyboardPage(),
-          userData: WelcomeStep.keyboard.index,
+          userData: WizardRouteData(
+            step: WelcomeStep.keyboard.index,
+          ),
           onLoad: (_) => KeyboardPage.load(ref),
         ),
         WelcomeRoutes.timezone: WizardRoute(
           builder: (_) => const TimezonePage(),
-          userData: WelcomeStep.timezone.index,
+          userData: WizardRouteData(
+            step: WelcomeStep.timezone.index,
+          ),
           onLoad: (_) => TimezonePage.load(context, ref),
         ),
         WelcomeRoutes.identity: WizardRoute(
           builder: (_) => const IdentityPage(),
-          userData: WelcomeStep.identity.index,
+          userData: WizardRouteData(
+            step: WelcomeStep.identity.index,
+          ),
           onLoad: (_) => IdentityPage.load(ref),
           onNext: (_) =>
               YaruWindow.of(context).close().then((_) => WelcomeRoutes.initial),
@@ -73,6 +82,9 @@ class _WelcomeWizardState extends ConsumerState<WelcomeWizard> {
 
   @override
   Widget build(BuildContext context) {
-    return Wizard(controller: _controller);
+    return Wizard(
+      controller: _controller,
+      userData: WizardData(totalSteps: WelcomeStep.values.length),
+    );
   }
 }

--- a/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
@@ -1,0 +1,11 @@
+class WizardData {
+  const WizardData({this.totalSteps});
+  final int? totalSteps;
+}
+
+class WizardRouteData {
+  const WizardRouteData({
+    this.step,
+  });
+  final int? step;
+}

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_wizard/constants.dart';
+import 'package:ubuntu_wizard/src/utils/wizard_data.dart';
 import 'package:wizard_router/wizard_router.dart';
 import 'package:yaru_widgets/widgets.dart';
 
@@ -25,8 +26,10 @@ class _WizardBarState extends State<WizardBar> {
   @override
   Widget build(BuildContext context) {
     final wizardScope = Wizard.maybeOf(context);
-    final totalSteps = (wizardScope?.wizardData as int?);
-    final currentStep = (wizardScope?.routeData as int?);
+    final wizardData = wizardScope?.wizardData as WizardData?;
+    final wizardRouteData = wizardScope?.routeData as WizardRouteData?;
+    final totalSteps = wizardData?.totalSteps;
+    final currentStep = wizardRouteData?.step;
 
     return Hero(
       tag: 'wizard-bottom-bar', // keep in place during page transitions

--- a/packages/ubuntu_wizard/lib/utils.dart
+++ b/packages/ubuntu_wizard/lib/utils.dart
@@ -8,3 +8,4 @@ export 'src/utils/property_stream_notifier.dart';
 export 'src/utils/proxy_asset_bundle.dart';
 export 'src/utils/string.dart';
 export 'src/utils/url_launcher.dart' hide log;
+export 'src/utils/wizard_data.dart';

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 import 'package:yaru_widgets/widgets.dart';
@@ -236,14 +237,14 @@ void main() {
           content: Text('Page 4 of 7'),
           bottomBar: WizardBar(),
         ),
-        userData: 3,
+        userData: const WizardRouteData(step: 3),
       ),
     };
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
         home: Wizard(
-          userData: 7,
+          userData: const WizardData(totalSteps: 7),
           routes: routes,
           initialRoute: '/foo',
         ),


### PR DESCRIPTION
Wraps the `userData` of the `Wizard`s and their `WizardRoutes` in a class, so that we can add more data besides the page index, e.g. whether a route is allowed to navigate back.