### PR TITLE
fix(welcome): clean up launcher reference

### DIFF
--- a/packages/ubuntu_welcome/snap/snapcraft.yaml
+++ b/packages/ubuntu_welcome/snap/snapcraft.yaml
@@ -48,7 +48,6 @@ parts:
     override-build: |
       set -eux
       mkdir -p $CRAFT_PART_INSTALL/bin/lib
-      cp snap/local/launcher $CRAFT_PART_INSTALL/bin/
       # https://github.com/canonical/ubuntu-desktop-installer/issues/1146
       (cd packages/ubuntu_wizard && flutter pub get)
       cd packages/ubuntu_welcome


### PR DESCRIPTION
```
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:31.567 execute action ubuntu-welcome:Action(part_name='ubuntu-welcome', step=Step.BUILD, action_type=ActionType.RUN, reason=None, project_vars=None, properties=ActionProperties(changed_files=None, changed_dirs=None))
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:31.567 load state file: /root/parts/ubuntu-welcome/state/pull
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:31.570 remove directory /root/parts/ubuntu-welcome/build
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:33.108 :: + set -eux
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:33.108 :: + mkdir -p /root/parts/ubuntu-welcome/install/bin/lib
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:33.109 :: + cp snap/local/launcher /root/parts/ubuntu-welcome/install/bin/
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:33.110 :: cp: cannot stat 'snap/local/launcher': No such file or directory
2023-06-21 09:36:33.632 :: 2023-06-21 07:36:33.310 'override-build' in part 'ubuntu-welcome' failed with code 1.
```