### PR TITLE
refactor(welcome): remove unused ConfigService

### DIFF
--- a/packages/ubuntu_welcome/lib/main.dart
+++ b/packages/ubuntu_welcome/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart' as p;
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -21,11 +19,7 @@ Future<void> main(List<String> args) async {
   })!;
   setupLogger(options);
 
-  final baseName = p.basename(Platform.resolvedExecutable);
-
   tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
-  // TODO: handle auto-login via IdentityService
-  tryRegisterService<ConfigService>(() => ConfigService('/tmp/$baseName.conf'));
   tryRegisterService<LocaleService>(XdgLocaleService.new);
   tryRegisterService<TimezoneService>(XdgTimezoneService.new);
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);

--- a/packages/ubuntu_welcome/pubspec.yaml
+++ b/packages/ubuntu_welcome/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   handy_window: ^0.3.0
   intl: ^0.18.0
   meta: ^1.7.0
-  path: ^1.8.0
   safe_change_notifier: ^0.2.0
   stdlibc: ^0.1.0
   timezone_map:


### PR DESCRIPTION
No longer needed after the recent refactoring that moved `ConfigService` usage from `IdentityModel` to `SubiquityIdentityService` since it was used for Subiquity-specific post-install tricks:
- #2134