### PR TITLE
refactor: migrate away from yaru_colors

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/active_directory/active_directory_dialogs.dart
@@ -4,6 +4,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -39,7 +40,7 @@ class ActiveDirectoryErrorDialog extends StatelessWidget {
                 data: lang.activeDirectoryErrorMessage,
                 style: {
                   'body': Style(margin: Margins.zero),
-                  'a': Style(color: context.linkColor),
+                  'a': Style(color: Theme.of(context).colorScheme.link),
                 },
                 onAnchorTap: (url, _, __) => launchUrl(url!),
                 shrinkWrap: true,

--- a/packages/ubuntu_desktop_installer/lib/pages/rst/rst_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/rst/rst_page.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'rst_model.dart';
@@ -59,7 +60,7 @@ class RstPage extends ConsumerWidget {
                       data: lang.instructionsForRST('help.ubuntu.com/rst'),
                       style: {
                         'body': Style(margin: Margins.zero),
-                        'a': Style(color: context.linkColor),
+                        'a': Style(color: Theme.of(context).colorScheme.link),
                       },
                       onLinkTap: (url, _, __) => launchUrl(url!),
                     ),

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/bitlocker/bitlocker_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/bitlocker/bitlocker_page.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'bitlocker_model.dart';
@@ -60,7 +61,7 @@ class BitLockerPage extends ConsumerWidget {
                         'help.ubuntu.com/bitlocker'),
                     style: {
                       'body': Style(margin: Margins.zero),
-                      'a': Style(color: context.linkColor),
+                      'a': Style(color: Theme.of(context).colorScheme.link),
                     },
                     onLinkTap: (url, _, __) => launchUrl(url!),
                   ),

--- a/packages/ubuntu_desktop_installer/lib/pages/storage/guided_resize/guided_resize_widgets.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/guided_resize/guided_resize_widgets.dart
@@ -4,9 +4,9 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_desktop_installer/l10n.dart';
-import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
 
 import 'guided_resize_model.dart';
 
@@ -90,7 +90,7 @@ class HiddenPartitionLabel extends StatelessWidget {
             Theme.of(context).textTheme.bodySmall!.fontSize!,
           ),
         ),
-        'a': Style(color: context.linkColor),
+        'a': Style(color: Theme.of(context).colorScheme.link),
       },
       onLinkTap: (url, _, __) => onTap(),
     );

--- a/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/welcome/welcome_page.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/widgets.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'welcome_model.dart';
@@ -75,7 +76,7 @@ class WelcomePage extends ConsumerWidget {
               data: lang.releaseNotesLabel(model.releaseNotesURL(locale)),
               style: {
                 'body': Style(margin: Margins.zero),
-                'a': Style(color: context.linkColor),
+                'a': Style(color: Theme.of(context).colorScheme.link),
               },
               onLinkTap: (url, _, __) => launchUrl(url!),
             ),

--- a/packages/ubuntu_desktop_installer/pubspec.yaml
+++ b/packages/ubuntu_desktop_installer/pubspec.yaml
@@ -68,7 +68,6 @@ dependencies:
   upower: ^0.7.0
   xdg_locale: ^0.0.1
   yaru: ^0.9.0
-  yaru_colors: ^0.1.6
   yaru_icons: ^1.0.0
   yaru_widgets: ^2.5.0
   yaru_window: ^0.1.3

--- a/packages/ubuntu_utils/lib/src/color.dart
+++ b/packages/ubuntu_utils/lib/src/color.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_colors/yaru_colors.dart';
 
 /// Adds utility extensions to [Color].
 extension HexColor on Color {
@@ -13,10 +12,4 @@ extension HexColor on Color {
 
 extension _HexInt on int {
   String toHex() => toRadixString(16).padLeft(2, '0');
-}
-
-extension LinkColor on BuildContext {
-  Color get linkColor => Theme.of(this).brightness == Brightness.light
-      ? YaruColors.blue[700]!
-      : YaruColors.blue[500]!;
 }

--- a/packages/ubuntu_utils/pubspec.yaml
+++ b/packages/ubuntu_utils/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   ubuntu_logger: ^0.0.3
   ubuntu_service: ^0.2.2
   url_launcher: ^6.1.0
-  yaru_colors: ^0.1.6
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/packages/ubuntu_wizard/lib/src/wizard_theme.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_theme.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 extension WizardThemeDataX on ThemeData {
   ThemeData customize() {
-    final errorColor = brightness == Brightness.light
-        ? YaruColors.red[700]!
-        : YaruColors.red[300]!;
+    final errorColor = YaruColors.from(brightness).error;
     final mouseCursor = MaterialStateProperty.all(SystemMouseCursors.basic);
     return copyWith(
       colorScheme: colorScheme.copyWith(error: errorColor),

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   ubuntu_localizations: ^0.2.0
   wizard_router: ^1.0.1
   yaru: ^0.9.0
-  yaru_colors: ^0.1.6
   yaru_widgets: ^2.5.0
 
 dev_dependencies:


### PR DESCRIPTION
The plan is to discontinue the old generated M2 colors aka. `yaru_colors.dart`. Use pre-defined semantic colors with light and dark variants from `yaru.dart` (0.8.0+) instead.