### PR TITLE
fix(ad): catch potential exception for long-lasting join result

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -1,6 +1,6 @@
 export 'package:ubuntu_service/ubuntu_service.dart';
 
-export 'services/active_directory_service.dart';
+export 'services/active_directory_service.dart' hide log;
 export 'services/config_service.dart' hide log;
 export 'services/desktop_service.dart';
 export 'services/identity_service.dart';

--- a/packages/ubuntu_desktop_installer/lib/services/active_directory_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/active_directory_service.dart
@@ -1,4 +1,5 @@
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 export 'package:subiquity_client/subiquity_client.dart'
     show
@@ -7,6 +8,8 @@ export 'package:subiquity_client/subiquity_client.dart'
         AdPasswordValidation,
         AdDomainNameValidation,
         AdJoinResult;
+
+final log = Logger('ad');
 
 abstract class ActiveDirectoryService {
   Future<bool> hasSupport();
@@ -79,8 +82,13 @@ class SubiquityActiveDirectoryService implements ActiveDirectoryService {
   }
 
   @override
-  Future<AdJoinResult> getJoinResult({bool wait = true}) {
-    return _subiquity.getActiveDirectoryJoinResult(wait: wait);
+  Future<AdJoinResult> getJoinResult({bool wait = true}) async {
+    try {
+      return await _subiquity.getActiveDirectoryJoinResult(wait: wait);
+    } catch (e) {
+      log.error(e);
+      return AdJoinResult.UNKNOWN;
+    }
   }
 }
 


### PR DESCRIPTION
The AD join result is requested ahead of time from the AD page. The result is returned later at some point during the installation after the necessary tools have been installed etc.