### PR TITLE
fix(welcome): override subiquity_client/test deps while they exist

### DIFF
--- a/packages/ubuntu_welcome/pubspec_overrides.yaml
+++ b/packages/ubuntu_welcome/pubspec_overrides.yaml
@@ -1,3 +1,8 @@
 dependency_overrides:
+  # TODO: remove subiquity dependencies
+  subiquity_client:
+    path: ../subiquity_client
+  subiquity_test:
+    path: ../subiquity_client/packages/subiquity_test
   ubuntu_wizard:
     path: ../ubuntu_wizard


### PR DESCRIPTION
Override the correct local dependencies from the Git submodule until these undesired dependencies go away after the upcoming modularization, to avoid breaking due to API changes in subiquity_client.

See also:
- https://github.com/canonical/subiquity_client.dart/pull/140
- https://github.com/canonical/ubuntu-desktop-installer/actions/runs/5276064005/jobs/9542284049?pr=2117