### PR TITLE
revert: "make WSL part of the CI aware of pubspec lockfile"

### DIFF
--- a/.github/workflows/wsl.yaml
+++ b/.github/workflows/wsl.yaml
@@ -25,24 +25,10 @@ jobs:
           channel: 'stable'
           flutter-version: ${{env.FLUTTER_VERSION}}
 
-      - name: Update pubspec.lock
-        working-directory: packages\ubuntu_wsl_setup\
-        shell: bash
-        run: flutter pub upgrade
-
-      - name: Create PR
-        if: github.event_name == 'push'
-        uses: peter-evans/create-pull-request@v5
-        with:
-          add-paths: packages/ubuntu_wsl_setup/pubspec.lock
-          title: 'chore: update WSL pubspec.lock'
-          commit-message: 'chore: update WSL pubspec.lock'
-          branch: create-pull-request/wsl-pubspec
-          delete-branch: true
-
       - name: Build Windows Target
         working-directory: packages\ubuntu_wsl_setup\
         run: |
+          flutter pub get
           flutter build windows -t .\lib\main_win.dart
 
   integration:

--- a/packages/ubuntu_wsl_setup/.gitignore
+++ b/packages/ubuntu_wsl_setup/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+pubspec.lock
 
 # Linux related
 generated_plugins.cmake


### PR DESCRIPTION
Reverts #2026 as discussed in #2132.

https://github.com/canonical/ubuntu-desktop-installer/pulls?q=is%3Apr+%22update+WSL+pubspec.lock%22+