### PR TITLE
feat(wizard): add proper support for nested wizards

### DIFF
--- a/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/widgets/wizard_button.dart
@@ -35,22 +35,32 @@ class WizardButton extends StatefulWidget {
   static Widget previous(
     BuildContext context, {
     bool? visible,
+    bool? enabled,
     WizardCallback? onBack,
-    bool root = false,
+    bool root = false, // TODO: remove
   }) {
     final wizard = Wizard.maybeOf(context, root: root);
-    final routeData = wizard?.routeData as WizardRouteData?;
+    final rootWizard = root ? wizard : Wizard.maybeOf(context, root: true);
+    final routeData =
+        (wizard?.routeData ?? rootWizard?.routeData) as WizardRouteData?;
+    final hasPrevious = routeData?.hasPrevious ??
+        (wizard?.hasPrevious == true || rootWizard?.hasPrevious == true);
+    final isLoading =
+        wizard?.isLoading == true || rootWizard?.isLoading == true;
     return AnimatedBuilder(
       animation: wizard?.controller ?? _noAnimation,
       builder: (context, child) => WizardButton(
-        label: UbuntuLocalizations.of(context).previousLabel,
-        visible: visible,
-        flat: true,
-        enabled: wizard?.isLoading != true &&
-            (routeData?.hasPrevious ?? wizard?.hasPrevious ?? false),
-        onActivated: onBack,
-        execute: wizard?.back,
-      ),
+          label: UbuntuLocalizations.of(context).previousLabel,
+          visible: visible,
+          flat: true,
+          enabled: !isLoading && (enabled ?? hasPrevious),
+          onActivated: onBack,
+          execute: () {
+            // navigate the root wizard at the end of a nested wizard
+            final effectiveWizard =
+                wizard?.hasPrevious == true ? wizard : rootWizard;
+            return effectiveWizard?.back();
+          }),
     );
   }
 
@@ -65,26 +75,33 @@ class WizardButton extends StatefulWidget {
     Object? arguments,
     WizardCallback? onNext,
     WizardCallback? onBack,
-    bool root = false,
+    bool root = false, // TODO: remove
   }) {
     final wizard = Wizard.maybeOf(context, root: root);
-    final routeData = wizard?.routeData as WizardRouteData?;
+    final rootWizard = root ? wizard : Wizard.maybeOf(context, root: true);
+    final routeData =
+        (wizard?.routeData ?? rootWizard?.routeData) as WizardRouteData?;
+    final hasNext = routeData?.hasNext ??
+        (wizard?.hasNext == true || rootWizard?.hasNext == true);
+    final isLoading =
+        wizard?.isLoading == true || rootWizard?.isLoading == true;
     return AnimatedBuilder(
       animation: wizard?.controller ?? _noAnimation,
       builder: (context, child) => WizardButton(
         label: label ??
-            (wizard?.hasNext == false
-                ? UbuntuLocalizations.of(context).doneLabel
-                : UbuntuLocalizations.of(context).nextLabel),
+            (hasNext
+                ? UbuntuLocalizations.of(context).nextLabel
+                : UbuntuLocalizations.of(context).doneLabel),
         visible: visible,
-        enabled: wizard?.isLoading != true &&
-            (enabled ?? routeData?.hasNext ?? true),
-        loading: wizard?.isLoading ?? false,
+        enabled: !isLoading && (enabled ?? hasNext),
+        loading: isLoading,
         flat: flat,
         highlighted: highlighted,
         onActivated: onNext,
         execute: () async {
-          await wizard?.next(arguments: arguments);
+          // navigate the root wizard at the end of a nested wizard
+          final effectiveWizard = wizard?.hasNext == true ? wizard : rootWizard;
+          await effectiveWizard?.next(arguments: arguments);
           onBack?.call();
         },
       ),

--- a/packages/ubuntu_wizard/test/nested_wizard_test.dart
+++ b/packages/ubuntu_wizard/test/nested_wizard_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:ubuntu_wizard/widgets.dart';
+
+void main() {
+  Widget buildPage(BuildContext context, String title) {
+    return WizardPage(
+      content: Text(title),
+      bottomBar: WizardBar(
+        leading: WizardButton.previous(context),
+        trailing: [WizardButton.next(context)],
+      ),
+    );
+  }
+
+  testWidgets('nested wizard', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
+        home: Wizard(
+          routes: {
+            '/1': WizardRoute(builder: (ctx) => buildPage(ctx, '1')),
+            '/2': WizardRoute(
+              builder: (_) => Wizard(
+                routes: {
+                  '/a': WizardRoute(builder: (ctx) => buildPage(ctx, '2A')),
+                  '/b': WizardRoute(builder: (ctx) => buildPage(ctx, '2B')),
+                  '/c': WizardRoute(builder: (ctx) => buildPage(ctx, '2C')),
+                },
+              ),
+            ),
+            '/3': WizardRoute(builder: (ctx) => buildPage(ctx, '3')),
+          },
+        ),
+      ),
+    );
+
+    final page1 = find.text('1');
+    final page2a = find.text('2A');
+    final page2b = find.text('2B');
+    final page2c = find.text('2C');
+    final page3 = find.text('3');
+
+    await tester.pumpAndSettle();
+    expect(page1, findsOneWidget);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    expect(page2a, findsOneWidget);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    expect(page2b, findsOneWidget);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    expect(page2c, findsOneWidget);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    expect(page3, findsOneWidget);
+
+    await tester.tapPrevious();
+    await tester.pumpAndSettle();
+    expect(page2c, findsOneWidget);
+
+    await tester.tapPrevious();
+    await tester.pumpAndSettle();
+    expect(page2b, findsOneWidget);
+
+    await tester.tapPrevious();
+    await tester.pumpAndSettle();
+    expect(page2a, findsOneWidget);
+
+    await tester.tapPrevious();
+    await tester.pumpAndSettle();
+    expect(page1, findsOneWidget);
+  });
+}


### PR DESCRIPTION
This PR makes nested wizards work out of the box by automatically looking up the root wizard when navigating past the boundary of a sub-wizard.

The problem with passing `root: true` for accessing the root wizard from a sub-wizard is that it creates an assumption on the wizard structure. We don't want individual pages to hard-code such assumptions about what comes next because it prevents the respective routes from being configurable.

Instead, we need a declarative set of independent onLoad-guarded routes that can be wired up with route configuration as we did with the top-level wizard.