### PR TITLE
refactor: use SessionService to reboot

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -83,6 +83,8 @@ Future<void> runInstallerApp(
       () => SubiquityNetworkService(getService<SubiquityClient>()));
   tryRegisterService(PowerService.new);
   tryRegisterService(ProductService.new);
+  tryRegisterService<SessionService>(
+      () => SubiquitySessionService(getService<SubiquityClient>()));
   tryRegisterService(() => StorageService(getService<SubiquityClient>()));
   tryRegisterService(SubiquityClient.new);
   tryRegisterService(

--- a/packages/ubuntu_desktop_installer/lib/pages/install/install_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/install/install_model.dart
@@ -14,6 +14,7 @@ final installModelProvider = ChangeNotifierProvider(
     getService<SubiquityClient>(),
     getService<JournalService>(),
     getService<ProductService>(),
+    getService<SessionService>(),
   ),
 );
 
@@ -57,11 +58,12 @@ class InstallationEvent {
 /// View model for [InstallPage].
 class InstallModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
-  InstallModel(this._client, this._journal, this._product);
+  InstallModel(this._client, this._journal, this._product, this._session);
 
   final SubiquityClient _client;
   final JournalService _journal;
   final ProductService _product;
+  final SessionService _session;
 
   Stream<String>? _log;
   ApplicationStatus? _status;
@@ -187,5 +189,5 @@ class InstallModel extends SafeChangeNotifier {
     subscription.cancel();
   }
 
-  Future<void> reboot() => _client.reboot(immediate: false);
+  Future<void> reboot() => _session.reboot(immediate: false);
 }

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/bitlocker/bitlocker_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/bitlocker/bitlocker_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
-import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
@@ -8,17 +7,17 @@ import 'package:ubuntu_logger/ubuntu_logger.dart';
 final log = Logger('bitlocker');
 
 /// Provider for [BitLockerModel].
-final bitLockerModelProvider = ChangeNotifierProvider(
-    (_) => BitLockerModel(getService<SubiquityClient>()));
+final bitLockerModelProvider =
+    ChangeNotifierProvider((_) => BitLockerModel(getService<SessionService>()));
 
 /// View model for [BitLockerPage].
 class BitLockerModel extends SafeChangeNotifier {
   /// Creates an instance with the given client.
-  BitLockerModel(this._client) {
+  BitLockerModel(this._session) {
     log.info('BitLocker must be turned off');
   }
 
-  final SubiquityClient _client;
+  final SessionService _session;
 
-  Future<void> reboot() => _client.reboot(immediate: true);
+  Future<void> reboot() => _session.reboot(immediate: true);
 }

--- a/packages/ubuntu_desktop_installer/test/install/install_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install/install_model_test.dart
@@ -19,6 +19,7 @@ void main() async {
       MockSubiquityClient(),
       MockJournalService(),
       product,
+      MockSessionService(),
     );
     expect(model.productInfo.name, 'Ubuntu');
     expect(model.productInfo.version, '24.04 LTS');
@@ -32,7 +33,8 @@ void main() async {
     when(journal.start(['event'], output: JournalOutput.cat))
         .thenAnswer((_) => const Stream.empty());
     final product = MockProductService();
-    final model = InstallModel(client, journal, product);
+    final session = MockSessionService();
+    final model = InstallModel(client, journal, product, session);
 
     ApplicationState? currentState;
     for (final nextState in ApplicationState.values) {
@@ -75,7 +77,8 @@ void main() async {
 
     final product = MockProductService();
 
-    final model = InstallModel(client, journal, product);
+    final session = MockSessionService();
+    final model = InstallModel(client, journal, product, session);
 
     expect(model.state, isNull);
     expect(model.isInstalling, isFalse);
@@ -123,7 +126,8 @@ void main() async {
 
     final product = MockProductService();
 
-    final model = InstallModel(client, journal, product);
+    final session = MockSessionService();
+    final model = InstallModel(client, journal, product, session);
 
     expect(model.hasError, isFalse);
 
@@ -137,6 +141,7 @@ void main() async {
       MockSubiquityClient(),
       MockJournalService(),
       MockProductService(),
+      MockSessionService(),
     );
     expect(model.isLogVisible, isFalse);
 
@@ -154,11 +159,16 @@ void main() async {
 
   test('reboot', () async {
     final client = MockSubiquityClient();
-    final model =
-        InstallModel(client, MockJournalService(), MockProductService());
+    final session = MockSessionService();
+    final model = InstallModel(
+      client,
+      MockJournalService(),
+      MockProductService(),
+      session,
+    );
 
     await model.reboot();
-    verify(client.reboot(immediate: false)).called(1);
+    verify(session.reboot(immediate: false)).called(1);
   });
 
   test('events', () async {
@@ -180,7 +190,8 @@ void main() async {
 
     final product = MockProductService();
 
-    final model = InstallModel(client, journal, product);
+    final session = MockSessionService();
+    final model = InstallModel(client, journal, product, session);
 
     expect(model.event.action, InstallationAction.none);
 

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -45,6 +45,7 @@ void main() {
   });
 
   testWidgets('fully automated installation', (tester) async {
+    registerMockService<SessionService>(MockSessionService());
     await tester.pumpWidget(
       tester.buildInstaller(
         state: ApplicationState.RUNNING,

--- a/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
@@ -256,6 +256,7 @@ void main() {
     final storage = MockStorageService();
     when(storage.guidedTarget).thenReturn(null);
 
+    registerMockService<SessionService>(MockSessionService());
     registerMockService<StorageService>(storage);
     registerMockService<SubiquityClient>(MockSubiquityClient());
     registerMockService<TelemetryService>(MockTelemetryService());

--- a/packages/ubuntu_desktop_installer/test/storage/bitlocker/bitlocker_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/bitlocker/bitlocker_model_test.dart
@@ -1,14 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/bitlocker/bitlocker_model.dart';
+
+import '../../test_utils.dart';
 
 void main() async {
   test('reboot', () async {
-    final client = MockSubiquityClient();
-    final model = BitLockerModel(client);
+    final session = MockSessionService();
+    final model = BitLockerModel(session);
 
     await model.reboot();
-    verify(client.reboot(immediate: true)).called(1);
+    verify(session.reboot(immediate: true)).called(1);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/test_utils.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.dart
@@ -92,6 +92,7 @@ extension InstallerTester on WidgetTester {
   NetworkService,
   PowerService,
   ProductService,
+  SessionService,
   SoundService,
   StorageService,
   TelemetryService,

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -28,14 +28,15 @@ import 'package:ubuntu_desktop_installer/services/locale_service.dart' as _i19;
 import 'package:ubuntu_desktop_installer/services/network_service.dart' as _i20;
 import 'package:ubuntu_desktop_installer/services/power_service.dart' as _i22;
 import 'package:ubuntu_desktop_installer/services/product_service.dart' as _i5;
-import 'package:ubuntu_desktop_installer/services/sound_service.dart' as _i23;
-import 'package:ubuntu_desktop_installer/services/storage_service.dart' as _i24;
+import 'package:ubuntu_desktop_installer/services/session_service.dart' as _i23;
+import 'package:ubuntu_desktop_installer/services/sound_service.dart' as _i24;
+import 'package:ubuntu_desktop_installer/services/storage_service.dart' as _i25;
 import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
-    as _i25;
-import 'package:ubuntu_desktop_installer/services/timezone_service.dart'
     as _i26;
+import 'package:ubuntu_desktop_installer/services/timezone_service.dart'
+    as _i27;
 import 'package:ubuntu_desktop_installer/services/udev_service.dart' as _i6;
-import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i27;
+import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i28;
 import 'package:upower/upower.dart' as _i4;
 
 // ignore_for_file: type=lint
@@ -1095,10 +1096,40 @@ class MockProductService extends _i1.Mock implements _i5.ProductService {
       ) as _i5.ProductInfo);
 }
 
+/// A class which mocks [SessionService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockSessionService extends _i1.Mock implements _i23.SessionService {
+  MockSessionService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i8.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
+        Invocation.method(
+          #reboot,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
+  _i8.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+        Invocation.method(
+          #shutdown,
+          [],
+          {#immediate: immediate},
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+}
+
 /// A class which mocks [SoundService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSoundService extends _i1.Mock implements _i23.SoundService {
+class MockSoundService extends _i1.Mock implements _i24.SoundService {
   MockSoundService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1117,7 +1148,7 @@ class MockSoundService extends _i1.Mock implements _i23.SoundService {
 /// A class which mocks [StorageService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStorageService extends _i1.Mock implements _i24.StorageService {
+class MockStorageService extends _i1.Mock implements _i25.StorageService {
   MockStorageService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1341,7 +1372,7 @@ class MockStorageService extends _i1.Mock implements _i24.StorageService {
 /// A class which mocks [TelemetryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTelemetryService extends _i1.Mock implements _i25.TelemetryService {
+class MockTelemetryService extends _i1.Mock implements _i26.TelemetryService {
   MockTelemetryService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1396,7 +1427,7 @@ class MockTelemetryService extends _i1.Mock implements _i25.TelemetryService {
 /// A class which mocks [TimezoneService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTimezoneService extends _i1.Mock implements _i26.TimezoneService {
+class MockTimezoneService extends _i1.Mock implements _i27.TimezoneService {
   MockTimezoneService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1476,7 +1507,7 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
 /// A class which mocks [UrlLauncher].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUrlLauncher extends _i1.Mock implements _i27.UrlLauncher {
+class MockUrlLauncher extends _i1.Mock implements _i28.UrlLauncher {
   MockUrlLauncher() {
     _i1.throwOnMissingStub(this);
   }


### PR DESCRIPTION
Uses the new `SessionService` rather than `SubiquityClient` to reboot in ubuntu_desktop_installer.
WSL setup still uses subiquity directly, since it's not yet using any other abstract services either.

UDENG-742