### PR TITLE
fix(storage): broadcast selection changes to allow re-subscribing

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/storage/manual/manual_storage_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/manual/manual_storage_model.dart
@@ -102,7 +102,7 @@ class ManualStorageModel extends SafeChangeNotifier {
 
   /// Notifies selection changes for auto-scrolling.
   Stream get onSelectionChanged => _selectionController.stream;
-  final _selectionController = StreamController();
+  final _selectionController = StreamController.broadcast();
 
   /// Whether a partition can be added for the currently selected disk.
   bool get canAddPartition => selectedGap?.usable == GapUsable.YES;


### PR DESCRIPTION
We are intentionally not disposing view-models when navigating back to keep the view state intact. However, single-subscription streams don't allow multiple subscriptions or even re-subscribing after closing. Therefore we must use a broadcast stream to allow the page to re-subscribe when navigating back and forth.

## Before

[Screencast from 2023-06-15 13-53-42.webm](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/91dd3328-85df-44ce-b90a-22513b7bf0f4)

## After

[Screencast from 2023-06-15 13-55-45.webm](https://github.com/canonical/ubuntu-desktop-installer/assets/140617/fd3834fe-561c-48f1-a39d-7e693432706f)