### PR TITLE
feat(identity): set account password when using the XDG backend

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -163,7 +163,7 @@ class IdentityModel extends PropertyStreamNotifier {
     _realName.value ??= identity.realname.orIfEmpty(null);
     _hostname.value ??= identity.hostname.orIfEmpty(null);
     _username.value ??= identity.username.orIfEmpty(null);
-    log.info('Loaded identity: ${identity.description}');
+    log.info('Loaded identity: $identity');
     _productName.value = await _readProductName();
     log.info('Read product name: ${_productName.value}');
 
@@ -173,15 +173,15 @@ class IdentityModel extends PropertyStreamNotifier {
   }
 
   /// Saves the identity data to the server.
-  Future<void> save({@visibleForTesting String? salt}) async {
+  Future<void> save() async {
     final identity = Identity(
       realname: realName,
       hostname: hostname,
       username: username,
-      cryptedPassword: encryptPassword(password, salt: salt),
+      password: password,
       autoLogin: autoLogin,
     );
-    log.info('Saved identity: ${identity.description}');
+    log.info('Saved identity: $identity');
 
     _telemetry?.addMetric('UseActiveDirectory', useActiveDirectory);
 
@@ -217,12 +217,6 @@ Future<String> _readProductName() async {
     productName = await _readDmiFile(kDMIProductNameFile);
   }
   return productName;
-}
-
-extension _IdentityDescription on Identity {
-  String get description {
-    return 'realname: "$realname", hostname: "$hostname", username: "$username"';
-  }
 }
 
 extension _StringTruncate on String {

--- a/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
@@ -23,6 +23,22 @@ class Identity {
   final String hostname;
   final bool autoLogin;
 
+  Identity copyWith({
+    String? realname,
+    String? username,
+    String? password,
+    String? hostname,
+    bool? autoLogin,
+  }) {
+    return Identity(
+      realname: realname ?? this.realname,
+      username: username ?? this.username,
+      password: password ?? this.password,
+      hostname: hostname ?? this.hostname,
+      autoLogin: autoLogin ?? this.autoLogin,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_wizard/utils.dart';
 
 import 'config_service.dart';
 
@@ -11,14 +12,14 @@ class Identity {
   const Identity({
     this.realname = '',
     this.username = '',
-    this.cryptedPassword = '',
+    this.password = '',
     this.hostname = '',
     this.autoLogin = false,
   });
 
   final String realname;
   final String username;
-  final String cryptedPassword;
+  final String password;
   final String hostname;
   final bool autoLogin;
 
@@ -28,7 +29,7 @@ class Identity {
     return other is Identity &&
         other.realname == realname &&
         other.username == username &&
-        other.cryptedPassword == cryptedPassword &&
+        other.password == password &&
         other.hostname == hostname &&
         other.autoLogin == autoLogin;
   }
@@ -38,7 +39,7 @@ class Identity {
     return Object.hash(
       realname,
       username,
-      cryptedPassword,
+      password,
       hostname,
       autoLogin,
     );
@@ -46,7 +47,8 @@ class Identity {
 
   @override
   String toString() {
-    return 'Identity(realname: $realname, username: $username, cryptedPassword: $cryptedPassword, hostname: $hostname, autoLogin: $autoLogin)';
+    final hiddenPassword = '*' * password.length;
+    return 'Identity(realname: $realname, username: $username, password: $hiddenPassword, hostname: $hostname, autoLogin: $autoLogin)';
   }
 }
 
@@ -72,7 +74,6 @@ class SubiquityIdentityService implements IdentityService {
     return Identity(
       realname: data.realname,
       username: data.username,
-      cryptedPassword: data.cryptedPassword,
       hostname: data.hostname,
       autoLogin: await _config.get(kAutoLoginUser) != null,
     );
@@ -89,7 +90,7 @@ class SubiquityIdentityService implements IdentityService {
     return _subiquity.setIdentity(IdentityData(
       realname: identity.realname,
       username: identity.username,
-      cryptedPassword: identity.cryptedPassword,
+      cryptedPassword: encryptPassword(identity.password),
       hostname: identity.hostname,
     ));
   }

--- a/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_model_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/identity/identity_model.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
-import 'package:ubuntu_wizard/utils.dart';
 
 import 'test_identity.dart';
 
@@ -22,7 +21,7 @@ void main() {
     const identity = Identity(
       realname: 'Ubuntu',
       username: 'ubuntu',
-      cryptedPassword: 'anything',
+      password: 'anything',
       hostname: 'impish',
     );
 
@@ -145,10 +144,10 @@ void main() {
   });
 
   test('save', () async {
-    final identity = Identity(
+    const identity = Identity(
       realname: 'Ubuntu',
       username: 'ubuntu',
-      cryptedPassword: encryptPassword('passwd', salt: 'test'),
+      password: 'passwd',
       hostname: 'impish',
     );
 
@@ -175,7 +174,7 @@ void main() {
     model.autoLogin = false;
     model.useActiveDirectory = false;
 
-    await model.save(salt: 'test');
+    await model.save();
 
     verify(service.setIdentity(identity)).called(1);
     verify(activeDirectory.setUsed(false)).called(1);
@@ -202,18 +201,18 @@ void main() {
     model.password = 'not-empty';
 
     model.autoLogin = true;
-    await model.save(salt: 'test');
-    verify(service.setIdentity(Identity(
+    await model.save();
+    verify(service.setIdentity(const Identity(
       username: 'someone',
-      cryptedPassword: encryptPassword('not-empty', salt: 'test'),
+      password: 'not-empty',
       autoLogin: true,
     ))).called(1);
 
     model.autoLogin = false;
-    await model.save(salt: 'test');
-    verify(service.setIdentity(Identity(
+    await model.save();
+    verify(service.setIdentity(const Identity(
       username: 'someone',
-      cryptedPassword: encryptPassword('not-empty', salt: 'test'),
+      password: 'not-empty',
       autoLogin: false,
     ))).called(1);
   });

--- a/packages/ubuntu_desktop_installer/test/identity/test_identity.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/test_identity.mocks.dart
@@ -189,11 +189,10 @@ class MockIdentityModel extends _i1.Mock implements _i2.IdentityModel {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
-  _i5.Future<void> save({String? salt}) => (super.noSuchMethod(
+  _i5.Future<void> save() => (super.noSuchMethod(
         Invocation.method(
           #save,
           [],
-          {#salt: salt},
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/packages/ubuntu_desktop_installer/test/services/identity_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/identity_service_test.dart
@@ -7,25 +7,27 @@ import 'package:ubuntu_desktop_installer/services/identity_service.dart';
 import '../identity/test_identity.dart';
 
 void main() {
-  const testIdentityData = IdentityData(
+  const testIdentity = IdentityData(
     realname: 'Arthur Dent',
     username: 'adent',
     hostname: 'heart-of-gold',
   );
-  const testIdentity = Identity(
-    realname: 'Arthur Dent',
-    username: 'adent',
-    hostname: 'heart-of-gold',
-    autoLogin: true,
-  );
+
   test('get identity', () async {
     final client = MockSubiquityClient();
-    when(client.getIdentity()).thenAnswer((_) async => testIdentityData);
+    when(client.getIdentity()).thenAnswer((_) async => testIdentity);
     final config = MockConfigService();
     when(config.get(SubiquityIdentityService.kAutoLoginUser))
         .thenAnswer((_) async => testIdentity.username);
     final service = SubiquityIdentityService(client, config);
-    expect(await service.getIdentity(), equals(testIdentity));
+    expect(
+        await service.getIdentity(),
+        equals(Identity(
+          realname: testIdentity.realname,
+          username: testIdentity.username,
+          hostname: testIdentity.hostname,
+          autoLogin: true,
+        )));
 
     verify(client.getIdentity()).called(1);
     verify(config.get(SubiquityIdentityService.kAutoLoginUser)).called(1);
@@ -35,9 +37,21 @@ void main() {
     final client = MockSubiquityClient();
     final config = MockConfigService();
     final service = SubiquityIdentityService(client, config);
-    await service.setIdentity(testIdentity);
+    await service.setIdentity(Identity(
+      realname: testIdentity.realname,
+      username: testIdentity.username,
+      hostname: testIdentity.hostname,
+      password: 'password',
+      autoLogin: true,
+    ));
 
-    verify(client.setIdentity(testIdentityData)).called(1);
+    verify(client.setIdentity(argThat(isA<IdentityData>()
+            .having((i) => i.realname, 'realname', testIdentity.realname)
+            .having((i) => i.username, 'username', testIdentity.username)
+            .having((i) => i.hostname, 'hostname', testIdentity.hostname)
+            .having((i) => i.cryptedPassword, 'cryptedPassword',
+                hasLength(greaterThan(8))))))
+        .called(1);
     verify(config.set(
             SubiquityIdentityService.kAutoLoginUser, testIdentity.username))
         .called(1);

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -35,7 +35,7 @@ import 'package:ubuntu_desktop_installer/services/telemetry_service.dart'
 import 'package:ubuntu_desktop_installer/services/timezone_service.dart'
     as _i27;
 import 'package:ubuntu_desktop_installer/services/udev_service.dart' as _i7;
-import 'package:ubuntu_wizard/src/utils/url_launcher.dart' as _i28;
+import 'package:ubuntu_wizard/utils.dart' as _i28;
 import 'package:upower/upower.dart' as _i5;
 
 // ignore_for_file: type=lint

--- a/packages/ubuntu_welcome/lib/services/xdg_identity_service.dart
+++ b/packages/ubuntu_welcome/lib/services/xdg_identity_service.dart
@@ -104,7 +104,7 @@ class XdgIdentityService implements IdentityService {
     await userObject.callMethod(
       'org.freedesktop.Accounts.User',
       'SetPassword',
-      [DBusString(_identity!.password)],
+      [DBusString(_identity!.password), const DBusString('')],
       replySignature: DBusSignature.empty,
     );
 

--- a/packages/ubuntu_welcome/lib/services/xdg_identity_service.dart
+++ b/packages/ubuntu_welcome/lib/services/xdg_identity_service.dart
@@ -83,16 +83,31 @@ class XdgIdentityService implements IdentityService {
           'Modifying the default user is not yet implemented');
     }
 
-    await _accountObject.callMethod(
-      'org.freedesktop.Accounts',
-      'CreateUser',
-      [
-        DBusString(_identity!.username),
-        DBusString(_identity!.realname),
-        const DBusInt32(1), // Administrator account
-      ],
-      replySignature: DBusSignature.objectPath,
+    final userObjectPath = await _accountObject
+        .callMethod(
+          'org.freedesktop.Accounts',
+          'CreateUser',
+          [
+            DBusString(_identity!.username),
+            DBusString(_identity!.realname),
+            const DBusInt32(1), // Administrator account
+          ],
+          replySignature: DBusSignature.objectPath,
+        )
+        .then((response) => response.values.first.asObjectPath());
+
+    final userObject = DBusRemoteObject(
+      _dBusClient,
+      name: 'org.freedesktop.Accounts',
+      path: userObjectPath,
     );
+    await userObject.callMethod(
+      'org.freedesktop.Accounts.User',
+      'SetPassword',
+      [DBusString(_identity!.password)],
+      replySignature: DBusSignature.empty,
+    );
+
     await _hostnameObject
         .callMethod('org.freedesktop.hostname1', 'SetStaticHostname', [
       DBusString(_identity!.hostname),

--- a/packages/ubuntu_welcome/test/services/xdg_identity_service_test.dart
+++ b/packages/ubuntu_welcome/test/services/xdg_identity_service_test.dart
@@ -55,6 +55,7 @@ void main() {
       name: 'SetPassword',
       values: [
         const DBusString('password'),
+        const DBusString(''),
       ],
       replySignature: DBusSignature.empty,
       noReplyExpected: false,

--- a/packages/ubuntu_welcome/test/services/xdg_identity_service_test.dart
+++ b/packages/ubuntu_welcome/test/services/xdg_identity_service_test.dart
@@ -30,7 +30,7 @@ void main() {
   test('apply', () async {
     final dBusClient = createMockDBusClient();
     final service = XdgIdentityService(dBusClient, 0);
-    await service.setIdentity(testIdentity);
+    await service.setIdentity(testIdentity.copyWith(password: 'password'));
 
     verify(dBusClient.callMethod(
       destination: 'org.freedesktop.Accounts',
@@ -43,6 +43,20 @@ void main() {
         const DBusInt32(1),
       ],
       replySignature: DBusSignature.objectPath,
+      noReplyExpected: false,
+      noAutoStart: false,
+      allowInteractiveAuthorization: false,
+    )).called(1);
+
+    verify(dBusClient.callMethod(
+      destination: 'org.freedesktop.Accounts',
+      path: DBusObjectPath('/test/object/path'),
+      interface: 'org.freedesktop.Accounts.User',
+      name: 'SetPassword',
+      values: [
+        const DBusString('password'),
+      ],
+      replySignature: DBusSignature.empty,
       noReplyExpected: false,
       noAutoStart: false,
       allowInteractiveAuthorization: false,
@@ -144,5 +158,18 @@ MockDBusClient createMockDBusClient({
       throw DBusMethodResponseException(DBusMethodErrorResponse.invalidArgs());
     },
   );
+
+  when(dBusClient.callMethod(
+    destination: 'org.freedesktop.Accounts',
+    path: DBusObjectPath('/test/object/path'),
+    interface: 'org.freedesktop.Accounts.User',
+    name: anyNamed('name'),
+    values: anyNamed('values'),
+    replySignature: DBusSignature.empty,
+    noReplyExpected: false,
+    noAutoStart: false,
+    allowInteractiveAuthorization: false,
+  )).thenAnswer((i) async => DBusMethodSuccessResponse([]));
+
   return dBusClient;
 }

--- a/packages/ubuntu_wizard/lib/src/utils/password.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/password.dart
@@ -45,7 +45,7 @@ String encryptPassword(
   Hash algorithm = Hash.sha512,
   String? salt,
 }) {
-  assert(password.isNotEmpty);
+  if (password.isEmpty) return '';
   switch (algorithm) {
     case Hash.sha256:
       return Crypt.sha256(password, salt: salt).toString();


### PR DESCRIPTION
To avoid a newly created user account being locked due to not having a password. This implies that the password must be passed unencrypted to the service layer because Subiquity expects an encrypted password whereas XDG AccountsService encrypts it on the fly in SetPassword().

Required for:
- #2136