### PR TITLE
refactor: make PropertyStreamNotifier a mixin

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/identity/identity_model.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
@@ -39,7 +40,7 @@ final identityModelProvider = ChangeNotifierProvider(
 );
 
 /// [IdentityPage]'s view model.
-class IdentityModel extends PropertyStreamNotifier {
+class IdentityModel extends SafeChangeNotifier with PropertyStreamNotifier {
   /// Creates the model with the given client.
   IdentityModel({
     required IdentityService service,

--- a/packages/ubuntu_desktop_installer/lib/pages/network/network_device.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/network_device.dart
@@ -1,13 +1,16 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
 import 'connect_model.dart';
 
 abstract class NetworkDeviceModel<T extends NetworkDevice>
-    extends PropertyStreamNotifier implements ConnectModel {
+    extends SafeChangeNotifier
+    with PropertyStreamNotifier
+    implements ConnectModel {
   NetworkDeviceModel(this.service, [this.udev]) {
     addPropertyListener('Devices', updateDevices);
   }
@@ -112,7 +115,7 @@ abstract class NetworkDeviceModel<T extends NetworkDevice>
   }
 }
 
-class NetworkDevice extends PropertyStreamNotifier {
+class NetworkDevice extends SafeChangeNotifier with PropertyStreamNotifier {
   NetworkDevice(this._device, this._udev) {
     _setDevice(_device);
     addPropertyListener('ActiveConnection', notifyListeners);

--- a/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/network/wifi_model.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:dbus/dbus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_wizard/utils.dart';
 
@@ -314,7 +315,7 @@ class WifiDevice extends NetworkDevice {
   }
 }
 
-class AccessPoint extends PropertyStreamNotifier {
+class AccessPoint extends SafeChangeNotifier with PropertyStreamNotifier {
   AccessPoint(this._accessPoint) {
     _setAccessPoint(_accessPoint);
     addPropertyListener('Strength', notifyListeners);

--- a/packages/ubuntu_desktop_installer/lib/pages/source/source_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/source/source_model.dart
@@ -1,5 +1,6 @@
 import 'package:async/async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
@@ -20,7 +21,7 @@ final sourceModelProvider = ChangeNotifierProvider(
   ),
 );
 
-class SourceModel extends PropertyStreamNotifier {
+class SourceModel extends SafeChangeNotifier with PropertyStreamNotifier {
   // ignore: public_member_api_docs
   SourceModel(
       {required SubiquityClient client,

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_model.dart
@@ -2,6 +2,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_wizard/utils.dart';
@@ -29,7 +30,7 @@ enum Option {
 }
 
 /// Implements the business logic of the welcome page.
-class WelcomeModel extends PropertyStreamNotifier {
+class WelcomeModel extends SafeChangeNotifier with PropertyStreamNotifier {
   /// Creates the model with the given client.
   WelcomeModel({
     required NetworkService network,

--- a/packages/ubuntu_desktop_installer/test/identity/test_identity.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/test_identity.mocks.dart
@@ -198,6 +198,38 @@ class MockIdentityModel extends _i1.Mock implements _i2.IdentityModel {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i5.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -233,38 +265,6 @@ class MockIdentityModel extends _i1.Mock implements _i2.IdentityModel {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,

--- a/packages/ubuntu_desktop_installer/test/network/test_network.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/network/test_network.mocks.dart
@@ -492,6 +492,38 @@ class MockEthernetDevice extends _i1.Mock implements _i3.EthernetDevice {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -527,38 +559,6 @@ class MockEthernetDevice extends _i1.Mock implements _i3.EthernetDevice {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,
@@ -747,6 +747,22 @@ class MockEthernetModel extends _i1.Mock implements _i3.EthernetModel {
         returnValueForMissingStub: null,
       );
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -783,22 +799,6 @@ class MockEthernetModel extends _i1.Mock implements _i3.EthernetModel {
         Invocation.method(
           #disablePropertyListeners,
           [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
         ),
         returnValueForMissingStub: null,
       );
@@ -998,6 +998,22 @@ class MockHiddenWifiModel extends _i1.Mock implements _i9.HiddenWifiModel {
         returnValueForMissingStub: null,
       );
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -1034,22 +1050,6 @@ class MockHiddenWifiModel extends _i1.Mock implements _i9.HiddenWifiModel {
         Invocation.method(
           #disablePropertyListeners,
           [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
         ),
         returnValueForMissingStub: null,
       );
@@ -1123,6 +1123,38 @@ class MockAccessPoint extends _i1.Mock implements _i4.AccessPoint {
         returnValueForMissingStub: null,
       );
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -1158,38 +1190,6 @@ class MockAccessPoint extends _i1.Mock implements _i4.AccessPoint {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,
@@ -1366,6 +1366,30 @@ class MockWifiDevice extends _i1.Mock implements _i4.WifiDevice {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -1401,30 +1425,6 @@ class MockWifiDevice extends _i1.Mock implements _i4.WifiDevice {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,
@@ -1638,6 +1638,22 @@ class MockWifiModel extends _i1.Mock implements _i4.WifiModel {
         returnValueForMissingStub: null,
       );
   @override
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i6.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -1674,22 +1690,6 @@ class MockWifiModel extends _i1.Mock implements _i4.WifiModel {
         Invocation.method(
           #disablePropertyListeners,
           [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
         ),
         returnValueForMissingStub: null,
       );

--- a/packages/ubuntu_desktop_installer/test/source/test_source.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/source/test_source.mocks.dart
@@ -113,6 +113,38 @@ class MockSourceModel extends _i1.Mock implements _i2.SourceModel {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i4.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -148,38 +180,6 @@ class MockSourceModel extends _i1.Mock implements _i2.SourceModel {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,

--- a/packages/ubuntu_desktop_installer/test/welcome/test_welcome.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/test_welcome.mocks.dart
@@ -82,6 +82,38 @@ class MockWelcomeModel extends _i1.Mock implements _i2.WelcomeModel {
         returnValue: '',
       ) as String);
   @override
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void setProperties(_i3.Stream<List<String>>? properties) =>
       super.noSuchMethod(
         Invocation.method(
@@ -117,38 +149,6 @@ class MockWelcomeModel extends _i1.Mock implements _i2.WelcomeModel {
   void disablePropertyListeners() => super.noSuchMethod(
         Invocation.method(
           #disablePropertyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
           [],
         ),
         returnValueForMissingStub: null,

--- a/packages/ubuntu_wizard/lib/src/utils/property_stream_notifier.dart
+++ b/packages/ubuntu_wizard/lib/src/utils/property_stream_notifier.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:safe_change_notifier/safe_change_notifier.dart';
 
 /// Listens and notifies a stream of property changes.
-class PropertyStreamNotifier extends SafeChangeNotifier {
+mixin PropertyStreamNotifier on ChangeNotifier {
   bool _enabled = true;
   final _callbacks = <String, VoidCallback>{};
   StreamSubscription<List<String>>? _subscription;

--- a/packages/ubuntu_wizard/test/property_stream_notifier_test.dart
+++ b/packages/ubuntu_wizard/test/property_stream_notifier_test.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_wizard/src/utils/property_stream_notifier.dart';
 
 void main() {
   test('listeners', () {
-    final notifier = PropertyStreamNotifier();
+    final notifier = TestPropertyStreamNotifier();
 
     var wasCanceled = false;
     var wasListened = false;
@@ -48,7 +49,7 @@ void main() {
   });
 
   test('enable and disable listeners', () {
-    final notifier = PropertyStreamNotifier();
+    final notifier = TestPropertyStreamNotifier();
     final controller = StreamController<List<String>>(sync: true);
     notifier.setProperties(controller.stream);
 
@@ -70,3 +71,6 @@ void main() {
     expect(bar, equals(1));
   });
 }
+
+class TestPropertyStreamNotifier extends ChangeNotifier
+    with PropertyStreamNotifier {}


### PR DESCRIPTION
Eliminate an unnecessary hidden dependency. PropertyStreamNotifier doesn't need to know anything about SafeChangeNotifier.