### PR TITLE
refactor(wizard): move ProxyAssetBundle out of WizardApp

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
@@ -121,7 +122,6 @@ Future<void> runInstallerApp(
         slides: slides ?? defaultSlides,
         child: Consumer(
           builder: (context, ref, child) => WizardApp(
-            appName: 'ubuntu_desktop_installer',
             theme: theme,
             darkTheme: darkTheme,
             onGenerateTitle: (context) {
@@ -131,8 +131,14 @@ Future<void> runInstallerApp(
             locale: ref.watch(localeProvider),
             localizationsDelegates: localizationsDelegates,
             supportedLocales: supportedLocales,
-            home: InstallerWizard(
-              welcome: options['welcome'],
+            home: DefaultAssetBundle(
+              bundle: ProxyAssetBundle(
+                rootBundle,
+                package: 'ubuntu_desktop_installer',
+              ),
+              child: InstallerWizard(
+                welcome: options['welcome'],
+              ),
             ),
           ),
         ),

--- a/packages/ubuntu_desktop_installer/test/installer_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_test.dart
@@ -124,7 +124,6 @@ extension on WidgetTester {
       child: SlidesContext(
         slides: [(_) => const SizedBox.shrink()],
         child: WizardApp(
-          appName: 'ubuntu_desktop_installer',
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
           home: const InstallerWizard(),

--- a/packages/ubuntu_welcome/lib/main.dart
+++ b/packages/ubuntu_welcome/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_desktop_installer/providers.dart';
@@ -48,12 +49,14 @@ Future<void> main(List<String> args) async {
     runApp(ProviderScope(
       child: Consumer(
         builder: (context, ref, child) => WizardApp(
-          appName: 'ubuntu_welcome',
           locale: ref.watch(localeProvider),
           onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,
-          home: const WelcomeWizard(),
+          home: DefaultAssetBundle(
+            bundle: ProxyAssetBundle(rootBundle, package: 'ubuntu_welcome'),
+            child: const WelcomeWizard(),
+          ),
         ),
       ),
     ));

--- a/packages/ubuntu_welcome/test/welcome_wizard_test.dart
+++ b/packages/ubuntu_welcome/test/welcome_wizard_test.dart
@@ -75,7 +75,6 @@ void main() {
 extension on WidgetTester {
   Widget buildTestWizard() {
     return WizardApp(
-      appName: 'ubuntu_welcome',
       localizationsDelegates: localizationsDelegates,
       supportedLocales: supportedLocales,
       home: const WelcomeWizard(),

--- a/packages/ubuntu_wizard/lib/src/wizard_app.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_app.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:ubuntu_wizard/utils.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -9,7 +7,6 @@ import 'wizard_theme.dart';
 class WizardApp extends StatelessWidget {
   const WizardApp({
     super.key,
-    required this.appName,
     this.theme,
     this.darkTheme,
     this.onGenerateTitle,
@@ -19,7 +16,6 @@ class WizardApp extends StatelessWidget {
     required this.home,
   });
 
-  final String appName;
   final ThemeData? theme;
   final ThemeData? darkTheme;
   final GenerateAppTitle? onGenerateTitle;
@@ -30,28 +26,25 @@ class WizardApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DefaultAssetBundle(
-      bundle: ProxyAssetBundle(rootBundle, package: appName),
-      child: YaruTheme(
-        builder: (context, yaru, child) {
-          return MaterialApp(
-            locale: locale,
-            onGenerateTitle: (context) {
-              final title = onGenerateTitle?.call(context) ?? '';
-              YaruWindow.of(context).setTitle(title);
-              return title;
-            },
-            theme: (theme ?? yaru.theme)?.customize(),
-            darkTheme: (darkTheme ?? yaru.darkTheme)?.customize(),
-            highContrastTheme: yaruHighContrastLight.customize(),
-            highContrastDarkTheme: yaruHighContrastDark.customize(),
-            debugShowCheckedModeBanner: false,
-            localizationsDelegates: localizationsDelegates,
-            supportedLocales: supportedLocales,
-            home: _WizardBackground(child: home),
-          );
-        },
-      ),
+    return YaruTheme(
+      builder: (context, yaru, child) {
+        return MaterialApp(
+          locale: locale,
+          onGenerateTitle: (context) {
+            final title = onGenerateTitle?.call(context) ?? '';
+            YaruWindow.of(context).setTitle(title);
+            return title;
+          },
+          theme: (theme ?? yaru.theme)?.customize(),
+          darkTheme: (darkTheme ?? yaru.darkTheme)?.customize(),
+          highContrastTheme: yaruHighContrastLight.customize(),
+          highContrastDarkTheme: yaruHighContrastDark.customize(),
+          debugShowCheckedModeBanner: false,
+          localizationsDelegates: localizationsDelegates,
+          supportedLocales: supportedLocales,
+          home: _WizardBackground(child: home),
+        );
+      },
     );
   }
 }

--- a/packages/ubuntu_wizard/test/wizard_app_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_app_test.dart
@@ -3,11 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 void main() {
   testWidgets('app structure', (tester) async {
     await tester.pumpWidget(const WizardApp(
-      appName: 'wizard_app_test',
       localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
       supportedLocales: UbuntuLocalizations.supportedLocales,
       home: Text('home'),
@@ -15,8 +15,6 @@ void main() {
 
     expect(find.byType(YaruTheme), findsOneWidget);
     expect(find.byType(MaterialApp), findsOneWidget);
-
-    final widget = tester.widget<WizardApp>(find.byType(WizardApp));
-    expect(widget.appName, equals('wizard_app_test'));
+    expect(find.byType(YaruWindowTitleBar), findsOneWidget);
   });
 }


### PR DESCRIPTION
To cut the last remaining dependency from `ubuntu_wizard` to `ubuntu_utils` in #2157.