### PR TITLE
refactor: eliminate unnecessary dependencies to InheritedLocale

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -31,6 +31,7 @@ class WelcomePage extends ConsumerWidget {
     final lang = AppLocalizations.of(context);
     final flavor = ref.watch(flavorProvider);
     final brightness = Theme.of(context).brightness;
+    final locale = Localizations.localeOf(context);
 
     return WizardPage(
       title: YaruWindowTitleBar(
@@ -72,8 +73,7 @@ class WelcomePage extends ConsumerWidget {
             maintainState: true,
             child: Html(
               shrinkWrap: true,
-              data: lang.releaseNotesLabel(
-                  model.releaseNotesURL(InheritedLocale.of(context))),
+              data: lang.releaseNotesLabel(model.releaseNotesURL(locale)),
               style: {
                 'body': Style(margin: Margins.zero),
                 'a': Style(color: context.linkColor),

--- a/packages/ubuntu_desktop_installer/test/source/source_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_wizard_test.dart
@@ -9,7 +9,6 @@ import 'package:ubuntu_desktop_installer/pages/source/source_wizard.dart';
 import 'package:ubuntu_desktop_installer/routes.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
-import 'package:ubuntu_wizard/utils.dart';
 import 'package:ubuntu_wizard/widgets.dart';
 
 import 'test_source.dart';
@@ -110,36 +109,34 @@ extension on WidgetTester {
 
     return pumpWidget(
       ProviderScope(
-        child: InheritedLocale(
-          child: MaterialApp(
-            localizationsDelegates: localizationsDelegates,
-            home: Consumer(
-              builder: (context, ref, child) {
-                return Wizard(
-                  routes: {
-                    '/first': WizardRoute(
-                      builder: (context) => WizardPage(
-                        content: const Text('first route'),
-                        bottomBar: WizardBar(
-                          trailing: [WizardButton.next(context)],
-                        ),
+        child: MaterialApp(
+          localizationsDelegates: localizationsDelegates,
+          home: Consumer(
+            builder: (context, ref, child) {
+              return Wizard(
+                routes: {
+                  '/first': WizardRoute(
+                    builder: (context) => WizardPage(
+                      content: const Text('first route'),
+                      bottomBar: WizardBar(
+                        trailing: [WizardButton.next(context)],
                       ),
                     ),
-                    Routes.source: WizardRoute(
-                      builder: (_) => const SourceWizard(),
-                      onLoad: (_) => SourcePage.load(ref),
+                  ),
+                  Routes.source: WizardRoute(
+                    builder: (_) => const SourceWizard(),
+                    onLoad: (_) => SourcePage.load(ref),
+                  ),
+                  '/last': WizardRoute(
+                    builder: (context) => WizardPage(
+                      content: const Text('last route'),
+                      bottomBar:
+                          WizardBar(leading: WizardButton.previous(context)),
                     ),
-                    '/last': WizardRoute(
-                      builder: (context) => WizardPage(
-                        content: const Text('last route'),
-                        bottomBar:
-                            WizardBar(leading: WizardButton.previous(context)),
-                      ),
-                    ),
-                  },
-                );
-              },
-            ),
+                  ),
+                },
+              );
+            },
           ),
         ),
       ),


### PR DESCRIPTION
The plan is to move `InheritedLocale` into `ubuntu-wsl-setup` and use a locale provider in the installer to get rid of the `ubuntu_utils` dependency from `ubuntu_wizard`.

See also:
- #2157