### PR TITLE
chore(snap): bump flutter version from 3.10.0 to 3.10.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.10.0
+    source-tag: 3.10.5
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
Changes:
- [3.10.1](https://groups.google.com/g/flutter-announce/c/YOkzZCpg0Yw)
- [3.10.2](https://groups.google.com/g/flutter-announce/c/NpwFtyEGzLw)
- [3.10.3](https://groups.google.com/g/flutter-announce/c/iRmERLM6d0Q)
- [3.10.4](https://groups.google.com/g/flutter-announce/c/IAoGHTIihR0)
- [3.10.5](https://groups.google.com/g/flutter-announce/c/1JBR_ZG9Y-4)