### PR TITLE
l10n: remove unused {disk} argument

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/l10n/app_cs.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_cs.arb
@@ -279,12 +279,11 @@
       "system": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "oddíl č. {disk}{partition} jako {format}",
+  "writeChangesPartitionEntryUnmounted": "oddíl č. {sysname} jako {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -305,12 +304,11 @@
   "@chooseYourLookPageHeader": {},
   "chooseYourLookPageTitle": "Zvolte si motiv vzhledu",
   "@chooseYourLookPageTitle": {},
-  "writeChangesPartitionEntryMounted": "oddíl č. {disk}{partition} jako {format}, použitý pro {mount}",
+  "writeChangesPartitionEntryMounted": "oddíl č. {sysname} jako {format}, použitý pro {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -641,32 +639,29 @@
       "url": {}
     }
   },
-  "writeChangesPartitionResized": "velikost oddílu <b>{disk}{partition}</b> změněna z <b>{oldsize}</b> na <b>{newsize}</b>",
+  "writeChangesPartitionResized": "velikost oddílu <b>{sysname}</b> změněna z <b>{oldsize}</b> na <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
   "installAlongsideResizePartition": "Změnit velikost oddílu",
   "@installAlongsideResizePartition": {},
-  "writeChangesPartitionCreated": "oddíl <b>{disk}{partition}</b> vytvořen",
+  "writeChangesPartitionCreated": "oddíl <b>{sysname}</b> vytvořen",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
-  "writeChangesPartitionMounted": "oddíl <b>{disk}{partition}</b> použit pro <b>{mount}</b>",
+  "writeChangesPartitionMounted": "oddíl <b>{sysname}</b> použit pro <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
@@ -709,22 +704,20 @@
   "@installAlongsidePartition": {},
   "installAlongsideSize": "Velikost:",
   "@installAlongsideSize": {},
-  "writeChangesPartitionFormattedMounted": "oddíl <b>{disk}{partition}</b> naformátovaný jako <b>{format}</b> použit pro <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "oddíl <b>{sysname}</b> naformátovaný jako <b>{format}</b> použit pro <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "oddíl <b>{disk}{partition}</b> naformátován jako <b>{format}</b>",
+  "writeChangesPartitionFormatted": "oddíl <b>{sysname}</b> naformátován jako <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_da.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_da.arb
@@ -475,41 +475,37 @@
   "@installAlongsideResizePartition": {},
   "partitionFormatNone": "Efterlad uformateret",
   "@partitionFormatNone": {},
-  "writeChangesPartitionResized": "partition <b>{disk}{partition}</b> ændres fra <b>{oldsize}</b> til <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partition <b>{sysname}</b> ændres fra <b>{oldsize}</b> til <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partition <b>{disk}{partition}</b> formateret som <b>{format}</b> brugt til <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partition <b>{sysname}</b> formateret som <b>{format}</b> brugt til <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "partition <b>{disk}{partition}</b> formateret som <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partition <b>{sysname}</b> formateret som <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "partition <b>{disk}{partition}</b> brugt til <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partition <b>{sysname}</b> brugt til <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
@@ -588,12 +584,11 @@
   "@whoAreYouPagePasswordHide": {},
   "writeChangesPartitionTablesHeader": "Partitionstabellen på de følgende enheder er ændret:",
   "@writeChangesPartitionTablesHeader": {},
-  "writeChangesPartitionCreated": "partition <b>{disk}{partition}</b> oprettet",
+  "writeChangesPartitionCreated": "partition <b>{sysname}</b> oprettet",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "installationSlidesCreativityTitle": "Berig din kreativitet",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_de.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_de.arb
@@ -306,22 +306,20 @@
   },
   "writeChangesPartitionsHeader": "Die folgenden Partitionsänderungen werden vorgenommen:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "Partition #{disk}{partition} als {format} benutzt für {mount}",
+  "writeChangesPartitionEntryMounted": "Partition #{sysname} als {format} benutzt für {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "Ein Eintrag einer eingehängten Partition",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "Partition #{disk}{partition} als {format}",
+  "writeChangesPartitionEntryUnmounted": "Partition #{sysname} als {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "Ein Eintrag einer nicht eingehängten Partition",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -597,22 +595,20 @@
   "@installAlongsideAvailable": {},
   "quitButtonText": "Installation beenden",
   "@quitButtonText": {},
-  "writeChangesPartitionFormattedMounted": "Partition <b>{disk}{partition}</b> formatiert als <b>{format}</b> verwendet für <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "Partition <b>{sysname}</b> formatiert als <b>{format}</b> verwendet für <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "Partition <b>{disk}{partition}</b> erstellt",
+  "writeChangesPartitionCreated": "Partition <b>{sysname}</b> erstellt",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceHasOnly": "Dieser Computer hat nur {SIZE}.",
@@ -629,31 +625,28 @@
       "SIZE": {}
     }
   },
-  "writeChangesPartitionFormatted": "Partition <b>{disk}{partition}</b> formatiert als <b>{format}</b>",
+  "writeChangesPartitionFormatted": "Partition <b>{sysname}</b> formatiert als <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionResized": "Größe der Partition <b>{disk}{partition}</b> von <b>{oldsize}</b> auf <b>{newsize}</b> geändert",
+  "writeChangesPartitionResized": "Größe der Partition <b>{sysname}</b> von <b>{oldsize}</b> auf <b>{newsize}</b> geändert",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionMounted": "Partition <b>{disk}{partition}</b> verwendet für <b>{mount}</b>",
+  "writeChangesPartitionMounted": "Partition <b>{sysname}</b> verwendet für <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_en.arb
@@ -529,50 +529,45 @@
   },
   "writeChangesPartitionsHeader": "The following partition changes are going to be applied:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionResized": "partition <b>{disk}{partition}</b> resized from <b>{oldsize}</b> to <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partition <b>{sysname}</b> resized from <b>{oldsize}</b> to <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partition <b>{disk}{partition}</b> formatted as <b>{format}</b> used for <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partition <b>{sysname}</b> formatted as <b>{format}</b> used for <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "partition <b>{disk}{partition}</b> formatted as <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partition <b>{sysname}</b> formatted as <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "partition <b>{disk}{partition}</b> used for <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partition <b>{sysname}</b> used for <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "partition <b>{disk}{partition}</b> created",
+  "writeChangesPartitionCreated": "partition <b>{sysname}</b> created",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "chooseYourLookPageTitle": "Choose your theme",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_eo.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_eo.arb
@@ -106,12 +106,11 @@
   "@updatesOtherSoftwarePageTitle": {},
   "turnOffRST": "Rapid-Konserveja Tekniko (RST) estas ŝaltita",
   "@turnOffRST": {},
-  "writeChangesPartitionEntryUnmounted": "subdisko #{disk}{partition} kiel {format}",
+  "writeChangesPartitionEntryUnmounted": "subdisko #{sysname} kiel {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -320,12 +319,11 @@
   "@writeChangesToDisk": {},
   "writeChangesPartitionsHeader": "La jenaj ŝanĝoj pri subdiskoj estas efektivigotaj:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "subdisko #{disk}{partition} kiel {format} ĉe {mount}",
+  "writeChangesPartitionEntryMounted": "subdisko #{sysname} kiel {format} ĉe {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -613,42 +611,38 @@
   },
   "quitButtonText": "Ĉesi instaladon",
   "@quitButtonText": {},
-  "writeChangesPartitionCreated": "krei la subdiskon <b>{disk}{partition}</b>",
+  "writeChangesPartitionCreated": "krei la subdiskon <b>{sysname}</b>",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "la subdisko <b>{disk}{partition}</b> strukturota laŭ <b>{format}</b> kaj uzota por <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "la subdisko <b>{sysname}</b> strukturota laŭ <b>{format}</b> kaj uzota por <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
   "notEnoughDiskSpaceTitle": "Ne sufiĉas spaco",
   "@notEnoughDiskSpaceTitle": {},
-  "writeChangesPartitionResized": "ŝanĝi la grandon de la subdisko <b>{disk}{partition}</b> de <b>{oldsize}</b> al <b>{newsize}</b>",
+  "writeChangesPartitionResized": "ŝanĝi la grandon de la subdisko <b>{sysname}</b> de <b>{oldsize}</b> al <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionMounted": "la subdisko <b>{disk}{partition}</b> uzota por <b>{mount}</b>",
+  "writeChangesPartitionMounted": "la subdisko <b>{sysname}</b> uzota por <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
@@ -660,12 +654,11 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionFormatted": "la subdisko <b>{disk}{partition}</b> strukturota laŭ <b>{format}</b>",
+  "writeChangesPartitionFormatted": "la subdisko <b>{sysname}</b> strukturota laŭ <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_es.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_es.arb
@@ -632,50 +632,45 @@
   "@installingSystem": {},
   "configuringSystem": "Configurando el sistema…",
   "@configuringSystem": {},
-  "writeChangesPartitionResized": "partición <b>{disk}{partition}</b> redimensionada de <b>{oldsize}</b> a <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partición <b>{sysname}</b> redimensionada de <b>{oldsize}</b> a <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormatted": "partición <b>{disk}{partition}</b> formateada como <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partición <b>{sysname}</b> formateada como <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partición <b>{disk}{partition}</b> formateada como <b>{format}</b> utilizada para <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partición <b>{sysname}</b> formateada como <b>{format}</b> utilizada para <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionMounted": "partición <b>{disk}{partition}</b> utilizada para <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partición <b>{sysname}</b> utilizada para <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "partición <b>{disk}{partition}</b> creada",
+  "writeChangesPartitionCreated": "partición <b>{sysname}</b> creada",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "showSecurityKey": "Mostrar la clave de seguridad",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_fa.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_fa.arb
@@ -264,21 +264,19 @@
       "path": {}
     }
   },
-  "writeChangesPartitionMounted": "افراز <b>{disk}{partition}</b> برای <b>{mount}</b> استفاده شد",
+  "writeChangesPartitionMounted": "افراز <b>{sysname}</b> برای <b>{mount}</b> استفاده شد",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "افراز <b>{disk}{partition}</b> ایجاد شد",
+  "writeChangesPartitionCreated": "افراز <b>{sysname}</b> ایجاد شد",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "chooseYourLookPageLightSetting": "روشن",
@@ -424,12 +422,11 @@
   "@whoAreYouPageConfirmPasswordLabel": {},
   "writeChangesPartitionsTitle": "افزارها",
   "@writeChangesPartitionsTitle": {},
-  "writeChangesPartitionFormatted": "افراز <b>{disk}{partition}</b> به صورت <b>{format}</b> قالب‌بندی شد",
+  "writeChangesPartitionFormatted": "افراز <b>{sysname}</b> به صورت <b>{format}</b> قالب‌بندی شد",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -437,12 +434,11 @@
   "@continueTesting": {},
   "installationCompleteTitle": "نصب کامل شد",
   "@installationCompleteTitle": {},
-  "writeChangesPartitionFormattedMounted": "افراز <b>{disk}{partition}</b> به صورت <b>{format}</b> برای <b>{mount}</b> قالب‌بندی شد",
+  "writeChangesPartitionFormattedMounted": "افراز <b>{sysname}</b> به صورت <b>{format}</b> برای <b>{mount}</b> قالب‌بندی شد",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -684,12 +680,11 @@
   "@selectGuidedStorageInfoLabel": {},
   "installAlongsideSpaceDivider": "با کشیدن تقسیم‌کنندهٔ زیر، فضای گرداننده را تخصیص دهید:",
   "@installAlongsideSpaceDivider": {},
-  "writeChangesPartitionResized": "اندازهٔ افراز <b>{disk}{partition}</b> از <b>{oldsize}</b> به <b>{newsize}</b> تغییر کرد",
+  "writeChangesPartitionResized": "اندازهٔ افراز <b>{sysname}</b> از <b>{oldsize}</b> به <b>{newsize}</b> تغییر کرد",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_fi.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_fi.arb
@@ -196,22 +196,20 @@
   },
   "writeChangesPartitionsHeader": "Seuraavat osiomuutokset toteutetaan:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "osio #{disk}{partition} tiedostojärjestelmänä {format} liitetty kohtaan {mount}",
+  "writeChangesPartitionEntryMounted": "osio #{sysname} tiedostojärjestelmänä {format} liitetty kohtaan {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "osio #{disk}{partition} tiedostojärjestelmänä {format}",
+  "writeChangesPartitionEntryUnmounted": "osio #{sysname} tiedostojärjestelmänä {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -654,50 +652,45 @@
   "@tooManyPrimaryPartitions": {},
   "partitionLimitReached": "Raja saavutettu",
   "@partitionLimitReached": {},
-  "writeChangesPartitionResized": "osion <b>{disk}{partition}</b> koko <b>{oldsize}</b> muutettu kokoon <b>{newsize}</b>",
+  "writeChangesPartitionResized": "osion <b>{sysname}</b> koko <b>{oldsize}</b> muutettu kokoon <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "osio <b>{disk}{partition}</b> alustettu muotoon <b>{format}</b> käytettäväksi liitospisteenä <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "osio <b>{sysname}</b> alustettu muotoon <b>{format}</b> käytettäväksi liitospisteenä <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "osio <b>{disk}{partition}</b> alustettu muotoon <b>{format}</b>",
+  "writeChangesPartitionFormatted": "osio <b>{sysname}</b> alustettu muotoon <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "osio <b>{disk}{partition}</b> käytettäväksi liitospisteenä <b>{mount}</b>",
+  "writeChangesPartitionMounted": "osio <b>{sysname}</b> käytettäväksi liitospisteenä <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "osio <b>{disk}{partition}</b> luotu",
+  "writeChangesPartitionCreated": "osio <b>{sysname}</b> luotu",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "whoAreYouPagePasswordShow": "Näytä",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_fr.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_fr.arb
@@ -311,22 +311,20 @@
   "@whoAreYouPagePasswordRequired": {},
   "whoAreYouPageConfirmPasswordLabel": "Confirmez votre mot de passe",
   "@whoAreYouPageConfirmPasswordLabel": {},
-  "writeChangesPartitionEntryMounted": "la partition #{disk}{partition} en {format} est utilisée pour {mount}",
+  "writeChangesPartitionEntryMounted": "la partition #{sysname} en {format} est utilisée pour {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "partition #{disk}{partition} en {format}",
+  "writeChangesPartitionEntryUnmounted": "partition #{sysname} en {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -581,12 +579,11 @@
       "url": {}
     }
   },
-  "writeChangesPartitionFormatted": "la partition <b>{disk}{partition}</b> formatée en <b>{format}</b>",
+  "writeChangesPartitionFormatted": "la partition <b>{sysname}</b> formatée en <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -605,12 +602,11 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionCreated": "la partition <b>{disk}{partition}</b> créée",
+  "writeChangesPartitionCreated": "la partition <b>{sysname}</b> créée",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceHasOnly": "Cet ordinateur n’a que {SIZE}.",
@@ -624,32 +620,29 @@
   "@quitButtonText": {},
   "notEnoughDiskSpaceTitle": "Pas assez d’espace",
   "@notEnoughDiskSpaceTitle": {},
-  "writeChangesPartitionResized": "la partition <b>{disk}{partition}</b> redimensionnée de <b>{oldsize}</b> à <b>{newsize}</b>",
+  "writeChangesPartitionResized": "la partition <b>{sysname}</b> redimensionnée de <b>{oldsize}</b> à <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "la partition <b>{disk}{partition}</b> formatée en <b>{format}</b> utilisée pour <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "la partition <b>{sysname}</b> formatée en <b>{format}</b> utilisée pour <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionMounted": "la partition <b>{disk}{partition}</b> utilisée pour <b>{mount}</b>",
+  "writeChangesPartitionMounted": "la partition <b>{sysname}</b> utilisée pour <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_he.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_he.arb
@@ -135,22 +135,20 @@
   "@chooseYourLookPageTitle": {},
   "chooseYourLookPageHeader": "תמיד ניתן לשנות את זה מאוחר יותר בהגדרות המראה.",
   "@chooseYourLookPageHeader": {},
-  "writeChangesPartitionEntryMounted": "מחיצה מס׳ {disk}{partition} בתור {format} משמשת עבור {mount}",
+  "writeChangesPartitionEntryMounted": "מחיצה מס׳ {sysname} בתור {format} משמשת עבור {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "מחיצה מס׳ {disk}{partition} בתור {format}",
+  "writeChangesPartitionEntryUnmounted": "מחיצה מס׳ {sysname} בתור {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -593,12 +591,11 @@
   },
   "installAlongsideAvailable": "זמין:",
   "@installAlongsideAvailable": {},
-  "writeChangesPartitionFormattedMounted": "מחיצה <b>{disk}{partition}</b> פורמטה כ־<b>{format}</b> ומשמשת עבור <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "מחיצה <b>{sysname}</b> פורמטה כ־<b>{format}</b> ומשמשת עבור <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -613,24 +610,22 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionResized": "הגודל של מחיצה <b>{disk}{partition}</b> ישתנה מ־<b>{oldsize}</b> ל־<b>{newsize}</b>",
+  "writeChangesPartitionResized": "הגודל של מחיצה <b>{sysname}</b> ישתנה מ־<b>{oldsize}</b> ל־<b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
   "quitButtonText": "יציאה מההתקנה",
   "@quitButtonText": {},
-  "writeChangesPartitionCreated": "המחיצה <b>{disk}{partition}</b> נוצרה",
+  "writeChangesPartitionCreated": "המחיצה <b>{sysname}</b> נוצרה",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceHasOnly": "במחשב זה יש רק {SIZE}.",
@@ -640,21 +635,19 @@
       "SIZE": {}
     }
   },
-  "writeChangesPartitionFormatted": "מחיצה <b>{disk}{partition}</b> פורמטה בתור <b>{format}</b>",
+  "writeChangesPartitionFormatted": "מחיצה <b>{sysname}</b> פורמטה בתור <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "מחיצה <b>{disk}{partition}</b> תשמש עבור <b>{mount}</b>",
+  "writeChangesPartitionMounted": "מחיצה <b>{sysname}</b> תשמש עבור <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_hu.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_hu.arb
@@ -38,12 +38,11 @@
   "@officeSlideCalc": {},
   "writeChangesDescription": "Ha folytatja, akkor az alább felsorolt változtatások a lemezekre lesznek írva. A további változtatásokat kézzel végezheti el.",
   "@writeChangesDescription": {},
-  "writeChangesPartitionEntryUnmounted": "partíció #<{disk}{partition} mint {format}",
+  "writeChangesPartitionEntryUnmounted": "partíció #<{sysname} mint {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -523,12 +522,11 @@
       "os": {}
     }
   },
-  "writeChangesPartitionEntryMounted": "#{disk}{partition} partíció, mint {format} a {mount} esetében",
+  "writeChangesPartitionEntryMounted": "#{sysname} partíció, mint {format} a {mount} esetében",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -671,51 +669,46 @@
   },
   "showSecurityKey": "Biztonsági kulcs megjelenítése",
   "@showSecurityKey": {},
-  "writeChangesPartitionCreated": "<b>{disk}{partition}</b> partíció létrehozva",
+  "writeChangesPartitionCreated": "<b>{sysname}</b> partíció létrehozva",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "installationTypeLVMEncryptionSelected": "LVM és titkosítás kiválasztva",
   "@installationTypeLVMEncryptionSelected": {},
-  "writeChangesPartitionResized": "<b>{disk}{partition}</b> partíció átméretezve <b>{oldsize}</b> méretről <b>{newsize}</b> méretre",
+  "writeChangesPartitionResized": "<b>{sysname}</b> partíció átméretezve <b>{oldsize}</b> méretről <b>{newsize}</b> méretre",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormatted": "<b>{disk}{partition}</b> partíció <b>{format}</b> formátumra formázva",
+  "writeChangesPartitionFormatted": "<b>{sysname}</b> partíció <b>{format}</b> formátumra formázva",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "<b>{disk}{partition}</b> partíció <b>{format}</b> formátumra formázva, <b>{mount}</b> helyre csatolva",
+  "writeChangesPartitionFormattedMounted": "<b>{sysname}</b> partíció <b>{format}</b> formátumra formázva, <b>{mount}</b> helyre csatolva",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionMounted": "<b>{disk}{partition}</b> partíció <b>{mount}</b> helyre csatolva",
+  "writeChangesPartitionMounted": "<b>{sysname}</b> partíció <b>{mount}</b> helyre csatolva",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_id.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_id.arb
@@ -109,12 +109,11 @@
   "@partitionUnitGB": {},
   "whoAreYouPageConfirmPasswordLabel": "Konfirmasikan kata sandi Anda",
   "@whoAreYouPageConfirmPasswordLabel": {},
-  "writeChangesPartitionEntryUnmounted": "partisi #{disk}{partition} sebagai {format}",
+  "writeChangesPartitionEntryUnmounted": "partisi #{sysname} sebagai {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -319,12 +318,11 @@
   "@whoAreYouPagePasswordMismatch": {},
   "writeChangesPartitionsHeader": "Partisi berikut akan diformat:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "partisi #{disk}{partition} sebagai {format} dipakai untuk {mount}",
+  "writeChangesPartitionEntryMounted": "partisi #{sysname} sebagai {format} dipakai untuk {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_ja.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_ja.arb
@@ -300,22 +300,20 @@
   "@writeChangesPartitionsHeader": {},
   "chooseYourLookPageTitle": "テーマを選択してください。",
   "@chooseYourLookPageTitle": {},
-  "writeChangesPartitionEntryMounted": "パーティション、#{disk}{partition} は {format} にフォーマットされ、 {mount} に割り当てられます",
+  "writeChangesPartitionEntryMounted": "パーティション、#{sysname} は {format} にフォーマットされ、 {mount} に割り当てられます",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "パーティション、#{disk}{partition} は {format} にフォーマットされます",
+  "writeChangesPartitionEntryUnmounted": "パーティション、#{sysname} は {format} にフォーマットされます",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -694,30 +692,27 @@
   "@continueTesting": {},
   "restartNow": "今すぐ再起動する",
   "@restartNow": {},
-  "writeChangesPartitionFormatted": "パーティション<b>{disk}{partition}</b>は<b>{format}</b>としてフォーマットされます。",
+  "writeChangesPartitionFormatted": "パーティション<b>{sysname}</b>は<b>{format}</b>としてフォーマットされます。",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "パーティション<b>{disk}{partition}</b>は<b>{mount}</b>として使用されます。",
+  "writeChangesPartitionMounted": "パーティション<b>{sysname}</b>は<b>{mount}</b>として使用されます。",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "パーティション<b>{disk}{partition}</b>は<b>{format}</b>としてフォーマットされ、<b>{mount}</b>として使用されます。",
+  "writeChangesPartitionFormattedMounted": "パーティション<b>{sysname}</b>は<b>{format}</b>としてフォーマットされ、<b>{mount}</b>として使用されます。",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -729,22 +724,20 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionResized": "パーティション<b>{disk}{partition}</b>のサイズが<b>{oldsize}</b>から<b>{newsize}</b>に変更されます。",
+  "writeChangesPartitionResized": "パーティション<b>{sysname}</b>のサイズが<b>{oldsize}</b>から<b>{newsize}</b>に変更されます。",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionCreated": "パーティション<b>{disk}{partition}</b>が作成されました。",
+  "writeChangesPartitionCreated": "パーティション<b>{sysname}</b>が作成されました。",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "tooManyPrimaryPartitions": "基本パーティションが多すぎます",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_ko.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_ko.arb
@@ -391,12 +391,11 @@
   "@chooseYourLookPageDarkSetting": {},
   "chooseYourLookPageLightSetting": "밝음",
   "@chooseYourLookPageLightSetting": {},
-  "writeChangesPartitionEntryMounted": "{mount} 로 사용되는 {format} 포맷의 #{disk}{partition} 파티션",
+  "writeChangesPartitionEntryMounted": "{mount} 로 사용되는 {format} 포맷의 #{sysname} 파티션",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -411,12 +410,11 @@
   "@diskHeadersFormat": {},
   "partitionFormatLabel": "용도:",
   "@partitionFormatLabel": {},
-  "writeChangesPartitionEntryUnmounted": "#{disk}{partition} 파티션을 {format} 로 포맷",
+  "writeChangesPartitionEntryUnmounted": "#{sysname} 파티션을 {format} 로 포맷",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -641,12 +639,11 @@
   "@configuringSystem": {},
   "installingSystem": "시스템 설치 중…",
   "@installingSystem": {},
-  "writeChangesPartitionCreated": "파티션 <b>{disk}{partition}</b> 생성됨",
+  "writeChangesPartitionCreated": "파티션 <b>{sysname}</b> 생성됨",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceHeader": "{RELEASE} 을(를) 설치하려면 적어도 {SIZE}의 디스크 공간이 필요합니다.",
@@ -673,12 +670,11 @@
       "SIZE": {}
     }
   },
-  "writeChangesPartitionFormatted": "파티션 <b>{disk}{partition}</b>을(를) <b>{format}</b> (으)로 포맷함",
+  "writeChangesPartitionFormatted": "파티션 <b>{sysname}</b>을(를) <b>{format}</b> (으)로 포맷함",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -686,22 +682,20 @@
   "@restartNow": {},
   "continueTesting": "체험 계속하기",
   "@continueTesting": {},
-  "writeChangesPartitionFormattedMounted": "파티션 <b>{disk}{partition}</b> 을(를) <b>{format}</b>(으)로 포맷하고 <b>{mount}</b>에 마운트",
+  "writeChangesPartitionFormattedMounted": "파티션 <b>{sysname}</b> 을(를) <b>{format}</b>(으)로 포맷하고 <b>{mount}</b>에 마운트",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionMounted": "파티션 <b>{disk}{partition}</b>을(를) <b>{mount}</b>에 사용",
+  "writeChangesPartitionMounted": "파티션 <b>{sysname}</b>을(를) <b>{mount}</b>에 사용",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
@@ -720,12 +714,11 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionResized": "파티션 <b>{disk}{partition}</b>의 크기를 <b>{oldsize}</b>에서 <b>{newsize}</b>로 조정",
+  "writeChangesPartitionResized": "파티션 <b>{sysname}</b>의 크기를 <b>{oldsize}</b>에서 <b>{newsize}</b>로 조정",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations.dart
@@ -1350,32 +1350,32 @@ abstract class AppLocalizations {
   /// A resized partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition <b>{disk}{partition}</b> resized from <b>{oldsize}</b> to <b>{newsize}</b>'**
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize);
+  /// **'partition <b>{sysname}</b> resized from <b>{oldsize}</b> to <b>{newsize}</b>'**
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize);
 
   /// A formatted and mounted partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition <b>{disk}{partition}</b> formatted as <b>{format}</b> used for <b>{mount}</b>'**
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount);
+  /// **'partition <b>{sysname}</b> formatted as <b>{format}</b> used for <b>{mount}</b>'**
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount);
 
   /// A formatted partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition <b>{disk}{partition}</b> formatted as <b>{format}</b>'**
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format);
+  /// **'partition <b>{sysname}</b> formatted as <b>{format}</b>'**
+  String writeChangesPartitionFormatted(Object sysname, Object format);
 
   /// A mounted partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition <b>{disk}{partition}</b> used for <b>{mount}</b>'**
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount);
+  /// **'partition <b>{sysname}</b> used for <b>{mount}</b>'**
+  String writeChangesPartitionMounted(Object sysname, Object mount);
 
   /// A created partition entry
   ///
   /// In en, this message translates to:
-  /// **'partition <b>{disk}{partition}</b> created'**
-  String writeChangesPartitionCreated(Object disk, Object partition);
+  /// **'partition <b>{sysname}</b> created'**
+  String writeChangesPartitionCreated(Object sysname);
 
   /// No description provided for @chooseYourLookPageTitle.
   ///

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_am.dart
@@ -620,28 +620,28 @@ class AppLocalizationsAm extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ar.dart
@@ -620,28 +620,28 @@ class AppLocalizationsAr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_be.dart
@@ -620,28 +620,28 @@ class AppLocalizationsBe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bg.dart
@@ -620,28 +620,28 @@ class AppLocalizationsBg extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bn.dart
@@ -620,28 +620,28 @@ class AppLocalizationsBn extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bo.dart
@@ -620,28 +620,28 @@ class AppLocalizationsBo extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_bs.dart
@@ -620,28 +620,28 @@ class AppLocalizationsBs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ca.dart
@@ -620,28 +620,28 @@ class AppLocalizationsCa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'S’aplicaran els canvis següents a les particions:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cs.dart
@@ -620,28 +620,28 @@ class AppLocalizationsCs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Budou provedeny následující změny na oddílech:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'velikost oddílu <b>$disk$partition</b> změněna z <b>$oldsize</b> na <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'velikost oddílu <b>$sysname</b> změněna z <b>$oldsize</b> na <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'oddíl <b>$disk$partition</b> naformátovaný jako <b>$format</b> použit pro <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'oddíl <b>$sysname</b> naformátovaný jako <b>$format</b> použit pro <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'oddíl <b>$disk$partition</b> naformátován jako <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'oddíl <b>$sysname</b> naformátován jako <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'oddíl <b>$disk$partition</b> použit pro <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'oddíl <b>$sysname</b> použit pro <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'oddíl <b>$disk$partition</b> vytvořen';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'oddíl <b>$sysname</b> vytvořen';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_cy.dart
@@ -620,28 +620,28 @@ class AppLocalizationsCy extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_da.dart
@@ -620,28 +620,28 @@ class AppLocalizationsDa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'De følgende partitionsændringer vil træde i kraft:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> ændres fra <b>$oldsize</b> til <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> ændres fra <b>$oldsize</b> til <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formateret som <b>$format</b> brugt til <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formateret som <b>$format</b> brugt til <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formateret som <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formateret som <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> brugt til <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> brugt til <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> oprettet';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> oprettet';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_de.dart
@@ -620,28 +620,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Die folgenden Partitionsänderungen werden vorgenommen:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'Größe der Partition <b>$disk$partition</b> von <b>$oldsize</b> auf <b>$newsize</b> geändert';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'Größe der Partition <b>$sysname</b> von <b>$oldsize</b> auf <b>$newsize</b> geändert';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'Partition <b>$disk$partition</b> formatiert als <b>$format</b> verwendet für <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'Partition <b>$sysname</b> formatiert als <b>$format</b> verwendet für <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'Partition <b>$disk$partition</b> formatiert als <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'Partition <b>$sysname</b> formatiert als <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'Partition <b>$disk$partition</b> verwendet für <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'Partition <b>$sysname</b> verwendet für <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'Partition <b>$disk$partition</b> erstellt';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'Partition <b>$sysname</b> erstellt';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_dz.dart
@@ -620,28 +620,28 @@ class AppLocalizationsDz extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_el.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_en.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eo.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEo extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'La jenaj ŝanĝoj pri subdiskoj estas efektivigotaj:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'ŝanĝi la grandon de la subdisko <b>$disk$partition</b> de <b>$oldsize</b> al <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'ŝanĝi la grandon de la subdisko <b>$sysname</b> de <b>$oldsize</b> al <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'la subdisko <b>$disk$partition</b> strukturota laŭ <b>$format</b> kaj uzota por <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'la subdisko <b>$sysname</b> strukturota laŭ <b>$format</b> kaj uzota por <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'la subdisko <b>$disk$partition</b> strukturota laŭ <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'la subdisko <b>$sysname</b> strukturota laŭ <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'la subdisko <b>$disk$partition</b> uzota por <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'la subdisko <b>$sysname</b> uzota por <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'krei la subdiskon <b>$disk$partition</b>';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'krei la subdiskon <b>$sysname</b>';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_es.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Se aplicarán los cambios siguientes a las particiones:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partición <b>$disk$partition</b> redimensionada de <b>$oldsize</b> a <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partición <b>$sysname</b> redimensionada de <b>$oldsize</b> a <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partición <b>$disk$partition</b> formateada como <b>$format</b> utilizada para <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partición <b>$sysname</b> formateada como <b>$format</b> utilizada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partición <b>$disk$partition</b> formateada como <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partición <b>$sysname</b> formateada como <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partición <b>$disk$partition</b> utilizada para <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partición <b>$sysname</b> utilizada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partición <b>$disk$partition</b> creada';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partición <b>$sysname</b> creada';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_et.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEt extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_eu.dart
@@ -620,28 +620,28 @@ class AppLocalizationsEu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fa.dart
@@ -620,28 +620,28 @@ class AppLocalizationsFa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'تغییرهای افراز زیرمی‌خواهند اعمال شوند:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'اندازهٔ افراز <b>$disk$partition</b> از <b>$oldsize</b> به <b>$newsize</b> تغییر کرد';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'اندازهٔ افراز <b>$sysname</b> از <b>$oldsize</b> به <b>$newsize</b> تغییر کرد';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'افراز <b>$disk$partition</b> به صورت <b>$format</b> برای <b>$mount</b> قالب‌بندی شد';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'افراز <b>$sysname</b> به صورت <b>$format</b> برای <b>$mount</b> قالب‌بندی شد';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'افراز <b>$disk$partition</b> به صورت <b>$format</b> قالب‌بندی شد';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'افراز <b>$sysname</b> به صورت <b>$format</b> قالب‌بندی شد';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'افراز <b>$disk$partition</b> برای <b>$mount</b> استفاده شد';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'افراز <b>$sysname</b> برای <b>$mount</b> استفاده شد';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'افراز <b>$disk$partition</b> ایجاد شد';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'افراز <b>$sysname</b> ایجاد شد';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fi.dart
@@ -620,28 +620,28 @@ class AppLocalizationsFi extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Seuraavat osiomuutokset toteutetaan:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'osion <b>$disk$partition</b> koko <b>$oldsize</b> muutettu kokoon <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'osion <b>$sysname</b> koko <b>$oldsize</b> muutettu kokoon <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'osio <b>$disk$partition</b> alustettu muotoon <b>$format</b> käytettäväksi liitospisteenä <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'osio <b>$sysname</b> alustettu muotoon <b>$format</b> käytettäväksi liitospisteenä <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'osio <b>$disk$partition</b> alustettu muotoon <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'osio <b>$sysname</b> alustettu muotoon <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'osio <b>$disk$partition</b> käytettäväksi liitospisteenä <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'osio <b>$sysname</b> käytettäväksi liitospisteenä <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'osio <b>$disk$partition</b> luotu';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'osio <b>$sysname</b> luotu';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_fr.dart
@@ -620,28 +620,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Les modification suivantes sur les partitions seront appliquées :';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'la partition <b>$disk$partition</b> redimensionnée de <b>$oldsize</b> à <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'la partition <b>$sysname</b> redimensionnée de <b>$oldsize</b> à <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'la partition <b>$disk$partition</b> formatée en <b>$format</b> utilisée pour <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'la partition <b>$sysname</b> formatée en <b>$format</b> utilisée pour <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'la partition <b>$disk$partition</b> formatée en <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'la partition <b>$sysname</b> formatée en <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'la partition <b>$disk$partition</b> utilisée pour <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'la partition <b>$sysname</b> utilisée pour <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'la partition <b>$disk$partition</b> créée';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'la partition <b>$sysname</b> créée';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ga.dart
@@ -620,28 +620,28 @@ class AppLocalizationsGa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gl.dart
@@ -620,28 +620,28 @@ class AppLocalizationsGl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_gu.dart
@@ -620,28 +620,28 @@ class AppLocalizationsGu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_he.dart
@@ -620,28 +620,28 @@ class AppLocalizationsHe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'השינויים הבאים יחולו על המחיצות:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'הגודל של מחיצה <b>$disk$partition</b> ישתנה מ־<b>$oldsize</b> ל־<b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'הגודל של מחיצה <b>$sysname</b> ישתנה מ־<b>$oldsize</b> ל־<b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'מחיצה <b>$disk$partition</b> פורמטה כ־<b>$format</b> ומשמשת עבור <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'מחיצה <b>$sysname</b> פורמטה כ־<b>$format</b> ומשמשת עבור <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'מחיצה <b>$disk$partition</b> פורמטה בתור <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'מחיצה <b>$sysname</b> פורמטה בתור <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'מחיצה <b>$disk$partition</b> תשמש עבור <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'מחיצה <b>$sysname</b> תשמש עבור <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'המחיצה <b>$disk$partition</b> נוצרה';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'המחיצה <b>$sysname</b> נוצרה';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hi.dart
@@ -620,28 +620,28 @@ class AppLocalizationsHi extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hr.dart
@@ -620,28 +620,28 @@ class AppLocalizationsHr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_hu.dart
@@ -620,28 +620,28 @@ class AppLocalizationsHu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'A következő partícióváltoztatások kerülnek alkalmazásra:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return '<b>$disk$partition</b> partíció átméretezve <b>$oldsize</b> méretről <b>$newsize</b> méretre';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return '<b>$sysname</b> partíció átméretezve <b>$oldsize</b> méretről <b>$newsize</b> méretre';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return '<b>$disk$partition</b> partíció <b>$format</b> formátumra formázva, <b>$mount</b> helyre csatolva';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return '<b>$sysname</b> partíció <b>$format</b> formátumra formázva, <b>$mount</b> helyre csatolva';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return '<b>$disk$partition</b> partíció <b>$format</b> formátumra formázva';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return '<b>$sysname</b> partíció <b>$format</b> formátumra formázva';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return '<b>$disk$partition</b> partíció <b>$mount</b> helyre csatolva';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return '<b>$sysname</b> partíció <b>$mount</b> helyre csatolva';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return '<b>$disk$partition</b> partíció létrehozva';
+  String writeChangesPartitionCreated(Object sysname) {
+    return '<b>$sysname</b> partíció létrehozva';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_id.dart
@@ -620,28 +620,28 @@ class AppLocalizationsId extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Partisi berikut akan diformat:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_is.dart
@@ -620,28 +620,28 @@ class AppLocalizationsIs extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_it.dart
@@ -620,28 +620,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ja.dart
@@ -620,28 +620,28 @@ class AppLocalizationsJa extends AppLocalizations {
   String get writeChangesPartitionsHeader => '以下のパーティション変更が適用されます：';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'パーティション<b>$disk$partition</b>のサイズが<b>$oldsize</b>から<b>$newsize</b>に変更されます。';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'パーティション<b>$sysname</b>のサイズが<b>$oldsize</b>から<b>$newsize</b>に変更されます。';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'パーティション<b>$disk$partition</b>は<b>$format</b>としてフォーマットされ、<b>$mount</b>として使用されます。';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'パーティション<b>$sysname</b>は<b>$format</b>としてフォーマットされ、<b>$mount</b>として使用されます。';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'パーティション<b>$disk$partition</b>は<b>$format</b>としてフォーマットされます。';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'パーティション<b>$sysname</b>は<b>$format</b>としてフォーマットされます。';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'パーティション<b>$disk$partition</b>は<b>$mount</b>として使用されます。';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'パーティション<b>$sysname</b>は<b>$mount</b>として使用されます。';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'パーティション<b>$disk$partition</b>が作成されました。';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'パーティション<b>$sysname</b>が作成されました。';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ka.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kk.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKk extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_km.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKm extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_kn.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKn extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ko.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKo extends AppLocalizations {
   String get writeChangesPartitionsHeader => '다음과 같은 파티션 변경사항이 적용됩니다:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return '파티션 <b>$disk$partition</b>의 크기를 <b>$oldsize</b>에서 <b>$newsize</b>로 조정';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return '파티션 <b>$sysname</b>의 크기를 <b>$oldsize</b>에서 <b>$newsize</b>로 조정';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return '파티션 <b>$disk$partition</b> 을(를) <b>$format</b>(으)로 포맷하고 <b>$mount</b>에 마운트';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return '파티션 <b>$sysname</b> 을(를) <b>$format</b>(으)로 포맷하고 <b>$mount</b>에 마운트';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return '파티션 <b>$disk$partition</b>을(를) <b>$format</b> (으)로 포맷함';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return '파티션 <b>$sysname</b>을(를) <b>$format</b> (으)로 포맷함';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return '파티션 <b>$disk$partition</b>을(를) <b>$mount</b>에 사용';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return '파티션 <b>$sysname</b>을(를) <b>$mount</b>에 사용';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return '파티션 <b>$disk$partition</b> 생성됨';
+  String writeChangesPartitionCreated(Object sysname) {
+    return '파티션 <b>$sysname</b> 생성됨';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ku.dart
@@ -620,28 +620,28 @@ class AppLocalizationsKu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lo.dart
@@ -620,28 +620,28 @@ class AppLocalizationsLo extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lt.dart
@@ -620,28 +620,28 @@ class AppLocalizationsLt extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Bus pritaikyti šie skaidinių pakeitimai:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'skaidinio <b>$disk$partition</b> dydis pakeistas iš <b>$oldsize</b> į <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'skaidinio <b>$sysname</b> dydis pakeistas iš <b>$oldsize</b> į <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'skaidinys <b>$disk$partition</b> formatuotas kaip <b>$format</b> ir panaudotas kaip <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'skaidinys <b>$sysname</b> formatuotas kaip <b>$format</b> ir panaudotas kaip <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'skaidinys <b>$disk$partition</b> formatuotas kaip <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'skaidinys <b>$sysname</b> formatuotas kaip <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'skaidinys <b>$disk$partition</b> panaudotas kaip <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'skaidinys <b>$sysname</b> panaudotas kaip <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'sukurtas skaidinys <b>$disk$partition</b>';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'sukurtas skaidinys <b>$sysname</b>';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_lv.dart
@@ -620,28 +620,28 @@ class AppLocalizationsLv extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mk.dart
@@ -620,28 +620,28 @@ class AppLocalizationsMk extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ml.dart
@@ -620,28 +620,28 @@ class AppLocalizationsMl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'ഇനിപ്പറയുന്ന പാർട്ടീഷനുകൾ ഫോർമാറ്റ് ചെയ്യാൻ പോകുന്നു:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_mr.dart
@@ -620,28 +620,28 @@ class AppLocalizationsMr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_my.dart
@@ -620,28 +620,28 @@ class AppLocalizationsMy extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nb.dart
@@ -620,28 +620,28 @@ class AppLocalizationsNb extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Følgende partisjonsendringer vil bli utført:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'endret størrelse fra $oldsize til $newsize for #$disk$partition';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'endret størrelse fra $oldsize til $newsize for #$sysname';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partisjon #$disk$partition formatert som $format og brukt til $mount';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partisjon #$sysname formatert som $format og brukt til $mount';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partisjon #$disk$partition formatert som $format';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partisjon #$sysname formatert som $format';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partisjon #$disk$partition brukt til $mount';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partisjon #$sysname brukt til $mount';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partisjon #$disk$partition opprettet';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partisjon #$sysname opprettet';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ne.dart
@@ -620,28 +620,28 @@ class AppLocalizationsNe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nl.dart
@@ -620,28 +620,28 @@ class AppLocalizationsNl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_nn.dart
@@ -620,28 +620,28 @@ class AppLocalizationsNn extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_oc.dart
@@ -620,28 +620,28 @@ class AppLocalizationsOc extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Las modificacions seguenta seràn aplicadas a las particions :';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'la particion <b>$disk$partition</b> redimensionada de <b>$oldsize</b> a <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'la particion <b>$sysname</b> redimensionada de <b>$oldsize</b> a <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'la particion <b>$disk$partition</b> formatada en <b>$format</b> utilizada per <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'la particion <b>$sysname</b> formatada en <b>$format</b> utilizada per <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'la particion <b>$disk$partition</b> formatada en <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'la particion <b>$sysname</b> formatada en <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'la particion <b>$disk$partition</b> utilizada per <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'la particion <b>$sysname</b> utilizada per <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'particion <b>$disk$partition</b> creada';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'particion <b>$sysname</b> creada';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pa.dart
@@ -620,28 +620,28 @@ class AppLocalizationsPa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pl.dart
@@ -620,28 +620,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Zostaną zastosowane następujące zmiany partycji:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partycja <b>$disk$partition</b> zmieniła rozmiar z <b>$oldsize</b> na <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partycja <b>$sysname</b> zmieniła rozmiar z <b>$oldsize</b> na <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partycja <b>$disk$partition</b> sformatowana jako <b>$format</b> używana do <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partycja <b>$sysname</b> sformatowana jako <b>$format</b> używana do <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partycja <b>$disk$partition</b> sformatowana jako <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partycja <b>$sysname</b> sformatowana jako <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partycja <b>$disk$partition</b> używana do <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partycja <b>$sysname</b> używana do <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'utworzona partycja <b>$disk$partition</b>';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'utworzona partycja <b>$sysname</b>';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_pt.dart
@@ -620,28 +620,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'As seguintes alterações às partições serão aplicadas:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partição <b>$disk$partition</b> redimensionada de <b>$oldsize</b> para <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partição <b>$sysname</b> redimensionada de <b>$oldsize</b> para <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partição <b>$disk$partition</b> formatada como <b>$format</b> usada para <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partição <b>$sysname</b> formatada como <b>$format</b> usada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partição <b>$disk$partition</b> formatada como <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partição <b>$sysname</b> formatada como <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partição <b>$disk$partition</b> usada para <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partição <b>$sysname</b> usada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partição <b>$disk$partition</b> criada';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partição <b>$sysname</b> criada';
   }
 
   @override
@@ -1532,28 +1532,28 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get writeChangesPartitionsHeader => 'As seguintes partições serão formatadas:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partição <b>$disk$partition</b> alterada de <b>$oldsize</b> para <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partição <b>$sysname</b> alterada de <b>$oldsize</b> para <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partição <b>$disk$partition</b> formatada como <b>$format</b> usada para <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partição <b>$sysname</b> formatada como <b>$format</b> usada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partição <b>$disk$partition</b> formatada como <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partição <b>$sysname</b> formatada como <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partição <b>$disk$partition</b> usada para <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partição <b>$sysname</b> usada para <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partição <b>$disk$partition</b> criada';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partição <b>$sysname</b> criada';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ro.dart
@@ -620,28 +620,28 @@ class AppLocalizationsRo extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ru.dart
@@ -620,28 +620,28 @@ class AppLocalizationsRu extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Будут применены следующие изменения разделов:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'размер раздела <b>$disk$partition</b> изменён с <b>$oldsize</b> на <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'размер раздела <b>$sysname</b> изменён с <b>$oldsize</b> на <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'раздел <b>$disk$partition</b> отформатирован как <b>$format</b> и использован для <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'раздел <b>$sysname</b> отформатирован как <b>$format</b> и использован для <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'раздел <b>$disk$partition</b> отформатирован как <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'раздел <b>$sysname</b> отформатирован как <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'раздел <b>$disk$partition</b> использован для <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'раздел <b>$sysname</b> использован для <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'раздел <b>$disk$partition</b> создан';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'раздел <b>$sysname</b> создан';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_se.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_si.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSi extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'පහත පංගු වෙනස්කම් යෙදෙනු ඇත:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return '#$disk$partition පංගුව $oldsize සිට $newsize දක්වා ප්‍රමාණනය කෙරිණි';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return '#$sysname පංගුව $oldsize සිට $newsize දක්වා ප්‍රමාණනය කෙරිණි';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return '#$disk$partition පංගුව $mount සඳහා භාවිතයට $format ලෙස පවිත්‍රව ඇත';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return '#$sysname පංගුව $mount සඳහා භාවිතයට $format ලෙස පවිත්‍රව ඇත';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return '#$disk$partition පංගුව $format ලෙස පවිත්‍රව ඇත';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return '#$sysname පංගුව $format ලෙස පවිත්‍රව ඇත';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return '#$disk$partition පංගුව $mount සඳහා භාවිතා වේ';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return '#$sysname පංගුව $mount සඳහා භාවිතා වේ';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return '#$disk$partition පංගුව සෑදිණි';
+  String writeChangesPartitionCreated(Object sysname) {
+    return '#$sysname පංගුව සෑදිණි';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sk.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSk extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Budú vykonané nasledujúce zmeny na oddieloch:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'veľkosť oddielu <b>$disk$partition</b> zmenené z <b>$oldsize</b> na <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'veľkosť oddielu <b>$sysname</b> zmenené z <b>$oldsize</b> na <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'oddiel <b>$disk$partition</b> naformátovaný ako <b>$format</b> použitý pre <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'oddiel <b>$sysname</b> naformátovaný ako <b>$format</b> použitý pre <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'oddiel <b>$disk$partition</b> naformátovaný ako <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'oddiel <b>$sysname</b> naformátovaný ako <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'oddiel <b>$disk$partition</b> použitý pre <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'oddiel <b>$sysname</b> použitý pre <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'oddiel <b>$disk$partition</b> vytvorený';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'oddiel <b>$sysname</b> vytvorený';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sl.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sq.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSq extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sr.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_sv.dart
@@ -620,28 +620,28 @@ class AppLocalizationsSv extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Följande partitionsändringar kommer att tillämpas:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> storleksändrad från <b>$oldsize</b> till <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> storleksändrad från <b>$oldsize</b> till <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formaterad som <b>$format</b> används för <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formaterad som <b>$format</b> används för <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formaterad som <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formaterad som <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> används för <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> används för <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> skapad';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> skapad';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ta.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTa extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_te.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTe extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tg.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTg extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_th.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTh extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tl.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTl extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_tr.dart
@@ -620,28 +620,28 @@ class AppLocalizationsTr extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Aşağıdaki bölüm değişiklikleri uygulanacak:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return '<b>$disk$partition</b> bölümü <b>$oldsize</b> boyutundan <b>$newsize</b> boyutuna yeniden boyutlandırıldı';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return '<b>$sysname</b> bölümü <b>$oldsize</b> boyutundan <b>$newsize</b> boyutuna yeniden boyutlandırıldı';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return '<b>$format </b> biçimindeki <b>$disk$partition</b> bölümü <b>$mount</b> için kullanıldı';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return '<b>$format </b> biçimindeki <b>$sysname</b> bölümü <b>$mount</b> için kullanıldı';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return '<b>$disk$partition</b> bölümü <b>$format</b> olarak biçimlendirildi';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return '<b>$sysname</b> bölümü <b>$format</b> olarak biçimlendirildi';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return '<b>$disk$partition</b> bölümü <b>$mount</b> için kullanıldı';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return '<b>$sysname</b> bölümü <b>$mount</b> için kullanıldı';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return '<b>$disk$partition</b> bölümü oluşturuldu';
+  String writeChangesPartitionCreated(Object sysname) {
+    return '<b>$sysname</b> bölümü oluşturuldu';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_ug.dart
@@ -620,28 +620,28 @@ class AppLocalizationsUg extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_uk.dart
@@ -620,28 +620,28 @@ class AppLocalizationsUk extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'Будуть застосовані наступні зміни розділів:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'розмір розділу #$disk$partition змінено з $oldsize на $newsize';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'розмір розділу #$sysname змінено з $oldsize на $newsize';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'розділ #$disk$partition, відформатований як $format, використано для $mount';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'розділ #$sysname, відформатований як $format, використано для $mount';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'розділ #$disk$partition відформатовано як $format';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'розділ #$sysname відформатовано як $format';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'розділ #$disk$partition використано для $mount';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'розділ #$sysname використано для $mount';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'створено розділ #$disk$partition';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'створено розділ #$sysname';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_vi.dart
@@ -620,28 +620,28 @@ class AppLocalizationsVi extends AppLocalizations {
   String get writeChangesPartitionsHeader => 'The following partition changes are going to be applied:';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return 'partition <b>$disk$partition</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return 'partition <b>$sysname</b> resized from <b>$oldsize</b> to <b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b> used for <b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return 'partition <b>$disk$partition</b> formatted as <b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return 'partition <b>$sysname</b> formatted as <b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return 'partition <b>$disk$partition</b> used for <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return 'partition <b>$sysname</b> used for <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return 'partition <b>$disk$partition</b> created';
+  String writeChangesPartitionCreated(Object sysname) {
+    return 'partition <b>$sysname</b> created';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_localizations_zh.dart
@@ -620,28 +620,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get writeChangesPartitionsHeader => '将应用以下分区更改：';
 
   @override
-  String writeChangesPartitionResized(Object disk, Object partition, Object oldsize, Object newsize) {
-    return '分区<b>$disk$partition</b> 从<b>$oldsize</b> 调整为<b>$newsize</b>';
+  String writeChangesPartitionResized(Object sysname, Object oldsize, Object newsize) {
+    return '分区<b>$sysname</b> 从<b>$oldsize</b> 调整为<b>$newsize</b>';
   }
 
   @override
-  String writeChangesPartitionFormattedMounted(Object disk, Object partition, Object format, Object mount) {
-    return '分区<b>$disk$partition</b> 格式化为<b>$format</b> 并挂载到<b>$mount</b>';
+  String writeChangesPartitionFormattedMounted(Object sysname, Object format, Object mount) {
+    return '分区<b>$sysname</b> 格式化为<b>$format</b> 并挂载到<b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionFormatted(Object disk, Object partition, Object format) {
-    return '分区<b>$disk$partition</b> 格式化为<b>$format</b>';
+  String writeChangesPartitionFormatted(Object sysname, Object format) {
+    return '分区<b>$sysname</b> 格式化为<b>$format</b>';
   }
 
   @override
-  String writeChangesPartitionMounted(Object disk, Object partition, Object mount) {
-    return '分区 <b>$disk$partition</b> 挂载到 <b>$mount</b>';
+  String writeChangesPartitionMounted(Object sysname, Object mount) {
+    return '分区 <b>$sysname</b> 挂载到 <b>$mount</b>';
   }
 
   @override
-  String writeChangesPartitionCreated(Object disk, Object partition) {
-    return '分区 <b>$disk$partition</b> 已创建';
+  String writeChangesPartitionCreated(Object sysname) {
+    return '分区 <b>$sysname</b> 已创建';
   }
 
   @override

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_lt.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_lt.arb
@@ -310,12 +310,11 @@
   },
   "writeChangesPartitionsHeader": "Bus pritaikyti šie skaidinių pakeitimai:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionResized": "skaidinio <b>{disk}{partition}</b> dydis pakeistas iš <b>{oldsize}</b> į <b>{newsize}</b>",
+  "writeChangesPartitionResized": "skaidinio <b>{sysname}</b> dydis pakeistas iš <b>{oldsize}</b> į <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
@@ -381,12 +380,11 @@
   "@whoAreYouPagePasswordMismatch": {},
   "writeChangesPartitionTablesHeader": "Šių įrenginių skaidinių lentelėms yra atlikti pakeitimai:",
   "@writeChangesPartitionTablesHeader": {},
-  "writeChangesPartitionCreated": "sukurtas skaidinys <b>{disk}{partition}</b>",
+  "writeChangesPartitionCreated": "sukurtas skaidinys <b>{sysname}</b>",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "chooseYourLookPageHeader": "Vėliau išvaizdos nustatymuose bet kada galėsite tai pakeisti.",
@@ -455,12 +453,11 @@
   "@partitionUnitGB": {},
   "writeChangesToDisk": "Pasiruošę įdiegti",
   "@writeChangesToDisk": {},
-  "writeChangesPartitionFormattedMounted": "skaidinys <b>{disk}{partition}</b> formatuotas kaip <b>{format}</b> ir panaudotas kaip <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "skaidinys <b>{sysname}</b> formatuotas kaip <b>{format}</b> ir panaudotas kaip <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -557,21 +554,19 @@
   "@whoAreYouPageUsernameInUse": {},
   "installationCompleteTitle": "Įdiegimas baigtas",
   "@installationCompleteTitle": {},
-  "writeChangesPartitionMounted": "skaidinys <b>{disk}{partition}</b> panaudotas kaip <b>{mount}</b>",
+  "writeChangesPartitionMounted": "skaidinys <b>{sysname}</b> panaudotas kaip <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "skaidinys <b>{disk}{partition}</b> formatuotas kaip <b>{format}</b>",
+  "writeChangesPartitionFormatted": "skaidinys <b>{sysname}</b> formatuotas kaip <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_ml.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_ml.arb
@@ -77,12 +77,11 @@
   "@writeChangesDescription": {},
   "writeChangesPartitionsHeader": "ഇനിപ്പറയുന്ന പാർട്ടീഷനുകൾ ഫോർമാറ്റ് ചെയ്യാൻ പോകുന്നു:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "പാർട്ടീഷൻ #{disk}{partition} {format} ആയി {mount} ഉപയോഗിച്ചു",
+  "writeChangesPartitionEntryMounted": "പാർട്ടീഷൻ #{sysname} {format} ആയി {mount} ഉപയോഗിച്ചു",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -373,12 +372,11 @@
   "@whoAreYouPagePasswordLabel": {},
   "whoAreYouPagePasswordRequired": "ഒരു പാസ്‌വേഡ് ആവശ്യമാണ്",
   "@whoAreYouPagePasswordRequired": {},
-  "writeChangesPartitionEntryUnmounted": "പാർട്ടീഷൻ #{disk}{partition} {format} ആയി",
+  "writeChangesPartitionEntryUnmounted": "പാർട്ടീഷൻ #{sysname} {format} ആയി",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_nb.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_nb.arb
@@ -583,12 +583,11 @@
   },
   "bootLoaderDevice": "Enhet å installere oppstartslaster på",
   "@bootLoaderDevice": {},
-  "writeChangesPartitionMounted": "partisjon #{disk}{partition} brukt til {mount}",
+  "writeChangesPartitionMounted": "partisjon #{sysname} brukt til {mount}",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
@@ -599,40 +598,36 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionResized": "endret størrelse fra {oldsize} til {newsize} for #{disk}{partition}",
+  "writeChangesPartitionResized": "endret størrelse fra {oldsize} til {newsize} for #{sysname}",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partisjon #{disk}{partition} formatert som {format} og brukt til {mount}",
+  "writeChangesPartitionFormattedMounted": "partisjon #{sysname} formatert som {format} og brukt til {mount}",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "partisjon #{disk}{partition} opprettet",
+  "writeChangesPartitionCreated": "partisjon #{sysname} opprettet",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
-  "writeChangesPartitionFormatted": "partisjon #{disk}{partition} formatert som {format}",
+  "writeChangesPartitionFormatted": "partisjon #{sysname} formatert som {format}",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_oc.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_oc.arb
@@ -379,22 +379,20 @@
   "@chooseSecurityKeyRequired": {},
   "selectGuidedStorageDropdownLabel": "Seleccionatz lo disc :",
   "@selectGuidedStorageDropdownLabel": {},
-  "writeChangesPartitionEntryMounted": "la particion #{disk}{partition} en {format} utilizada per {mount}",
+  "writeChangesPartitionEntryMounted": "la particion #{sysname} en {format} utilizada per {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "particion #{disk}{partition} en {format}",
+  "writeChangesPartitionEntryUnmounted": "particion #{sysname} en {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -608,12 +606,11 @@
   "@installingSystem": {},
   "configuringSystem": "Configuracion del sistèma…",
   "@configuringSystem": {},
-  "writeChangesPartitionResized": "la particion <b>{disk}{partition}</b> redimensionada de <b>{oldsize}</b> a <b>{newsize}</b>",
+  "writeChangesPartitionResized": "la particion <b>{sysname}</b> redimensionada de <b>{oldsize}</b> a <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
@@ -628,39 +625,35 @@
   },
   "supportSlideResources": "Per mai d’entresenhas, visitatz las paginas <a href=\"https://www.ubuntu.com/support/community-support\">assisténcia de la comunautat</a> o <a href=\"https://www.ubuntu.com/support\">l’assiténcia comerciala</a>.",
   "@supportSlideResources": {},
-  "writeChangesPartitionCreated": "particion <b>{disk}{partition}</b> creada",
+  "writeChangesPartitionCreated": "particion <b>{sysname}</b> creada",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
-  "writeChangesPartitionMounted": "la particion <b>{disk}{partition}</b> utilizada per <b>{mount}</b>",
+  "writeChangesPartitionMounted": "la particion <b>{sysname}</b> utilizada per <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "la particion <b>{disk}{partition}</b> formatada en <b>{format}</b> utilizada per <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "la particion <b>{sysname}</b> formatada en <b>{format}</b> utilizada per <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "la particion <b>{disk}{partition}</b> formatada en <b>{format}</b>",
+  "writeChangesPartitionFormatted": "la particion <b>{sysname}</b> formatada en <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_pl.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_pl.arb
@@ -135,12 +135,11 @@
   "@whoAreYouPageInvalidUsername": {},
   "writeChangesPartitionsHeader": "Zostaną zastosowane następujące zmiany partycji:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryUnmounted": "partycja #{disk}{partition} jako {format}",
+  "writeChangesPartitionEntryUnmounted": "partycja #{sysname} jako {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -313,12 +312,11 @@
       "path": {}
     }
   },
-  "writeChangesPartitionEntryMounted": "partycja #{disk}{partition} jako {format} używana do {mount}",
+  "writeChangesPartitionEntryMounted": "partycja #{sysname} jako {format} używana do {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -593,12 +591,11 @@
   },
   "installAlongsideSize": "Rozmiar:",
   "@installAlongsideSize": {},
-  "writeChangesPartitionFormattedMounted": "partycja <b>{disk}{partition}</b> sformatowana jako <b>{format}</b> używana do <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partycja <b>{sysname}</b> sformatowana jako <b>{format}</b> używana do <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -607,40 +604,36 @@
   "@notEnoughDiskSpaceTitle": {},
   "quitButtonText": "Zakończ instalację",
   "@quitButtonText": {},
-  "writeChangesPartitionMounted": "partycja <b>{disk}{partition}</b> używana do <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partycja <b>{sysname}</b> używana do <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionResized": "partycja <b>{disk}{partition}</b> zmieniła rozmiar z <b>{oldsize}</b> na <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partycja <b>{sysname}</b> zmieniła rozmiar z <b>{oldsize}</b> na <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormatted": "partycja <b>{disk}{partition}</b> sformatowana jako <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partycja <b>{sysname}</b> sformatowana jako <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionCreated": "utworzona partycja <b>{disk}{partition}</b>",
+  "writeChangesPartitionCreated": "utworzona partycja <b>{sysname}</b>",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceHeader": "Potrzebujesz co najmniej {SIZE} przestrzeni dyskowej, aby zainstalować {RELEASE}.",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_pt.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_pt.arb
@@ -277,22 +277,20 @@
   },
   "writeChangesPartitionsHeader": "As seguintes alterações às partições serão aplicadas:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "partição #{disk}{partition} como {format} usada para {mount}",
+  "writeChangesPartitionEntryMounted": "partição #{sysname} como {format} usada para {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "partição #{disk}{partition} como {format}",
+  "writeChangesPartitionEntryUnmounted": "partição #{sysname} como {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -471,22 +469,20 @@
   "@whoAreYouPageUsernameTooLong": {},
   "whoAreYouPageShowPassword": "Mostrar palavra-passe",
   "@whoAreYouPageShowPassword": {},
-  "writeChangesPartitionResized": "partição <b>{disk}{partition}</b> redimensionada de <b>{oldsize}</b> para <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partição <b>{sysname}</b> redimensionada de <b>{oldsize}</b> para <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionCreated": "partição <b>{disk}{partition}</b> criada",
+  "writeChangesPartitionCreated": "partição <b>{sysname}</b> criada",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "whereAreYouPageTitle": "Selecione o seu fuso-horário",
@@ -535,31 +531,28 @@
       "url": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partição <b>{disk}{partition}</b> formatada como <b>{format}</b> usada para <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partição <b>{sysname}</b> formatada como <b>{format}</b> usada para <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "partição <b>{disk}{partition}</b> formatada como <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partição <b>{sysname}</b> formatada como <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "partição <b>{disk}{partition}</b> usada para <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partição <b>{sysname}</b> usada para <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_pt_BR.arb
@@ -285,22 +285,20 @@
   },
   "writeChangesPartitionsHeader": "As seguintes partições serão formatadas:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "partição #{disk}{partition} como {format} usada para {mount}",
+  "writeChangesPartitionEntryMounted": "partição #{sysname} como {format} usada para {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "Um registro de partição montada",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "partição #{disk}{partition} como {format}",
+  "writeChangesPartitionEntryUnmounted": "partição #{sysname} como {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "Um registro de partição não montada",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -600,48 +598,43 @@
   "@installCodecsTitle": {},
   "installCodecsSubtitle": "Este software está sujeito aos termos de licença incluídos em sua documentação. Alguns são proprietários.",
   "@installCodecsSubtitle": {},
-  "writeChangesPartitionCreated": "partição <b>{disk}{partition}</b> criada",
+  "writeChangesPartitionCreated": "partição <b>{sysname}</b> criada",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "partição <b>{disk}{partition}</b> formatada como <b>{format}</b> usada para <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partição <b>{sysname}</b> formatada como <b>{format}</b> usada para <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "partição <b>{disk}{partition}</b> formatada como <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partição <b>{sysname}</b> formatada como <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "partição <b>{disk}{partition}</b> usada para <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partição <b>{sysname}</b> usada para <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionResized": "partição <b>{disk}{partition}</b> alterada de <b>{oldsize}</b> para <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partição <b>{sysname}</b> alterada de <b>{oldsize}</b> para <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_ru.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_ru.arb
@@ -401,21 +401,19 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "раздел #{disk}{partition} как {format}",
+  "writeChangesPartitionEntryUnmounted": "раздел #{sysname} как {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionEntryMounted": "раздел #{disk}{partition} как {format} используется для {mount}",
+  "writeChangesPartitionEntryMounted": "раздел #{sysname} как {format} используется для {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -591,23 +589,21 @@
   },
   "installAlongsideAvailable": "Доступно:",
   "@installAlongsideAvailable": {},
-  "writeChangesPartitionMounted": "раздел <b>{disk}{partition}</b> использован для <b>{mount}</b>",
+  "writeChangesPartitionMounted": "раздел <b>{sysname}</b> использован для <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
   "quitButtonText": "Отменить установку",
   "@quitButtonText": {},
-  "writeChangesPartitionResized": "размер раздела <b>{disk}{partition}</b> изменён с <b>{oldsize}</b> на <b>{newsize}</b>",
+  "writeChangesPartitionResized": "размер раздела <b>{sysname}</b> изменён с <b>{oldsize}</b> на <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
@@ -647,31 +643,28 @@
       "SIZE": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "раздел <b>{disk}{partition}</b> отформатирован как <b>{format}</b> и использован для <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "раздел <b>{sysname}</b> отформатирован как <b>{format}</b> и использован для <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "раздел <b>{disk}{partition}</b> отформатирован как <b>{format}</b>",
+  "writeChangesPartitionFormatted": "раздел <b>{sysname}</b> отформатирован как <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionCreated": "раздел <b>{disk}{partition}</b> создан",
+  "writeChangesPartitionCreated": "раздел <b>{sysname}</b> создан",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "installationTypeLVMEncryptionSelected": "LVM и шифрование выбраны",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_si.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_si.arb
@@ -619,22 +619,20 @@
   },
   "newPartitionTableConfirmationMessage": "ඔබ පංගුකරණයට සමස්ත උපාංගයක් තෝරාගෙන ඇත. ඔබ එහි නව පංගු වගුවක් සෑදීමට ගියහොත්, පවතින සියළුම පංගු ඉවත් කෙරෙනු ඇත.\n\nඔබට අවශ්‍ය නම් මෙම මෙහෙයුම පසුව අහෝසි කිරීමට හැකිය.",
   "@newPartitionTableConfirmationMessage": {},
-  "writeChangesPartitionFormattedMounted": "#{disk}{partition} පංගුව {mount} සඳහා භාවිතයට {format} ලෙස පවිත්‍රව ඇත",
+  "writeChangesPartitionFormattedMounted": "#{sysname} පංගුව {mount} සඳහා භාවිතයට {format} ලෙස පවිත්‍රව ඇත",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "#{disk}{partition} පංගුව {format} ලෙස පවිත්‍රව ඇත",
+  "writeChangesPartitionFormatted": "#{sysname} පංගුව {format} ලෙස පවිත්‍රව ඇත",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -655,21 +653,19 @@
   "@newPartitionTableConfirmationTitle": {},
   "partitionCreateTitle": "පංගුව සාදන්න",
   "@partitionCreateTitle": {},
-  "writeChangesPartitionMounted": "#{disk}{partition} පංගුව {mount} සඳහා භාවිතා වේ",
+  "writeChangesPartitionMounted": "#{sysname} පංගුව {mount} සඳහා භාවිතා වේ",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "#{disk}{partition} පංගුව සෑදිණි",
+  "writeChangesPartitionCreated": "#{sysname} පංගුව සෑදිණි",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "welcomeSlideDescription": "වේගවත් සහ නව විශේෂාංග වලින් පිරුණු {RELEASE} හි නවතම අනුවාදය අන් කවරදාටත් වඩා පරිගණනය පහසු කරයි. මෙන්න බලන්න අළුත් දේවල් ටිකක්...",
@@ -730,12 +726,11 @@
   "@writeChangesPartitionTablesHeader": {},
   "writeChangesPartitionsHeader": "පහත පංගු වෙනස්කම් යෙදෙනු ඇත:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionResized": "#{disk}{partition} පංගුව {oldsize} සිට {newsize} දක්වා ප්‍රමාණනය කෙරිණි",
+  "writeChangesPartitionResized": "#{sysname} පංගුව {oldsize} සිට {newsize} දක්වා ප්‍රමාණනය කෙරිණි",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_sk.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_sk.arb
@@ -542,41 +542,37 @@
   "@noInternet": {},
   "selectGuidedStorageInstallNow": "Nainštalovať teraz",
   "@selectGuidedStorageInstallNow": {},
-  "writeChangesPartitionFormattedMounted": "oddiel <b>{disk}{partition}</b> naformátovaný ako <b>{format}</b> použitý pre <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "oddiel <b>{sysname}</b> naformátovaný ako <b>{format}</b> použitý pre <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionResized": "veľkosť oddielu <b>{disk}{partition}</b> zmenené z <b>{oldsize}</b> na <b>{newsize}</b>",
+  "writeChangesPartitionResized": "veľkosť oddielu <b>{sysname}</b> zmenené z <b>{oldsize}</b> na <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionMounted": "oddiel <b>{disk}{partition}</b> použitý pre <b>{mount}</b>",
+  "writeChangesPartitionMounted": "oddiel <b>{sysname}</b> použitý pre <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionFormatted": "oddiel <b>{disk}{partition}</b> naformátovaný ako <b>{format}</b>",
+  "writeChangesPartitionFormatted": "oddiel <b>{sysname}</b> naformátovaný ako <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -782,12 +778,11 @@
       "path": {}
     }
   },
-  "writeChangesPartitionCreated": "oddiel <b>{disk}{partition}</b> vytvorený",
+  "writeChangesPartitionCreated": "oddiel <b>{sysname}</b> vytvorený",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "readyToUse": "**{system}** je nainštalované a pripravené na použitie",

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_sv.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_sv.arb
@@ -321,22 +321,20 @@
   },
   "writeChangesPartitionsHeader": "Följande partitionsändringar kommer att tillämpas:",
   "@writeChangesPartitionsHeader": {},
-  "writeChangesPartitionEntryMounted": "partition #{disk}{partition} som {format} används för {mount}",
+  "writeChangesPartitionEntryMounted": "partition #{sysname} som {format} används för {mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionEntryUnmounted": "partition #{disk}{partition} som {format}",
+  "writeChangesPartitionEntryUnmounted": "partition #{sysname} som {format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -646,30 +644,27 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionFormatted": "partition <b>{disk}{partition}</b> formaterad som <b>{format}</b>",
+  "writeChangesPartitionFormatted": "partition <b>{sysname}</b> formaterad som <b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "partition <b>{disk}{partition}</b> används för <b>{mount}</b>",
+  "writeChangesPartitionMounted": "partition <b>{sysname}</b> används för <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "partition <b>{disk}{partition}</b> skapad",
+  "writeChangesPartitionCreated": "partition <b>{sysname}</b> skapad",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceTitle": "Inte tillräckligt med utrymme",
@@ -698,22 +693,20 @@
   },
   "quitButtonText": "Avbryt installation",
   "@quitButtonText": {},
-  "writeChangesPartitionFormattedMounted": "partition <b>{disk}{partition}</b> formaterad som <b>{format}</b> används för <b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "partition <b>{sysname}</b> formaterad som <b>{format}</b> används för <b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionResized": "partition <b>{disk}{partition}</b> storleksändrad från <b>{oldsize}</b> till <b>{newsize}</b>",
+  "writeChangesPartitionResized": "partition <b>{sysname}</b> storleksändrad från <b>{oldsize}</b> till <b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_tr.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_tr.arb
@@ -526,23 +526,21 @@
   },
   "partitionFormatLabel": "Kullanılan:",
   "@partitionFormatLabel": {},
-  "writeChangesPartitionMounted": "<b>{disk}{partition}</b> bölümü <b>{mount}</b> için kullanıldı",
+  "writeChangesPartitionMounted": "<b>{sysname}</b> bölümü <b>{mount}</b> için kullanıldı",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
   "writeChangesPartitionTablesHeader": "Aşağıdaki cihazların bölüm tabloları değiştirildi:",
   "@writeChangesPartitionTablesHeader": {},
-  "writeChangesPartitionResized": "<b>{disk}{partition}</b> bölümü <b>{oldsize}</b> boyutundan <b>{newsize}</b> boyutuna yeniden boyutlandırıldı",
+  "writeChangesPartitionResized": "<b>{sysname}</b> bölümü <b>{oldsize}</b> boyutundan <b>{newsize}</b> boyutuna yeniden boyutlandırıldı",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
@@ -561,12 +559,11 @@
   "@installAlongsideAvailable": {},
   "whoAreYouPageUsernameTooLong": "Bu ad çok uzun.",
   "@whoAreYouPageUsernameTooLong": {},
-  "writeChangesPartitionFormatted": "<b>{disk}{partition}</b> bölümü <b>{format}</b> olarak biçimlendirildi",
+  "writeChangesPartitionFormatted": "<b>{sysname}</b> bölümü <b>{format}</b> olarak biçimlendirildi",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -588,12 +585,11 @@
       "product": {}
     }
   },
-  "writeChangesPartitionCreated": "<b>{disk}{partition}</b> bölümü oluşturuldu",
+  "writeChangesPartitionCreated": "<b>{sysname}</b> bölümü oluşturuldu",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "installationTypeLVM": "Yeni {RELEASE} kurulumuyla LVM kullan",
@@ -619,12 +615,11 @@
       "os2": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "<b>{format} </b> biçimindeki <b>{disk}{partition}</b> bölümü <b>{mount}</b> için kullanıldı",
+  "writeChangesPartitionFormattedMounted": "<b>{format} </b> biçimindeki <b>{sysname}</b> bölümü <b>{mount}</b> için kullanıldı",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_uk.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_uk.arb
@@ -136,12 +136,11 @@
   },
   "partitionLocationEnd": "Кінець цього простору",
   "@partitionLocationEnd": {},
-  "writeChangesPartitionFormatted": "розділ #{disk}{partition} відформатовано як {format}",
+  "writeChangesPartitionFormatted": "розділ #{sysname} відформатовано як {format}",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -158,12 +157,11 @@
   "@writeChangesFallbackSerial": {
     "description": "Default display name for a disk without a serial (unlikely)"
   },
-  "writeChangesPartitionFormattedMounted": "розділ #{disk}{partition}, відформатований як {format}, використано для {mount}",
+  "writeChangesPartitionFormattedMounted": "розділ #{sysname}, відформатований як {format}, використано для {mount}",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
@@ -521,21 +519,19 @@
   "@whoAreYouPageUsernameInUse": {},
   "whoAreYouPagePasswordLabel": "Оберіть пароль",
   "@whoAreYouPagePasswordLabel": {},
-  "writeChangesPartitionMounted": "розділ #{disk}{partition} використано для {mount}",
+  "writeChangesPartitionMounted": "розділ #{sysname} використано для {mount}",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "створено розділ #{disk}{partition}",
+  "writeChangesPartitionCreated": "створено розділ #{sysname}",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "installationCompleteTitle": "Встановлення завершено",
@@ -605,12 +601,11 @@
   "@whoAreYouPagePasswordMismatch": {},
   "whoAreYouPageShowPassword": "Показати пароль",
   "@whoAreYouPageShowPassword": {},
-  "writeChangesPartitionResized": "розмір розділу #{disk}{partition} змінено з {oldsize} на {newsize}",
+  "writeChangesPartitionResized": "розмір розділу #{sysname} змінено з {oldsize} на {newsize}",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/l10n/app_zh.arb
+++ b/packages/ubuntu_desktop_installer/lib/l10n/app_zh.arb
@@ -207,24 +207,22 @@
   "@normalInstallationTitle": {},
   "installationTypeAlongsideInfo": "将保存文件、音乐和其他个人文件。每次启动时，您可以选择所需的操作系统。",
   "@installationTypeAlongsideInfo": {},
-  "writeChangesPartitionEntryMounted": "分区#{disk}{partition}作为{format}用于{mount}",
+  "writeChangesPartitionEntryMounted": "分区#{sysname}作为{format}用于{mount}",
   "@writeChangesPartitionEntryMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }
   },
   "repairInstallationDescription": "修复选项将在保留个人数据和设置的情况下重新安装所有已安装的软件。",
   "@repairInstallationDescription": {},
-  "writeChangesPartitionEntryUnmounted": "分区#{disk}{partition}作为{format}",
+  "writeChangesPartitionEntryUnmounted": "分区#{sysname}作为{format}",
   "@writeChangesPartitionEntryUnmounted": {
     "description": "An unmounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
@@ -650,30 +648,27 @@
   },
   "quitButtonText": "退出安装",
   "@quitButtonText": {},
-  "writeChangesPartitionFormatted": "分区<b>{disk}{partition}</b> 格式化为<b>{format}</b>",
+  "writeChangesPartitionFormatted": "分区<b>{sysname}</b> 格式化为<b>{format}</b>",
   "@writeChangesPartitionFormatted": {
     "description": "A formatted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {}
     }
   },
-  "writeChangesPartitionMounted": "分区 <b>{disk}{partition}</b> 挂载到 <b>{mount}</b>",
+  "writeChangesPartitionMounted": "分区 <b>{sysname}</b> 挂载到 <b>{mount}</b>",
   "@writeChangesPartitionMounted": {
     "description": "A mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "mount": {}
     }
   },
-  "writeChangesPartitionCreated": "分区 <b>{disk}{partition}</b> 已创建",
+  "writeChangesPartitionCreated": "分区 <b>{sysname}</b> 已创建",
   "@writeChangesPartitionCreated": {
     "description": "A created partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {}
+      "sysname": {}
     }
   },
   "notEnoughDiskSpaceTitle": "空间不足",
@@ -686,22 +681,20 @@
       "RELEASE": {}
     }
   },
-  "writeChangesPartitionResized": "分区<b>{disk}{partition}</b> 从<b>{oldsize}</b> 调整为<b>{newsize}</b>",
+  "writeChangesPartitionResized": "分区<b>{sysname}</b> 从<b>{oldsize}</b> 调整为<b>{newsize}</b>",
   "@writeChangesPartitionResized": {
     "description": "A resized partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "oldsize": {},
       "newsize": {}
     }
   },
-  "writeChangesPartitionFormattedMounted": "分区<b>{disk}{partition}</b> 格式化为<b>{format}</b> 并挂载到<b>{mount}</b>",
+  "writeChangesPartitionFormattedMounted": "分区<b>{sysname}</b> 格式化为<b>{format}</b> 并挂载到<b>{mount}</b>",
   "@writeChangesPartitionFormattedMounted": {
     "description": "A formatted and mounted partition entry",
     "placeholders": {
-      "disk": {},
-      "partition": {},
+      "sysname": {},
       "format": {},
       "mount": {}
     }

--- a/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/confirm/confirm_page.dart
@@ -141,36 +141,29 @@ class _PartitionLabel extends StatelessWidget {
   String formatPartition(AppLocalizations lang) {
     if (partition.resize == true) {
       return lang.writeChangesPartitionResized(
-        '', // TODO: remove unused {disk} argument
         partition.sysname,
         filesize(original?.size ?? 0),
         filesize(partition.size ?? 0),
       );
     } else if (partition.wipe != null && partition.mount?.isNotEmpty == true) {
       return lang.writeChangesPartitionFormattedMounted(
-        '', // TODO: remove unused {disk} argument
         partition.sysname,
         partition.format ?? '',
         partition.mount ?? '',
       );
     } else if (partition.wipe != null && partition.format?.isNotEmpty == true) {
       return lang.writeChangesPartitionFormatted(
-        '', // TODO: remove unused {disk} argument
         partition.sysname,
         partition.format ?? '',
       );
     } else if (partition.mount?.isNotEmpty == true) {
       return lang.writeChangesPartitionMounted(
-        '', // TODO: remove unused {disk} argument
         partition.sysname,
         partition.mount ?? '',
       );
     } else {
       assert(partition.preserve == false);
-      return lang.writeChangesPartitionCreated(
-        '', // TODO: remove unused {disk} argument
-        partition.sysname,
-      );
+      return lang.writeChangesPartitionCreated(partition.sysname);
     }
   }
 

--- a/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
@@ -102,20 +102,20 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildConfirmPage(model)));
 
     expect(
-        find.html(tester.lang.writeChangesPartitionFormattedMounted(
-            '', 'sdb3', 'ext3', '/mnt/3')),
+        find.html(tester.lang
+            .writeChangesPartitionFormattedMounted('sdb3', 'ext3', '/mnt/3')),
         findsOneWidget);
     expect(
-        find.html(tester.lang.writeChangesPartitionFormatted('sdb', 4, 'ext4')),
+        find.html(tester.lang.writeChangesPartitionFormatted('sdb4', 'ext4')),
         findsOneWidget);
     expect(
-        find.html(tester.lang.writeChangesPartitionMounted('sdb', 5, '/mnt/5')),
+        find.html(tester.lang.writeChangesPartitionMounted('sdb5', '/mnt/5')),
         findsOneWidget);
     expect(
-        find.html(tester.lang.writeChangesPartitionResized(
-            'sdb', 6, filesize(123), filesize(66))),
+        find.html(tester.lang
+            .writeChangesPartitionResized('sdb6', filesize(123), filesize(66))),
         findsOneWidget);
-    expect(find.html(tester.lang.writeChangesPartitionCreated('sdb', 7)),
+    expect(find.html(tester.lang.writeChangesPartitionCreated('sdb7')),
         findsOneWidget);
   });
 


### PR DESCRIPTION
We changed from `{disk}{partition}` to `{sysname}` to fix the formatting of NVME partitions ("nvme0n11" vs. "nvme0n1p1") but weren't able to change translations right before the release.

See also:
- #1821