### PR TITLE
feat: control page navigation options in routes

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -117,7 +117,10 @@ class _InstallWizard extends ConsumerWidget {
     final postInstall = <String, WizardRoute>{
       Routes.timezone: WizardRoute(
         builder: (_) => const TimezonePage(),
-        userData: WizardRouteData(step: InstallationStep.timezone.index),
+        userData: WizardRouteData(
+          step: InstallationStep.timezone.index,
+          canGoBack: false,
+        ),
         onLoad: (_) => TimezonePage.load(context, ref),
       ),
       Routes.identity: WizardRoute(
@@ -158,8 +161,11 @@ class _InstallWizard extends ConsumerWidget {
       userData: WizardData(totalSteps: InstallationStep.values.length),
       routes: <String, WizardRoute>{
         Routes.loading: WizardRoute(
-          builder: (_) => const LoadingPage(),
-        ),
+            builder: (_) => const LoadingPage(),
+            userData: const WizardRouteData(
+              canGoBack: false,
+              canGoNext: false,
+            )),
         ...preInstall.map(guardRoute),
         Routes.confirm: WizardRoute(
           builder: (_) => const ConfirmPage(),
@@ -200,8 +206,11 @@ class _AutoinstallWizard extends StatelessWidget {
     return Wizard(
       routes: <String, WizardRoute>{
         Routes.loading: WizardRoute(
-          builder: (_) => const LoadingPage(),
-        ),
+            builder: (_) => const LoadingPage(),
+            userData: const WizardRouteData(
+              canGoBack: false,
+              canGoNext: false,
+            )),
         Routes.confirm: WizardRoute(
           builder: (_) => const ConfirmPage(),
           onLoad: (_) => status?.isInstalling != true,

--- a/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer/installer_wizard.dart
@@ -119,7 +119,7 @@ class _InstallWizard extends ConsumerWidget {
         builder: (_) => const TimezonePage(),
         userData: WizardRouteData(
           step: InstallationStep.timezone.index,
-          canGoBack: false,
+          hasPrevious: false,
         ),
         onLoad: (_) => TimezonePage.load(context, ref),
       ),
@@ -163,8 +163,8 @@ class _InstallWizard extends ConsumerWidget {
         Routes.loading: WizardRoute(
             builder: (_) => const LoadingPage(),
             userData: const WizardRouteData(
-              canGoBack: false,
-              canGoNext: false,
+              hasPrevious: false,
+              hasNext: false,
             )),
         ...preInstall.map(guardRoute),
         Routes.confirm: WizardRoute(
@@ -208,8 +208,8 @@ class _AutoinstallWizard extends StatelessWidget {
         Routes.loading: WizardRoute(
             builder: (_) => const LoadingPage(),
             userData: const WizardRouteData(
-              canGoBack: false,
-              canGoNext: false,
+              hasPrevious: false,
+              hasNext: false,
             )),
         Routes.confirm: WizardRoute(
           builder: (_) => const ConfirmPage(),

--- a/packages/ubuntu_desktop_installer/lib/pages/loading/loading_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/loading/loading_page.dart
@@ -44,10 +44,8 @@ class _LoadingPageState extends ConsumerState<LoadingPage> {
         ],
       ),
       bottomBar: WizardBar(
-        leading: WizardButton.previous(context, enabled: false),
-        trailing: [
-          WizardButton.next(context, enabled: false),
-        ],
+        leading: WizardButton.previous(context),
+        trailing: [WizardButton.next(context)],
       ),
     );
   }

--- a/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/timezone/timezone_page.dart
@@ -113,10 +113,7 @@ class TimezonePage extends ConsumerWidget {
         ],
       ),
       bottomBar: WizardBar(
-        leading: WizardButton.previous(
-          context,
-          enabled: false,
-        ),
+        leading: WizardButton.previous(context),
         trailing: [
           WizardButton.next(
             context,

--- a/packages/ubuntu_desktop_installer/test/loading/loading_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/loading/loading_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/loading/loading_page.dart';
-import 'package:yaru_test/yaru_test.dart';
 
 import 'test_loading.dart';
 
@@ -15,13 +14,5 @@ void main() {
 
     await tester.pumpAndSettle(const Duration(seconds: 3));
     expect(find.byType(LoadingPage), findsNothing);
-  });
-
-  testWidgets('disabled buttons', (tester) async {
-    final model = MockLoadingModel();
-    await tester.pumpWidget(tester.buildApp((_) => buildLoadingPage(model)));
-
-    expect(find.button(tester.ulang.previousLabel), isDisabled);
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/timezone/timezone_page_test.dart
@@ -4,7 +4,6 @@ import 'package:mockito/mockito.dart';
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/pages/timezone/timezone_page.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
-import 'package:yaru_test/yaru_test.dart';
 
 import 'test_timezone.dart';
 
@@ -191,12 +190,5 @@ void main() {
       TimezonePage.formatTimezone(timezone),
       'America/New York',
     );
-  });
-
-  testWidgets('previous button is disabled', (tester) async {
-    final model = buildTimezoneModel();
-    await tester.pumpWidget(tester.buildApp((_) => buildTimezonePage(model)));
-
-    expect(find.button(tester.ulang.previousLabel), isDisabled);
   });
 }

--- a/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
@@ -6,6 +6,10 @@ class WizardData {
 class WizardRouteData {
   const WizardRouteData({
     this.step,
+    this.canGoBack,
+    this.canGoNext,
   });
   final int? step;
+  final bool? canGoBack;
+  final bool? canGoNext;
 }

--- a/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/wizard_data.dart
@@ -6,10 +6,10 @@ class WizardData {
 class WizardRouteData {
   const WizardRouteData({
     this.step,
-    this.canGoBack,
-    this.canGoNext,
+    this.hasPrevious,
+    this.hasNext,
   });
   final int? step;
-  final bool? canGoBack;
-  final bool? canGoNext;
+  final bool? hasPrevious;
+  final bool? hasNext;
 }

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
@@ -47,7 +47,7 @@ class WizardButton extends StatefulWidget {
         visible: visible,
         flat: true,
         enabled: wizard?.isLoading != true &&
-            (routeData?.canGoBack ?? wizard?.hasPrevious ?? false),
+            (routeData?.hasPrevious ?? wizard?.hasPrevious ?? false),
         onActivated: onBack,
         execute: wizard?.back,
       ),
@@ -78,7 +78,7 @@ class WizardButton extends StatefulWidget {
                 : UbuntuLocalizations.of(context).nextLabel),
         visible: visible,
         enabled: wizard?.isLoading != true &&
-            (enabled ?? routeData?.canGoNext ?? true),
+            (enabled ?? routeData?.hasNext ?? true),
         loading: wizard?.isLoading ?? false,
         flat: flat,
         highlighted: highlighted,

--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_wizard/utils.dart';
 import 'package:wizard_router/wizard_router.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -34,11 +35,11 @@ class WizardButton extends StatefulWidget {
   static Widget previous(
     BuildContext context, {
     bool? visible,
-    bool? enabled,
     WizardCallback? onBack,
     bool root = false,
   }) {
     final wizard = Wizard.maybeOf(context, root: root);
+    final routeData = wizard?.routeData as WizardRouteData?;
     return AnimatedBuilder(
       animation: wizard?.controller ?? _noAnimation,
       builder: (context, child) => WizardButton(
@@ -46,7 +47,7 @@ class WizardButton extends StatefulWidget {
         visible: visible,
         flat: true,
         enabled: wizard?.isLoading != true &&
-            (enabled ?? wizard?.hasPrevious ?? false),
+            (routeData?.canGoBack ?? wizard?.hasPrevious ?? false),
         onActivated: onBack,
         execute: wizard?.back,
       ),
@@ -67,6 +68,7 @@ class WizardButton extends StatefulWidget {
     bool root = false,
   }) {
     final wizard = Wizard.maybeOf(context, root: root);
+    final routeData = wizard?.routeData as WizardRouteData?;
     return AnimatedBuilder(
       animation: wizard?.controller ?? _noAnimation,
       builder: (context, child) => WizardButton(
@@ -75,7 +77,8 @@ class WizardButton extends StatefulWidget {
                 ? UbuntuLocalizations.of(context).doneLabel
                 : UbuntuLocalizations.of(context).nextLabel),
         visible: visible,
-        enabled: wizard?.isLoading != true && (enabled ?? true),
+        enabled: wizard?.isLoading != true &&
+            (enabled ?? routeData?.canGoNext ?? true),
         loading: wizard?.isLoading ?? false,
         flat: flat,
         highlighted: highlighted,


### PR DESCRIPTION
Moves the control over whether or not the next/previous buttons are enabled from the pages to the `WizardRoute` using the `userData` property.