### PR TITLE
Don't stage directly libllvm, it's pulled in via library depends

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -210,7 +210,6 @@ parts:
       - libglapi-mesa
       - libgraphite2-3
       - libxshmfence1
-      - libllvm12
       - libpciaccess0
       - libvulkan1
       - shared-mime-info
@@ -240,7 +239,6 @@ parts:
       - usr/lib/*/libglapi*.so.*
       - usr/lib/*/libgraphite2*.so.*
       - usr/lib/*/libxshmfence*.so.*
-      - usr/lib/*/libLLVM-12.so.*
       - usr/lib/*/libpciaccess*.so.*
       - usr/lib/*/libsensors*.so.*
       - usr/lib/*/libvulkan*.so.*


### PR DESCRIPTION
The version currently listed is wrong for core22 and unused

It's not the first time we forget to update the version when switching to a new core serie. Currently 15 is being used by the software stack but we are still pulling 12 for nothing. Instead of having a version manually specify let's get it through the dri components depends. 

A local build shows that libllbvm15 is being pulled it as expected, the removal of the extra libllvm makes the snap 20mb smaller