### PR TITLE
chore(makefile): add aptdeps & gitdeps targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
+SUBIQUITY_DIR = packages/subiquity_client/subiquity
+
+$(SUBIQUITY_DIR):
+	[ -d $(SUBIQUITY_DIR) ] || git submodule update --init --recursive
+
+.PHONY: aptdeps
+aptdeps: $(SUBIQUITY_DIR)
+	$(MAKE) -C $(SUBIQUITY_DIR) aptdeps
+
+.PHONY: gitdeps
+gitdeps: $(SUBIQUITY_DIR)
+	$(MAKE) -C $(SUBIQUITY_DIR) gitdeps
+
 .PHONY: install_deps
-install_deps:
-	@[ -d packages/subiquity_client/subiquity ] || git submodule update --init --recursive
-	@$(MAKE) -C packages/subiquity_client/subiquity install_deps
+install_deps: $(SUBIQUITY_DIR)
+	$(MAKE) -C $(SUBIQUITY_DIR) install_deps


### PR DESCRIPTION
For more fine-grained control over updating subiquity's dependencies.

- `aptdeps`: install system dependencies via apt
- `gitdeps`: install local git dependencies i.e. curtin & probert
- `install_deps`: both

Especially `gitdeps` is nice to have separately because it's occasionally needed after submodule updates.