### PR TITLE
fix(screenshot_test): simulate window close at tear down

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -19,8 +19,10 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'test_pages.dart';
 
-void main() {
+Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final window = await YaruWindow.ensureInitialized();
 
   setUpAll(() => autoUpdateGoldenFiles = true);
 
@@ -34,7 +36,12 @@ void main() {
     );
   });
 
-  tearDown(() async => await resetAllServices());
+  tearDown(() async {
+    final windowClosed = YaruTestWindow.waitForClosed();
+    window.close();
+    await windowClosed;
+    await resetAllServices();
+  });
 
   testWidgets('1.locale', (tester) async {
     await runInstallerApp([], theme: currentTheme);


### PR DESCRIPTION
Unlike other integration tests that run through full installation flows until the window is closed, the screenshot test navigates into specific screens just to take screenshots of them. As such, there's nothing triggering the app to stop Subiquity etc. unless we simulate window close.

This should prevent a series of obscure screenshot test errors because Subiquity is no longer left running while the data directory would be, at the same time, cleaned up in the beginning of each test to ensure a clean environment.

Ref: #2143