### PR TITLE
fix(wizard): guard against setState() when already unmounted

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
@@ -146,8 +146,10 @@ class _WizardButtonState extends State<WizardButton> {
         ? () async {
             setState(() => activating = true);
             await widget.onActivated?.call();
-            setState(() => activating = false);
-            if (mounted) widget.execute?.call();
+            if (mounted) {
+              setState(() => activating = false);
+              widget.execute?.call();
+            }
           }
         : null;
 


### PR DESCRIPTION
Spotted while running the screenshot test locally:
```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test (but after the test had completed):
setState() called after dispose(): _WizardButtonState#9e800(lifecycle state: defunct, not mounted)
This error happens if you call setState() on a State object for a widget that no longer appears in
the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error
can occur when code calls setState() from a timer or an animation callback.
The preferred solution is to cancel the timer or stop listening to the animation in the dispose()
callback. Another solution is to check the "mounted" property of this object before calling
setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is
retaining a reference to this State object after it has been removed from the tree. To avoid memory
leaks, consider breaking the reference to this object during dispose().

When the exception was thrown, this was the stack:
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1103:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1138:6)
#2      _WizardButtonState.build.<anonymous closure> (package:ubuntu_wizard/src/widgets/wizard_button.dart:149:13)
<asynchronous suspension>
════════════════════════════════════════════════════════════════════════════════════════════════════
```