### PR TITLE
refactor(install): replace manual status query loop with monitorStatus()

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/screenshot_test.dart
@@ -478,6 +478,11 @@ class FakeSubiquityClient extends SubiquityClient {
   }
 
   @override
+  Stream<ApplicationStatus?> monitorStatus() {
+    return Stream.value(fakeApplicationStatus(state));
+  }
+
+  @override
   Future<bool> hasRst() async => true;
 }
 

--- a/packages/ubuntu_desktop_installer/test/install/test_install.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/install/test_install.mocks.dart
@@ -134,6 +134,14 @@ class MockInstallModel extends _i1.Mock implements _i3.InstallModel {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   _i4.Future<void> precacheSlideImages(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -165,14 +173,6 @@ class MockInstallModel extends _i1.Mock implements _i3.InstallModel {
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
The ready-made `monitorStatus()` handles exceptions as appropriate:
- https://github.com/canonical/subiquity_client.dart/pull/144