### PR TITLE
fix(screenshot_test): prevent exceptions when closing keyboard dialog

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -10,6 +9,7 @@ import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru_test/yaru_test.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../test/test_utils.dart';
 
@@ -96,7 +96,9 @@ Future<void> testKeyboardPage(
 
     await takeScreenshot(tester, '$screenshot-detect');
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.tap(find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(YaruWindowControl)));
     await tester.pumpAndSettle();
   }
 


### PR DESCRIPTION
Found while trying to take tester.runApp() into use in screenshot_test:
```
══╡ EXCEPTION CAUGHT BY SERVICES LIBRARY ╞══════════════════════════════════════════════════════════
The following _TypeError was thrown while processing a raw key listener:
type 'RawKeyEventDataAndroid' is not a subtype of type 'RawKeyEventDataLinux' in type cast

When the exception was thrown, this was the stack:
#0      _DetectKeyboardViewState._handleKey (package:ubuntu_desktop_installer/pages/keyboard/keyboard_widgets.dart:98:29)
#1      RawKeyboard.handleRawKeyEvent (package:flutter/src/services/raw_keyboard.dart:705:19)
#2      KeyEventManager.handleRawKeyMessage (package:flutter/src/services/hardware_keyboard.dart:953:30)
#3      BasicMessageChannel.setMessageHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:212:49)
#4      TestDefaultBinaryMessenger.handlePlatformMessage (package:flutter_test/src/test_default_binary_messenger.dart:93:42)
#5      KeyEventSimulator._simulateKeyEventByRawEvent.<anonymous closure> (package:flutter_test/src/event_simulation.dart:655:79)
#8      TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#9      KeyEventSimulator._simulateKeyEventByRawEvent (package:flutter_test/src/event_simulation.dart:653:27)
#10     KeyEventSimulator.simulateKeyDownEvent.simulateByRawEvent (package:flutter_test/src/event_simulation.dart:733:14)
#11     KeyEventSimulator.simulateKeyDownEvent (package:flutter_test/src/event_simulation.dart:740:16)
#12     simulateKeyDownEvent (package:flutter_test/src/event_simulation.dart:873:48)
#13     WidgetController.sendKeyEvent (package:flutter_test/src/controller.dart:1404:32)
#14     testKeyboardPage (file:///home/jpnurmi/Projects/canonical/ubuntu-desktop-installer/packages/ubuntu_desktop_installer/integration_test/test_pages.dart:99:18)
<asynchronous suspension>
<asynchronous suspension>
(elided 3 frames from dart:async and package:stack_trace)

Event: RawKeyDownEvent#3f538(logicalKey: LogicalKeyboardKey#4eada(keyId: "0x10000001b", keyLabel:
  "Escape", debugName: "Escape"), physicalKey: PhysicalKeyboardKey#e41f8(usbHidUsage: "0x00070029",
  debugName: "Escape"), repeat: false)
════════════════════════════════════════════════════════════════════════════════════════════════════
```
Ref: #2143