### PR TITLE
refactor(storage): remove non-existent "reinstall" option

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/storage/installation_type/installation_type_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/installation_type/installation_type_model.dart
@@ -9,9 +9,6 @@ enum InstallationType {
   /// Erase entire disk and perform guided partitioning.
   erase,
 
-  /// Replace existing OS installation.
-  reinstall,
-
   /// Install alongside existing OS installation.
   alongside,
 
@@ -125,8 +122,6 @@ class InstallationTypeModel extends SafeChangeNotifier {
       case InstallationType.alongside:
         return !_diskService.useEncryption &&
             _storages?.any((t) => t is GuidedStorageTargetUseGap) == true;
-      case InstallationType.reinstall:
-        throw UnimplementedError();
       case InstallationType.manual:
       case InstallationType.bitlocker:
       case null:
@@ -197,8 +192,6 @@ class InstallationTypeModel extends SafeChangeNotifier {
       return 'use_crypto';
     } else if (installationType == InstallationType.erase) {
       return 'use_device';
-    } else if (installationType == InstallationType.reinstall) {
-      return 'reinstall_partition';
     } else if (installationType == InstallationType.alongside) {
       return 'resize_use_free';
     } else if (installationType == InstallationType.manual) {

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/installation_type/installation_type_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/installation_type/installation_type_page.dart
@@ -72,20 +72,6 @@ class InstallationTypePage extends ConsumerWidget {
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // TODO: offer "reinstall" when subiquity has support for it
-          // if (model.existingOS != null)
-          //   YaruRadioButton<InstallationType>(
-          //     title: Text(lang.installationTypeReinstall(model.existingOS!)),
-          //     subtitle: Html(
-          //       data: lang.installationTypeReinstallWarning(
-          //           Theme.of(context).errorColor.toHex(), model.existingOS!),
-          //       style: {'body': Style(margin: EdgeInsets.zero)},
-          //     ),
-          //     value: InstallationType.reinstall,
-          //     groupValue: model.installationType,
-          //     onChanged: (v) => model.installationType = v!,
-          //   ),
-          // if (model.existingOS != null) const SizedBox(height: kContentSpacing),
           if (model.canInstallAlongside || model.hasBitLocker)
             Padding(
               padding: const EdgeInsets.only(bottom: kContentSpacing),

--- a/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_model_test.dart
@@ -111,12 +111,6 @@ void main() {
     verify(telemetry.addMetric('PartitionMethod', 'use_device')).called(1);
     reset(telemetry);
 
-    model.installationType = InstallationType.reinstall;
-    await model.save();
-    verify(telemetry.addMetric('PartitionMethod', 'reinstall_partition'))
-        .called(1);
-    reset(telemetry);
-
     model.installationType = InstallationType.alongside;
     await model.save();
     verify(telemetry.addMetric('PartitionMethod', 'resize_use_free')).called(1);
@@ -262,7 +256,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // reformat
@@ -272,7 +265,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), reformat);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // multiple reformats
@@ -281,7 +273,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // resize
@@ -298,7 +289,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), isNull);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // gap
@@ -312,7 +302,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), gap);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // multiple gaps
@@ -331,7 +320,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), isNull);
     expect(model.preselectTarget(InstallationType.alongside), gap3);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
 
     // all
@@ -340,7 +328,6 @@ void main() {
     await model.init();
     expect(model.preselectTarget(InstallationType.erase), reformat);
     expect(model.preselectTarget(InstallationType.alongside), gap);
-    expect(model.preselectTarget(InstallationType.reinstall), isNull);
     expect(model.preselectTarget(InstallationType.manual), isNull);
   });
 

--- a/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/installation_type/installation_type_page_test.dart
@@ -82,24 +82,6 @@ void main() {
     );
   });
 
-  testWidgets('reinstall', (tester) async {
-    final model = buildInstallationTypeModel(existingOS: [
-      const OsProber(
-        long: 'Ubuntu 18.04 LTS',
-        label: 'Ubuntu',
-        version: '18.04 LTS',
-        type: 'ext4',
-      )
-    ]);
-    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
-
-    final radio = find.radioButton<InstallationType>(
-        tester.lang.installationTypeReinstall('Ubuntu 18.04 LTS'));
-    expect(radio, findsOneWidget);
-    await tester.tap(radio);
-    verify(model.installationType = InstallationType.reinstall).called(1);
-  }, skip: true);
-
   testWidgets('alongside windows', (tester) async {
     final model = buildInstallationTypeModel(
       productInfo: ProductInfo(name: 'Ubuntu 22.10'),


### PR DESCRIPTION
There's no such feature in Subiquity. The radio button has been commented out from the GUI for 1.5 years. Maintaining the non-existent option in the view model causes unnecessary confusion while refactoring. Adding such a radio button will be trivial if/when there's support in the backend.