### PR TITLE
refactor: sync and clean up dialog paddings

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
@@ -25,6 +25,9 @@ class ActiveDirectoryErrorDialog extends StatelessWidget {
         title: Text(lang.activeDirectoryErrorTitle),
       ),
       titlePadding: EdgeInsets.zero,
+      contentPadding: const EdgeInsets.all(kYaruPagePadding),
+      actionsPadding: const EdgeInsets.all(kYaruPagePadding),
+      buttonPadding: EdgeInsets.zero,
       content: SizedBox(
         width: 600,
         child: Row(

--- a/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/keyboard/keyboard_dialogs.dart
@@ -35,9 +35,8 @@ Future<StepResult?> showDetectKeyboardDialog(BuildContext context) async {
               title: Text(lang.detectLayout),
             ),
             titlePadding: EdgeInsets.zero,
-            contentPadding: kContentPadding.copyWith(
-                top: kContentSpacing, bottom: kContentSpacing),
-            actionsPadding: kFooterPadding,
+            contentPadding: const EdgeInsets.all(kYaruPagePadding),
+            actionsPadding: const EdgeInsets.all(kYaruPagePadding),
             buttonPadding: EdgeInsets.zero,
             content: SizedBox(
               width: size.width * _kDialogWidthFactor,

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/guided_resize/storage_size_dialog.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/guided_resize/storage_size_dialog.dart
@@ -75,6 +75,8 @@ class StorageSizeDialog extends StatelessWidget {
         title: Text(title),
       ),
       titlePadding: EdgeInsets.zero,
+      contentPadding: const EdgeInsets.all(kYaruPagePadding),
+      actionsPadding: const EdgeInsets.all(kYaruPagePadding),
       buttonPadding: EdgeInsets.zero,
       content: CallbackShortcuts(
         bindings: {

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/manual/manual_storage_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/manual/manual_storage_dialogs.dart
@@ -36,9 +36,8 @@ Future<void> showCreatePartitionDialog(
             title: Text(lang.partitionCreateTitle),
           ),
           titlePadding: EdgeInsets.zero,
-          contentPadding: kContentPadding.copyWith(
-              top: kContentSpacing, bottom: kContentSpacing),
-          actionsPadding: kFooterPadding,
+          contentPadding: const EdgeInsets.all(kYaruPagePadding),
+          actionsPadding: const EdgeInsets.all(kYaruPagePadding),
           buttonPadding: EdgeInsets.zero,
           scrollable: true,
           content: FormLayout(
@@ -156,9 +155,8 @@ Future<void> showEditPartitionDialog(
             title: Text(lang.partitionEditTitle),
           ),
           titlePadding: EdgeInsets.zero,
-          contentPadding: kContentPadding.copyWith(
-              top: kContentSpacing, bottom: kContentSpacing),
-          actionsPadding: kFooterPadding,
+          contentPadding: const EdgeInsets.all(kYaruPagePadding),
+          actionsPadding: const EdgeInsets.all(kYaruPagePadding),
           buttonPadding: EdgeInsets.zero,
           scrollable: true,
           content: FormLayout(

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/storage_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/storage_dialogs.dart
@@ -24,9 +24,8 @@ Future<void> showAdvancedFeaturesDialog(
           title: Text(lang.installationTypeAdvancedTitle),
         ),
         titlePadding: EdgeInsets.zero,
-        contentPadding: kContentPadding.copyWith(
-            top: kContentSpacing, bottom: kContentSpacing),
-        actionsPadding: kFooterPadding,
+        contentPadding: const EdgeInsets.all(kYaruPagePadding),
+        actionsPadding: const EdgeInsets.all(kYaruPagePadding),
         buttonPadding: EdgeInsets.zero,
         scrollable: true,
         content: AnimatedBuilder(

--- a/packages/ubuntu_desktop_installer/lib/widgets/dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/widgets/dialogs.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets/push_button.dart';
-import 'package:ubuntu_wizard/constants.dart';
-import 'package:yaru_widgets/widgets.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 /// Shows a confirmation dialog with the given title and message.
 Future<bool> showConfirmationDialog(
@@ -19,9 +18,9 @@ Future<bool> showConfirmationDialog(
       return AlertDialog(
         title: YaruDialogTitleBar(title: Text(title)),
         titlePadding: EdgeInsets.zero,
-        contentPadding: kContentPadding.copyWith(
-            top: kContentSpacing, bottom: kContentSpacing),
-        actionsPadding: kFooterPadding,
+        contentPadding: const EdgeInsets.all(kYaruPagePadding),
+        actionsPadding: const EdgeInsets.all(kYaruPagePadding),
+        buttonPadding: EdgeInsets.zero,
         content: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 420),
             child: Text(message)),


### PR DESCRIPTION
The old constants from `ubuntu_wizard` made their way everywhere...