### PR TITLE
refactor(test): port away from problematic WidgetTester.lang

### DIFF
--- a/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
+++ b/packages/ubuntu_desktop_installer/integration_test/test_pages.dart
@@ -12,18 +12,17 @@ import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru_test/yaru_test.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '../test/test_utils.dart';
-
 Future<void> testLocalePage(
   WidgetTester tester, {
   String? language,
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(LocalePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.localePageTitle('Ubuntu')),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(LocalePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.localePageTitle('Ubuntu')), findsOneWidget);
 
   if (language != null) {
     final tile = find.listTile(language, skipOffstage: false);
@@ -47,10 +46,11 @@ Future<void> testWelcomePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(WelcomePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.welcomePageTitle('Ubuntu')),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(WelcomePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.welcomePageTitle('Ubuntu')), findsOneWidget);
 
   if (option != null) {
     await tester.tap(find.radio<Option>(option));
@@ -71,10 +71,11 @@ Future<void> testKeyboardPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(KeyboardPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.keyboardTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(KeyboardPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.keyboardTitle), findsOneWidget);
 
   if (keyboard != null) {
     if (keyboard.layout.isNotEmpty) {
@@ -97,7 +98,7 @@ Future<void> testKeyboardPage(
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
 
-    await tester.tapButton(tester.lang.keyboardDetectButton);
+    await tester.tapButton(l10n.keyboardDetectButton);
     await tester.pumpAndSettle();
 
     await takeScreenshot(tester, '$screenshot-detect');
@@ -117,10 +118,11 @@ Future<void> testNetworkPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(NetworkPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.connectToInternetPageTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(NetworkPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.connectToInternetPageTitle), findsOneWidget);
 
   if (mode != null) {
     await tester.tapRadio<ConnectMode>(mode);
@@ -140,10 +142,11 @@ Future<void> testSourcePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(SourcePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.updatesOtherSoftwarePageTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(SourcePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.updatesOtherSoftwarePageTitle), findsOneWidget);
 
   if (sourceId != null) {
     await tester.tapRadio<String>(sourceId);
@@ -162,17 +165,18 @@ Future<void> testNotEnoughDiskSpacePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(NotEnoughDiskSpacePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.notEnoughDiskSpaceTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(NotEnoughDiskSpacePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.notEnoughDiskSpaceTitle), findsOneWidget);
 
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
   }
 
   final windowClosed = YaruTestWindow.waitForClosed();
-  await tester.tapButton(tester.lang.quitButtonText);
+  await tester.tapButton(l10n.quitButtonText);
   await expectLater(windowClosed, completes);
 }
 
@@ -184,17 +188,18 @@ Future<void> testStoragePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(StoragePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.installationTypeTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(StoragePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.installationTypeTitle), findsOneWidget);
 
   if (type != null) {
     await tester.tapRadio<StorageType>(type);
     await tester.pump();
   }
   if (advancedFeature != null) {
-    await tester.tapButton(tester.lang.installationTypeAdvancedLabel);
+    await tester.tapButton(l10n.installationTypeAdvancedLabel);
     await tester.pumpAndSettle();
 
     await tester.tapRadio<AdvancedFeature>(advancedFeature);
@@ -202,7 +207,7 @@ Future<void> testStoragePage(
 
     if (useEncryption != null) {
       await tester.toggleButton(
-        tester.lang.installationTypeEncrypt('Ubuntu'),
+        l10n.installationTypeEncrypt('Ubuntu'),
         true,
       );
     }
@@ -231,17 +236,18 @@ Future<void> testSecurityKeyPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(SecurityKeyPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.chooseSecurityKeyTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(SecurityKeyPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.chooseSecurityKeyTitle), findsOneWidget);
 
   await tester.enterText(
-    find.textField(tester.lang.chooseSecurityKey),
+    find.textField(l10n.chooseSecurityKey),
     securityKey,
   );
   await tester.enterText(
-    find.textField(tester.lang.confirmSecurityKey),
+    find.textField(l10n.confirmSecurityKey),
     securityKey,
   );
 
@@ -260,18 +266,19 @@ Future<void> testManualStoragePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(ManualStoragePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.allocateDiskSpace),
-    findsOneWidget,
-  );
 
-  await tester.tapButton(tester.lang.newPartitionTable);
+  final context = tester.element(find.byType(ManualStoragePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.allocateDiskSpace), findsOneWidget);
+
+  await tester.tapButton(l10n.newPartitionTable);
   await tester.pumpAndSettle();
 
   for (final disk in storage ?? const <Disk>[]) {
     for (final partition in disk.partitions.whereType<Partition>()) {
       // TODO: find the correct "free space" slot when there are multiple disks
-      await tester.tap(find.text(tester.lang.freeDiskSpace).last);
+      await tester.tap(find.text(l10n.freeDiskSpace).last);
       await tester.pump();
 
       await tester.tap(find.byIcon(Icons.add));
@@ -316,9 +323,12 @@ Future<void> testGuidedReformatPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(GuidedReformatPage);
+
+  final context = tester.element(find.byType(GuidedReformatPage));
+  final l10n = AppLocalizations.of(context);
+
   expect(
-    find.title(
-        (AppLocalizations l10n) => l10n.selectGuidedStoragePageTitle('Ubuntu')),
+    find.title(l10n.selectGuidedStoragePageTitle('Ubuntu')),
     findsOneWidget,
   );
 
@@ -335,10 +345,13 @@ Future<void> testGuidedResizePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(GuidedResizePage);
+
+  final context = tester.element(find.byType(GuidedResizePage));
+  final l10n = AppLocalizations.of(context);
+
   final productInfo = getService<ProductService>().getProductInfo();
   expect(
-    find.title((AppLocalizations l10n) =>
-        l10n.installationTypeAlongsideUnknown(productInfo)),
+    find.title(l10n.installationTypeAlongsideUnknown(productInfo)),
     findsOneWidget,
   );
 
@@ -372,16 +385,17 @@ Future<void> testConfirmPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(ConfirmPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.confirmPageTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(ConfirmPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.confirmPageTitle), findsOneWidget);
 
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapButton(tester.lang.confirmInstallButton);
+  await tester.tapButton(l10n.confirmInstallButton);
 }
 
 Future<void> testBitLockerPage(
@@ -389,16 +403,17 @@ Future<void> testBitLockerPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(BitLockerPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.bitlockerTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(BitLockerPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.bitlockerTitle), findsOneWidget);
 
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapButton(tester.lang.restartIntoWindows);
+  await tester.tapButton(l10n.restartIntoWindows);
   await tester.pumpAndSettle();
   expect(find.byType(AlertDialog), findsOneWidget);
 
@@ -407,7 +422,7 @@ Future<void> testBitLockerPage(
   }
 
   final windowClosed = YaruTestWindow.waitForClosed();
-  await tester.tapButton(tester.lang.restartButtonText);
+  await tester.tapButton(l10n.restartButtonText);
   await expectLater(windowClosed, completes);
 }
 
@@ -416,13 +431,17 @@ Future<void> testRstPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(RstPage);
-  expect(find.title((AppLocalizations l10n) => l10n.rstTitle), findsOneWidget);
+
+  final context = tester.element(find.byType(RstPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.rstTitle), findsOneWidget);
 
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.tapButton(tester.lang.restartIntoWindows);
+  await tester.tapButton(l10n.restartIntoWindows);
   await tester.pumpAndSettle();
   expect(find.byType(AlertDialog), findsOneWidget);
 
@@ -431,7 +450,7 @@ Future<void> testRstPage(
   }
 
   final windowClosed = YaruTestWindow.waitForClosed();
-  await tester.tapButton(tester.lang.restartButtonText);
+  await tester.tapButton(l10n.restartButtonText);
   await expectLater(windowClosed, completes);
 }
 
@@ -445,8 +464,8 @@ Future<void> testTimezonePage(
 
   final context = tester.element(find.byType(TimezonePage));
   final l10n = TimezoneLocalizations.of(context);
-  expect(find.widgetWithText(YaruWindowTitleBar, l10n.timezonePageTitle),
-      findsOneWidget);
+
+  expect(find.title(l10n.timezonePageTitle), findsOneWidget);
 
   if (location != null) {
     await tester.enterText(
@@ -484,36 +503,37 @@ Future<void> testIdentityPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(IdentityPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.identityPageTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(IdentityPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.identityPageTitle), findsOneWidget);
 
   if (identity?.realname != null) {
     await tester.enterText(
-      find.textField(tester.lang.identityRealNameLabel),
+      find.textField(l10n.identityRealNameLabel),
       identity!.realname,
     );
   }
   if (identity?.hostname != null) {
     await tester.enterText(
-      find.textField(tester.lang.identityHostnameLabel),
+      find.textField(l10n.identityHostnameLabel),
       identity!.hostname,
     );
   }
   if (identity?.username != null) {
     await tester.enterText(
-      find.textField(tester.lang.identityUsernameLabel),
+      find.textField(l10n.identityUsernameLabel),
       identity!.username,
     );
   }
   if (password != null) {
     await tester.enterText(
-      find.textField(tester.lang.identityPasswordLabel),
+      find.textField(l10n.identityPasswordLabel),
       password,
     );
     await tester.enterText(
-      find.textField(tester.lang.identityConfirmPasswordLabel),
+      find.textField(l10n.identityConfirmPasswordLabel),
       password,
     );
   }
@@ -534,26 +554,27 @@ Future<void> testActiveDirectoryPage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(ActiveDirectoryPage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.activeDirectoryTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(ActiveDirectoryPage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.activeDirectoryTitle), findsOneWidget);
 
   if (domainName != null) {
     await tester.enterText(
-      find.textField(tester.lang.activeDirectoryDomainLabel),
+      find.textField(l10n.activeDirectoryDomainLabel),
       domainName,
     );
   }
   if (adminName != null) {
     await tester.enterText(
-      find.textField(tester.lang.activeDirectoryAdminLabel),
+      find.textField(l10n.activeDirectoryAdminLabel),
       adminName,
     );
   }
   if (password != null) {
     await tester.enterText(
-      find.textField(tester.lang.activeDirectoryPasswordLabel),
+      find.textField(l10n.activeDirectoryPasswordLabel),
       password,
     );
   }
@@ -572,10 +593,11 @@ Future<void> testThemePage(
   String? screenshot,
 }) async {
   await tester.pumpUntilPage(ThemePage);
-  expect(
-    find.title((AppLocalizations l10n) => l10n.themePageTitle),
-    findsOneWidget,
-  );
+
+  final context = tester.element(find.byType(ThemePage));
+  final l10n = AppLocalizations.of(context);
+
+  expect(find.title(l10n.themePageTitle), findsOneWidget);
 
   if (theme != null) {
     final asset = find.asset('assets/theme/${theme.name}-theme.png');
@@ -597,14 +619,17 @@ Future<void> testInstallPage(
 }) async {
   await tester.pumpUntilPage(InstallPage);
 
+  final context = tester.element(find.byType(InstallPage));
+  final l10n = AppLocalizations.of(context);
+
   if (screenshot != null) {
     await takeScreenshot(tester, screenshot);
   }
 
-  await tester.pumpUntil(find.button(tester.lang.continueTesting));
+  await tester.pumpUntil(find.button(l10n.continueTesting));
 
   final windowClosed = YaruTestWindow.waitForClosed();
-  await tester.tapButton(tester.lang.continueTesting);
+  await tester.tapButton(l10n.continueTesting);
   await expectLater(windowClosed, completes);
 }
 
@@ -616,9 +641,9 @@ extension on WidgetTester {
 }
 
 extension on CommonFinders {
-  Finder title<T>(LocalizationFunction<T> tr) {
+  Finder title(String title) {
     return find.ancestor(
-      of: find.l10n<T>(tr),
+      of: find.text(title),
       matching: find.byType(YaruWindowTitleBar),
     );
   }

--- a/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/active_directory/active_directory_page_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/pages.dart';
 import 'package:ubuntu_desktop_installer/pages/active_directory/active_directory_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/active_directory/active_directory_l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -41,7 +43,9 @@ void main() {
 
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
-    final error = validation.localize(tester.lang);
+    final context = tester.element(find.byType(ActiveDirectoryPage));
+    final lang = AppLocalizations.of(context);
+    final error = validation.localize(lang);
     if (error.isNotEmpty) {
       expect(find.text(error), findsNothing);
     }
@@ -65,9 +69,11 @@ void main() {
 
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
-    final error = validation.localize(tester.lang);
+    final context = tester.element(find.byType(ActiveDirectoryPage));
+    final lang = AppLocalizations.of(context);
+    final error = validation.localize(lang);
     if (error.isNotEmpty) {
-      expect(find.text(validation.localize(tester.lang)), findsNothing);
+      expect(find.text(validation.localize(lang)), findsNothing);
     }
 
     final textField = find.textField('admin');
@@ -88,7 +94,9 @@ void main() {
 
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
-    final error = validation.localize(tester.lang);
+    final context = tester.element(find.byType(ActiveDirectoryPage));
+    final lang = AppLocalizations.of(context);
+    final error = validation.localize(lang);
     if (error.isNotEmpty) {
       expect(find.text(error), findsNothing);
     }
@@ -107,7 +115,7 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
@@ -115,7 +123,7 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildActiveDirectoryPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 
   testWidgets('save AD connection info', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/confirm/confirm_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/pages/confirm/confirm_page.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -100,26 +102,29 @@ void main() {
     });
     await tester.pumpWidget(tester.buildApp((_) => buildConfirmPage(model)));
 
+    final context = tester.element(find.byType(ConfirmPage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-        find.html(
-            tester.lang.confirmPartitionFormatMount('sdb3', 'ext3', '/mnt/3')),
-        findsOneWidget);
-    expect(find.html(tester.lang.confirmPartitionFormat('sdb4', 'ext4')),
-        findsOneWidget);
-    expect(find.html(tester.lang.confirmPartitionMount('sdb5', '/mnt/5')),
+        find.html(l10n.confirmPartitionFormatMount('sdb3', 'ext3', '/mnt/3')),
         findsOneWidget);
     expect(
-        find.html(tester.lang.confirmPartitionResize('sdb6', '123 B', '66 B')),
+        find.html(l10n.confirmPartitionFormat('sdb4', 'ext4')), findsOneWidget);
+    expect(find.html(l10n.confirmPartitionMount('sdb5', '/mnt/5')),
         findsOneWidget);
-    expect(
-        find.html(tester.lang.confirmPartitionCreate('sdb7')), findsOneWidget);
+    expect(find.html(l10n.confirmPartitionResize('sdb6', '123 B', '66 B')),
+        findsOneWidget);
+    expect(find.html(l10n.confirmPartitionCreate('sdb7')), findsOneWidget);
   });
 
   testWidgets('starts installation', (tester) async {
     final model = buildConfirmModel();
     await tester.pumpWidget(tester.buildApp((_) => buildConfirmPage(model)));
 
-    final installButton = find.button(tester.lang.confirmInstallButton);
+    final context = tester.element(find.byType(ConfirmPage));
+    final l10n = AppLocalizations.of(context);
+
+    final installButton = find.button(l10n.confirmInstallButton);
     expect(installButton, findsOneWidget);
 
     await tester.tap(installButton);

--- a/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/identity/identity_page_test.dart
@@ -93,12 +93,12 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
     final context = tester.element(find.byType(IdentityPage));
-    final lang = UbuntuLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.weakPassword), findsNothing);
-    expect(find.text(lang.fairPassword), findsNothing);
-    expect(find.text(lang.goodPassword), findsNothing);
-    expect(find.text(lang.strongPassword), findsNothing);
+    expect(find.text(l10n.weakPassword), findsNothing);
+    expect(find.text(l10n.fairPassword), findsNothing);
+    expect(find.text(l10n.goodPassword), findsNothing);
+    expect(find.text(l10n.strongPassword), findsNothing);
   });
 
   testWidgets('weak password', (tester) async {
@@ -109,9 +109,9 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
     final context = tester.element(find.byType(IdentityPage));
-    final lang = UbuntuLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.weakPassword), findsOneWidget);
+    expect(find.text(l10n.weakPassword), findsOneWidget);
   });
 
   testWidgets('fair password', (tester) async {
@@ -122,9 +122,9 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
     final context = tester.element(find.byType(IdentityPage));
-    final lang = UbuntuLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.fairPassword), findsOneWidget);
+    expect(find.text(l10n.fairPassword), findsOneWidget);
   });
 
   testWidgets('good password', (tester) async {
@@ -135,9 +135,9 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
     final context = tester.element(find.byType(IdentityPage));
-    final lang = UbuntuLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.goodPassword), findsOneWidget);
+    expect(find.text(l10n.goodPassword), findsOneWidget);
   });
 
   testWidgets('strong password', (tester) async {
@@ -148,31 +148,34 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
     final context = tester.element(find.byType(IdentityPage));
-    final lang = UbuntuLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
 
-    expect(find.text(lang.strongPassword), findsOneWidget);
+    expect(find.text(l10n.strongPassword), findsOneWidget);
   });
 
   testWidgets('valid input', (tester) async {
     final model = buildIdentityModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildIdentityModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 
   testWidgets('auto-login', (tester) async {
     final model = buildIdentityModel(autoLogin: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
     final requiredPasswordSwitch = find.switchButton(
-      tester.lang.identityRequirePassword,
+      l10n.identityRequirePassword,
     );
     expect(requiredPasswordSwitch, findsOneWidget);
     expect(requiredPasswordSwitch, isNotChecked);
@@ -185,7 +188,10 @@ void main() {
     final model = buildIdentityModel(showPassword: false);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final showPasswordButton = find.button(tester.lang.identityPasswordShow);
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
+    final showPasswordButton = find.button(l10n.identityPasswordShow);
     expect(showPasswordButton, findsOneWidget);
 
     await tester.tap(showPasswordButton);
@@ -196,7 +202,10 @@ void main() {
     final model = buildIdentityModel(showPassword: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final hidePasswordButton = find.button(tester.lang.identityPasswordHide);
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
+    final hidePasswordButton = find.button(l10n.identityPasswordHide);
     expect(hidePasswordButton, findsOneWidget);
 
     await tester.tap(hidePasswordButton);
@@ -216,7 +225,10 @@ void main() {
         buildIdentityModel(isConnected: true, hasActiveDirectorySupport: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
+    final checkbox = find.checkButton(l10n.activeDirectoryOption);
     expect(checkbox, findsOneWidget);
     expect(checkbox, isNotChecked);
     expect(checkbox, isEnabled);
@@ -230,7 +242,10 @@ void main() {
         buildIdentityModel(isConnected: true, hasActiveDirectorySupport: false);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
+    final checkbox = find.checkButton(l10n.activeDirectoryOption);
     expect(checkbox, findsNothing);
   });
 
@@ -239,7 +254,10 @@ void main() {
         buildIdentityModel(isConnected: false, hasActiveDirectorySupport: true);
     await tester.pumpWidget(tester.buildApp((_) => buildIdentityPage(model)));
 
-    final checkbox = find.checkButton(tester.lang.activeDirectoryOption);
+    final context = tester.element(find.byType(IdentityPage));
+    final l10n = AppLocalizations.of(context);
+
+    final checkbox = find.checkButton(l10n.activeDirectoryOption);
     expect(checkbox, findsOneWidget);
     expect(checkbox, isNotChecked);
     expect(checkbox, isDisabled);

--- a/packages/ubuntu_desktop_installer/test/install/install_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install/install_page_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/install/install_model.dart';
+import 'package:ubuntu_desktop_installer/pages/install/install_page.dart';
 import 'package:ubuntu_desktop_installer/pages/install/slide_view.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_test/yaru_test.dart';
@@ -95,10 +97,13 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
     await tester.pumpAndSettle();
 
-    expect(find.text(tester.lang.copyingFiles), findsOneWidget);
-    expect(find.text(tester.lang.installingSystem), findsNothing);
-    expect(find.text(tester.lang.configuringSystem), findsNothing);
-    expect(find.text(tester.lang.installationFailed), findsNothing);
+    final context = tester.element(find.byType(InstallPage));
+    final l10n = AppLocalizations.of(context);
+
+    expect(find.text(l10n.copyingFiles), findsOneWidget);
+    expect(find.text(l10n.installingSystem), findsNothing);
+    expect(find.text(l10n.configuringSystem), findsNothing);
+    expect(find.text(l10n.installationFailed), findsNothing);
 
     when(model.event)
         .thenReturn(InstallationEvent.fromString('installing system'));
@@ -108,10 +113,10 @@ void main() {
     ));
     await tester.pump();
 
-    expect(find.text(tester.lang.installingSystem), findsOneWidget);
-    expect(find.text(tester.lang.copyingFiles), findsNothing);
-    expect(find.text(tester.lang.configuringSystem), findsNothing);
-    expect(find.text(tester.lang.installationFailed), findsNothing);
+    expect(find.text(l10n.installingSystem), findsOneWidget);
+    expect(find.text(l10n.copyingFiles), findsNothing);
+    expect(find.text(l10n.configuringSystem), findsNothing);
+    expect(find.text(l10n.installationFailed), findsNothing);
 
     when(model.event)
         .thenReturn(InstallationEvent.fromString('final system configuration'));
@@ -121,10 +126,10 @@ void main() {
     ));
     await tester.pump();
 
-    expect(find.text(tester.lang.configuringSystem), findsOneWidget);
-    expect(find.text(tester.lang.copyingFiles), findsNothing);
-    expect(find.text(tester.lang.installingSystem), findsNothing);
-    expect(find.text(tester.lang.installationFailed), findsNothing);
+    expect(find.text(l10n.configuringSystem), findsOneWidget);
+    expect(find.text(l10n.copyingFiles), findsNothing);
+    expect(find.text(l10n.installingSystem), findsNothing);
+    expect(find.text(l10n.installationFailed), findsNothing);
 
     when(model.hasError).thenReturn(true);
     await tester.pumpWidget(Container(
@@ -133,17 +138,20 @@ void main() {
     ));
     await tester.pump();
 
-    expect(find.text(tester.lang.installationFailed), findsOneWidget);
-    expect(find.text(tester.lang.copyingFiles), findsNothing);
-    expect(find.text(tester.lang.installingSystem), findsNothing);
-    expect(find.text(tester.lang.configuringSystem), findsNothing);
+    expect(find.text(l10n.installationFailed), findsOneWidget);
+    expect(find.text(l10n.copyingFiles), findsNothing);
+    expect(find.text(l10n.installingSystem), findsNothing);
+    expect(find.text(l10n.configuringSystem), findsNothing);
   });
 
   testWidgets('restart', (tester) async {
     final model = buildInstallModel(isDone: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final restartButton = find.textContaining(tester.lang.restartButtonText);
+    final context = tester.element(find.byType(InstallPage));
+    final l10n = AppLocalizations.of(context);
+
+    final restartButton = find.textContaining(l10n.restartButtonText);
     expect(restartButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -159,7 +167,10 @@ void main() {
     final model = buildInstallModel(isDone: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final continueButton = find.button(tester.lang.continueTesting);
+    final context = tester.element(find.byType(InstallPage));
+    final l10n = AppLocalizations.of(context);
+
+    final continueButton = find.button(l10n.continueTesting);
     expect(continueButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();

--- a/packages/ubuntu_desktop_installer/test/install/slides_test.dart
+++ b/packages/ubuntu_desktop_installer/test/install/slides_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_desktop_installer/slides/default_slides.dart';
 import 'package:ubuntu_desktop_installer/slides/slide_widgets.dart';
@@ -11,8 +12,6 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import '../test_utils.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = Scaffold);
-
   testWidgets('inherited slides', (tester) async {
     slide1(_) => const Text('slide1');
     slide2(_) => const Text('slide2');
@@ -62,14 +61,17 @@ void main() {
       verify(urlLauncher.launchUrl(url)).called(1);
     }
 
+    final context = tester.element(find.byType(Scaffold));
+    final l10n = AppLocalizations.of(context);
+
     expectLaunchUrl(
-      tester.lang.installationSlidesSupportDocumentation,
+      l10n.installationSlidesSupportDocumentation,
       'https://help.ubuntu.com',
     );
     expectLaunchUrl('Ask Ubuntu', 'https://askubuntu.com');
     expectLaunchUrl('Ubuntu Discourse', 'https://discourse.ubuntu.com');
     expectLaunchUrl(
-      tester.lang.installationSlidesSupportUbuntuPro,
+      l10n.installationSlidesSupportUbuntuPro,
       'https://ubuntu.com/pro',
     );
   });

--- a/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
+++ b/packages/ubuntu_desktop_installer/test/installer_wizard_test.dart
@@ -155,6 +155,9 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(Wizard));
+    final l10n = AppLocalizations.of(context);
+
     await tester.pumpAndSettle();
     expect(find.byType(LocalePage), findsOneWidget);
     // localeModel is not a mock
@@ -193,7 +196,7 @@ void main() {
     verify(securityKeyModel.init()).called(1); // skipped
     verify(confirmModel.init()).called(1);
 
-    await tester.tapButton(tester.lang.confirmInstallButton);
+    await tester.tapButton(l10n.confirmInstallButton);
     await tester.pumpAndSettle();
     expect(find.byType(TimezonePage), findsOneWidget);
     verify(timezoneModel.init()).called(1);
@@ -353,6 +356,10 @@ void main() {
         ]),
       ),
     );
+
+    final context = tester.element(find.byType(Wizard));
+    final l10n = AppLocalizations.of(context);
+
     await tester.pumpAndSettle();
     expect(find.byType(KeyboardPage), findsOneWidget);
     verify(keyboardModel.init()).called(1);
@@ -362,7 +369,7 @@ void main() {
     expect(find.byType(ConfirmPage), findsOneWidget);
     verify(confirmModel.init()).called(1);
 
-    await tester.tapButton(tester.lang.confirmInstallButton);
+    await tester.tapButton(l10n.confirmInstallButton);
     await tester.pumpAndSettle();
     expect(find.byType(IdentityPage), findsOneWidget);
     verify(identityModel.init()).called(1);

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_dialogs_test.dart
@@ -9,8 +9,6 @@ import 'package:ubuntu_test/ubuntu_test.dart';
 import 'test_keyboard.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = DetectKeyboardView);
-
   testWidgets('detect layout', (tester) async {
     final service = MockKeyboardService();
     when(service.getKeyboardStep('0')).thenAnswer((_) async {

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_page_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_page.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_widgets.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
@@ -46,7 +48,10 @@ void main() {
     final model = buildKeyboardModel();
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final textField = find.textField(tester.lang.keyboardTestHint);
+    final context = tester.element(find.byType(KeyboardPage));
+    final l10n = AppLocalizations.of(context);
+
+    final textField = find.textField(l10n.keyboardTestHint);
     expect(textField, findsOneWidget);
     await tester.enterText(textField, 'foo bar');
     await tester.pump();
@@ -57,7 +62,10 @@ void main() {
     final model = buildKeyboardModel();
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final detectButton = find.button(tester.lang.keyboardDetectButton);
+    final context = tester.element(find.byType(KeyboardPage));
+    final l10n = AppLocalizations.of(context);
+
+    final detectButton = find.button(l10n.keyboardDetectButton);
     expect(detectButton, findsOneWidget);
     await tester.tap(detectButton);
     await tester.pumpAndSettle();
@@ -65,8 +73,7 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
     expect(find.byType(DetectKeyboardView), findsOneWidget);
 
-    final context = tester.element(find.byType(DetectKeyboardView));
-    Navigator.of(context)
+    Navigator.of(tester.element(find.byType(DetectKeyboardView)))
         .pop(const AnyStep.stepResult(layout: 'layout', variant: 'variant'));
     await tester.pumpAndSettle();
     verify(model.trySelectLayoutVariant('layout', 'variant'));
@@ -76,7 +83,10 @@ void main() {
     final model = buildKeyboardModel(canDetectLayout: false);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    final detectButton = find.button(tester.lang.keyboardDetectButton);
+    final context = tester.element(find.byType(KeyboardPage));
+    final l10n = AppLocalizations.of(context);
+
+    final detectButton = find.button(l10n.keyboardDetectButton);
     expect(detectButton, findsNothing);
   });
 
@@ -84,14 +94,14 @@ void main() {
     final model = buildKeyboardModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildKeyboardModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildKeyboardPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 
   testWidgets('key search', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/keyboard/keyboard_widgets_test.dart
+++ b/packages/ubuntu_desktop_installer/test/keyboard/keyboard_widgets_test.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/keyboard/keyboard_widgets.dart';
 
 import '../test_utils.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = DetectKeyboardView);
-
   testWidgets('press key', (tester) async {
     int? keyPress;
 
@@ -19,11 +18,14 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(DetectKeyboardView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(PressKeyView), findsOneWidget);
     expect(find.text('x'), findsOneWidget);
     expect(find.text('y'), findsOneWidget);
     expect(find.text('z'), findsOneWidget);
-    expect(find.text(tester.lang.keyboardPressKeyLabel), findsOneWidget);
+    expect(find.text(l10n.keyboardPressKeyLabel), findsOneWidget);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'linux');
     expect(keyPress, equals(25 - 8));
@@ -37,8 +39,11 @@ void main() {
       tester.buildApp((_) => const DetectKeyboardView(keyPresent: 'x')),
     );
 
+    final context = tester.element(find.byType(DetectKeyboardView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(KeyPresentView), findsOneWidget);
     expect(find.text('x'), findsOneWidget);
-    expect(find.text(tester.lang.keyboardKeyPresentLabel), findsOneWidget);
+    expect(find.text(l10n.keyboardKeyPresentLabel), findsOneWidget);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/network/connect_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/connect_view_test.dart
@@ -10,8 +10,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'test_network.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = NoConnectView);
-
   testWidgets('disabled when no ethernet nor wifi', (tester) async {
     final ethernet = buildEthernetModel(isEnabled: false);
     final wifi = buildWifiModel(isEnabled: true);

--- a/packages/ubuntu_desktop_installer/test/network/ethernet_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/ethernet_view_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/ethernet_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/ethernet_view.dart';
@@ -10,8 +11,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'test_network.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = Column);
-
   testWidgets('select ethernet mode', (tester) async {
     ConnectMode? mode;
 
@@ -67,12 +66,15 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(EthernetView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
 
-    expect(find.text(tester.lang.wiredDisabled), findsOneWidget);
-    expect(find.text(tester.lang.wiredMustBeEnabled), findsOneWidget);
+    expect(find.text(l10n.wiredDisabled), findsOneWidget);
+    expect(find.text(l10n.wiredMustBeEnabled), findsOneWidget);
 
-    final button = find.button(tester.lang.enableWired);
+    final button = find.button(l10n.enableWired);
     expect(button, findsOneWidget);
     await tester.tap(button);
     expect(wasEnabled, isTrue);
@@ -103,8 +105,11 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(EthernetView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(OutlinedButton), findsNothing);
     expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
-    expect(find.text(tester.lang.noWiredConnection), findsOneWidget);
+    expect(find.text(l10n.noWiredConnection), findsOneWidget);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/network_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:ubuntu_desktop_installer/pages/network/connect_model.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/network/ethernet_view.dart';
 import 'package:ubuntu_desktop_installer/pages/network/hidden_wifi_view.dart';
 import 'package:ubuntu_desktop_installer/pages/network/network_model.dart';
@@ -49,7 +49,10 @@ void main() {
         .buildApp((_) => buildNetworkPage(model: model, ethernet: false)));
     await tester.pumpAndSettle();
 
-    final button = find.button(tester.lang.enableWired);
+    final context = tester.element(find.byType(NetworkPage));
+    final l10n = AppLocalizations.of(context);
+
+    final button = find.button(l10n.enableWired);
     expect(button, findsOneWidget);
     await tester.tap(button);
     expect(model.connectMode, ConnectMode.ethernet);
@@ -61,7 +64,10 @@ void main() {
         tester.buildApp((_) => buildNetworkPage(model: model, wifi: false)));
     await tester.pumpAndSettle();
 
-    final button = find.button(tester.lang.enableWifi);
+    final context = tester.element(find.byType(NetworkPage));
+    final l10n = AppLocalizations.of(context);
+
+    final button = find.button(l10n.enableWifi);
     expect(button, findsOneWidget);
     await tester.tap(button);
     expect(model.connectMode, ConnectMode.wifi);

--- a/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/network/wifi_view_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/network/network_page.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_model.dart';
 import 'package:ubuntu_desktop_installer/pages/network/wifi_view.dart';
@@ -11,8 +12,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'test_network.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = WifiView);
-
   testWidgets('device and access point tiles', (tester) async {
     final device1 = MockWifiDevice();
     when(device1.model).thenReturn('model1');
@@ -141,13 +140,16 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(WifiView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(WifiListView), findsNothing);
     expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
 
-    expect(find.text(tester.lang.wirelessNetworkingDisabled), findsOneWidget);
-    expect(find.text(tester.lang.wifiMustBeEnabled), findsOneWidget);
+    expect(find.text(l10n.wirelessNetworkingDisabled), findsOneWidget);
+    expect(find.text(l10n.wifiMustBeEnabled), findsOneWidget);
 
-    final button = find.button(tester.lang.enableWifi);
+    final button = find.button(l10n.enableWifi);
     expect(button, findsOneWidget);
     await tester.tap(button);
     expect(wasEnabled, isTrue);
@@ -179,9 +181,12 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(WifiView));
+    final l10n = AppLocalizations.of(context);
+
     expect(find.byType(WifiListView), findsNothing);
     expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
-    expect(find.text(tester.lang.noWifiDevicesDetected), findsOneWidget);
+    expect(find.text(l10n.noWifiDevicesDetected), findsOneWidget);
   });
 
   testWidgets('starts periodic scanning', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/rst/rst_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/rst/rst_page_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
+import 'package:ubuntu_desktop_installer/pages/rst/rst_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
@@ -15,7 +17,10 @@ void main() {
     final model = buildRstModel();
     await tester.pumpWidget(tester.buildApp((_) => buildRstPage(model)));
 
-    final restartButton = find.button(tester.lang.restartIntoWindows);
+    final context = tester.element(find.byType(RstPage));
+    final l10n = AppLocalizations.of(context);
+
+    final restartButton = find.button(l10n.restartIntoWindows);
     expect(restartButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -28,7 +33,7 @@ void main() {
 
     final dialogButton = find.descendant(
         of: find.byType(AlertDialog),
-        matching: find.text(tester.lang.restartButtonText));
+        matching: find.text(l10n.restartButtonText));
 
     await tester.tap(dialogButton);
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/secure_boot/secure_boot_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_desktop_installer/pages/secure_boot/secure_boot_model.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -63,13 +64,13 @@ void main() {
     final model = buildSecureBootModel(isFormValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildSecureBootPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildSecureBootModel(isFormValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildSecureBootPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/source/not_enough_disk_space/not_enough_disk_space_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/not_enough_disk_space/not_enough_disk_space_page_test.dart
@@ -26,8 +26,9 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(NotEnoughDiskSpacePage));
-    expect(find.text(tester.lang.notEnoughDiskSpaceUbuntu('Ubuntu')),
-        findsOneWidget);
+    final l10n = AppLocalizations.of(context);
+
+    expect(find.text(l10n.notEnoughDiskSpaceUbuntu('Ubuntu')), findsOneWidget);
     expect(find.text(context.formatByteSize(123456)), findsOneWidget);
     expect(find.text(context.formatByteSize(654321)), findsOneWidget);
   });
@@ -36,7 +37,10 @@ void main() {
     final model = buildNotEnoughDiskSpaceModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final button = find.button(tester.lang.quitButtonText);
+    final context = tester.element(find.byType(NotEnoughDiskSpacePage));
+    final l10n = AppLocalizations.of(context);
+
+    final button = find.button(l10n.quitButtonText);
     expect(button, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();

--- a/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/source/source_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:ubuntu_desktop_installer/pages/source/source_model.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/source/source_page.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru/yaru.dart';
@@ -30,7 +30,10 @@ void main() {
     final model = buildSourceModel(installDrivers: true);
     await tester.pumpWidget(tester.buildApp((_) => buildSourcePage(model)));
 
-    final checkbox = find.checkButton(tester.lang.installDriversTitle);
+    final context = tester.element(find.byType(SourcePage));
+    final l10n = AppLocalizations.of(context);
+
+    final checkbox = find.checkButton(l10n.installDriversTitle);
     expect(checkbox, findsOneWidget);
     expect(checkbox, isChecked);
 
@@ -45,7 +48,10 @@ void main() {
     final model = buildSourceModel(installCodecs: true);
     await tester.pumpWidget(tester.buildApp((_) => buildSourcePage(model)));
 
-    final checkbox = find.checkButton(tester.lang.installCodecsTitle);
+    final context = tester.element(find.byType(SourcePage));
+    final l10n = AppLocalizations.of(context);
+
+    final checkbox = find.checkButton(l10n.installCodecsTitle);
     expect(checkbox, findsOneWidget);
     expect(checkbox, isChecked);
 
@@ -61,12 +67,15 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildSourcePage(model)));
     await tester.pumpAndSettle();
 
+    final context = tester.element(find.byType(SourcePage));
+    final l10n = AppLocalizations.of(context);
+
     final warning = find.byType(Html);
     final theme = Theme.of(tester.element(find.byType(Scaffold)));
     expect(warning, findsOneWidget);
     expect(
       tester.widget<Html>(warning).data,
-      equals(tester.lang.onBatteryWarning(theme.colorScheme.error.toHex())),
+      equals(l10n.onBatteryWarning(theme.colorScheme.error.toHex())),
     );
   });
 
@@ -81,9 +90,12 @@ void main() {
     final model = buildSourceModel(isOnline: false);
     await tester.pumpWidget(tester.buildApp((_) => buildSourcePage(model)));
 
-    expect(find.text(tester.lang.offlineWarning), findsNothing);
+    final context = tester.element(find.byType(SourcePage));
+    final l10n = AppLocalizations.of(context);
 
-    final checkbox = find.checkButton(tester.lang.installCodecsTitle);
+    expect(find.text(l10n.offlineWarning), findsNothing);
+
+    final checkbox = find.checkButton(l10n.installCodecsTitle);
     expect(checkbox, findsOneWidget);
     expect(checkbox, isDisabled);
 
@@ -94,7 +106,7 @@ void main() {
     await tester.pump();
 
     await tester.pumpAndSettle(const Duration(milliseconds: 500));
-    expect(find.text(tester.lang.offlineWarning), findsOneWidget);
+    expect(find.text(l10n.offlineWarning), findsOneWidget);
   });
 
   testWidgets('continue on the next page', (tester) async {

--- a/packages/ubuntu_desktop_installer/test/storage/bitlocker/bitlocker_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/bitlocker/bitlocker_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/bitlocker/bitlocker_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/bitlocker/bitlocker_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -24,7 +25,10 @@ void main() {
       ),
     );
 
-    final restartButton = find.button(tester.lang.restartIntoWindows);
+    final context = tester.element(find.byType(BitLockerPage));
+    final l10n = AppLocalizations.of(context);
+
+    final restartButton = find.button(l10n.restartIntoWindows);
     expect(restartButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -35,7 +39,7 @@ void main() {
 
     final dialogButton = find.descendant(
         of: find.byType(AlertDialog),
-        matching: find.text(tester.lang.restartButtonText));
+        matching: find.text(l10n.restartButtonText));
 
     await tester.tap(dialogButton);
     await tester.pumpAndSettle();

--- a/packages/ubuntu_desktop_installer/test/storage/guided_resize/guided_resize_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/guided_resize/guided_resize_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:split_view/split_view.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/guided_resize/guided_resize_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/guided_resize/guided_resize_page.dart';
 import 'package:ubuntu_desktop_installer/services/product_service.dart';
@@ -38,7 +39,7 @@ void main() {
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     expect(
-      find.text('sda1 - Ubuntu 22.04 LTS - 123 ${tester.ulang.byte}'),
+      find.text('sda1 - Ubuntu 22.04 LTS - 123 B'),
       findsOneWidget,
     );
   });
@@ -97,8 +98,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(GuidedResizePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.html(tester.lang.installAlongsideHiddenPartitions(4, '')),
+      find.html(l10n.installAlongsideHiddenPartitions(4, '')),
       findsOneWidget,
     );
   });
@@ -110,8 +114,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(GuidedResizePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeAlongsideUnknown('Ubuntu 22.10')),
+      find.text(l10n.installationTypeAlongsideUnknown('Ubuntu 22.10')),
       findsOneWidget,
     );
   });
@@ -123,9 +130,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(GuidedResizePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(
-          tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 10')),
+      find.text(l10n.installationTypeAlongside('Ubuntu 22.10', 'Windows 10')),
       findsOneWidget,
     );
   });
@@ -137,8 +146,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(GuidedResizePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeAlongsideDual(
+      find.text(l10n.installationTypeAlongsideDual(
           'Ubuntu 22.10', 'Ubuntu 21.10', 'Ubuntu 22.04 LTS')),
       findsOneWidget,
     );
@@ -151,8 +163,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(GuidedResizePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10')),
+      find.text(l10n.installationTypeAlongsideMulti('Ubuntu 22.10')),
       findsOneWidget,
     );
   });

--- a/packages/ubuntu_desktop_installer/test/storage/guided_resize/storage_size_dialog_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/guided_resize/storage_size_dialog_test.dart
@@ -11,8 +11,6 @@ import 'package:yaru_test/yaru_test.dart';
 import '../../test_utils.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = AlertDialog);
-
   testWidgets('resize storage', (tester) async {
     await tester.pumpWidget(tester.buildApp((_) => const Scaffold()));
 
@@ -29,7 +27,7 @@ void main() {
 
     expect(find.text('Test title'), findsOneWidget);
     expect(find.text('/dev/sda1 (Test storage)'), findsOneWidget);
-    expect(find.text('50-200 ${tester.ulang.megabyte}'), findsOneWidget);
+    expect(find.text('50-200 MB'), findsOneWidget);
 
     expect(find.byType(StorageSizeBox), findsOneWidget);
     expect(find.byType(EditableText), findsOneWidget);

--- a/packages/ubuntu_desktop_installer/test/storage/guided_resize/storage_split_view_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/guided_resize/storage_split_view_test.dart
@@ -13,8 +13,6 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import '../../test_utils.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = AlertDialog);
-
   testWidgets('resize by drag', (tester) async {
     int? size;
 

--- a/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_dialogs_test.dart
@@ -18,8 +18,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import 'test_manual_storage.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = AlertDialog);
-
   testWidgets('create partition', (tester) async {
     final disk = fakeDisk();
     const gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
@@ -89,7 +87,7 @@ void main() {
     await tester.enterText(find.byType(YaruAutocomplete<String>), '/tst foo');
     await tester.pump();
 
-    expect(find.button(tester.ulang.okLabel), isDisabled);
+    expect(find.button(find.okLabel), isDisabled);
   });
 
   testWidgets('edit partition', (tester) async {
@@ -196,6 +194,6 @@ void main() {
     await tester.enterText(find.byType(YaruAutocomplete<String>), 'tst');
     await tester.pump();
 
-    expect(find.button(tester.ulang.okLabel), isDisabled);
+    expect(find.button(find.okLabel), isDisabled);
   });
 }

--- a/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/manual/manual_storage_page_test.dart
@@ -4,11 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/manual/manual_storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/manual/manual_storage_page.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/manual/storage_selector.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
-import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_test/yaru_test.dart';
@@ -122,11 +122,14 @@ void main() {
         canReformatDisk: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final addButton = find.iconButton(Icons.add);
     expect(addButton, findsOneWidget);
     expect(addButton, isDisabled);
 
-    final editButton = find.button(tester.lang.changeButtonText);
+    final editButton = find.button(l10n.changeButtonText);
     expect(editButton, findsOneWidget);
     expect(editButton, isDisabled);
 
@@ -134,7 +137,7 @@ void main() {
     expect(removeButton, findsOneWidget);
     expect(removeButton, isDisabled);
 
-    final reformatButton = find.button(tester.lang.newPartitionTable);
+    final reformatButton = find.button(l10n.newPartitionTable);
     expect(reformatButton, findsOneWidget);
     expect(reformatButton, isDisabled);
   });
@@ -154,7 +157,10 @@ void main() {
         buildManualStorageModel(disks: testDisks, canEditPartition: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final editButton = find.button(tester.lang.changeButtonText);
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final editButton = find.button(l10n.changeButtonText);
     expect(editButton, findsOneWidget);
     expect(editButton, isEnabled);
   });
@@ -195,7 +201,10 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final resetButton = find.button(tester.lang.newPartitionTable);
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final resetButton = find.button(l10n.newPartitionTable);
     expect(resetButton, findsOneWidget);
     expect(resetButton, isEnabled);
 
@@ -212,7 +221,10 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final resetButton = find.button(tester.lang.newPartitionTable);
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final resetButton = find.button(l10n.newPartitionTable);
     expect(resetButton, findsOneWidget);
     expect(resetButton, isEnabled);
 
@@ -233,7 +245,10 @@ void main() {
     final model = buildManualStorageModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final revertButton = find.button(tester.lang.revertButtonText);
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final revertButton = find.button(l10n.revertButtonText);
     expect(revertButton, findsOneWidget);
     expect(revertButton, isEnabled);
 
@@ -278,7 +293,7 @@ void main() {
     final model = buildManualStorageModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 
   testWidgets('too many primary partitions', (tester) async {
@@ -290,6 +305,9 @@ void main() {
     final model = buildManualStorageModel(selectedGap: unusableGap);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(ManualStoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final addButton = find.iconButton(Icons.add);
     expect(addButton, isDisabled);
     expect(
@@ -297,7 +315,7 @@ void main() {
         of: addButton,
         matching: find.byWidgetPredicate((widget) =>
             widget is Tooltip &&
-            widget.message == tester.lang.tooManyPrimaryPartitions),
+            widget.message == l10n.tooManyPrimaryPartitions),
       ),
       findsOneWidget,
     );

--- a/packages/ubuntu_desktop_installer/test/storage/security_key/security_key_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/security_key/security_key_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/security_key/security_key_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/security_key/security_key_page.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
@@ -44,21 +45,24 @@ void main() {
     final model = buildSecurityKeyModel(isValid: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('invalid input', (tester) async {
     final model = buildSecurityKeyModel(isValid: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
   });
 
   testWidgets('show security key', (tester) async {
     final model = buildSecurityKeyModel(showSecurityKey: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final showSecurityKeyButton = find.checkButton(tester.lang.showSecurityKey);
+    final context = tester.element(find.byType(SecurityKeyPage));
+    final l10n = AppLocalizations.of(context);
+
+    final showSecurityKeyButton = find.checkButton(l10n.showSecurityKey);
     expect(showSecurityKeyButton, findsOneWidget);
 
     await tester.tap(showSecurityKeyButton);

--- a/packages/ubuntu_desktop_installer/test/storage/storage_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/storage_dialogs_test.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/storage_dialogs.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/storage_page.dart';
@@ -11,8 +11,6 @@ import 'package:yaru_test/yaru_test.dart';
 import 'test_storage.dart';
 
 void main() {
-  setUpAll(() => InstallerTester.context = AlertDialog);
-
   testWidgets('select zfs', (tester) async {
     final model = MockStorageModel();
     when(model.existingOS).thenReturn(null);
@@ -27,16 +25,18 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final result = showAdvancedFeaturesDialog(
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(
-        find.radioButton<AdvancedFeature>(tester.lang.installationTypeZFS));
+    await tester
+        .tap(find.radioButton<AdvancedFeature>(l10n.installationTypeZFS));
     await tester.pump();
 
-    await tester
-        .tap(find.checkButton(tester.lang.installationTypeEncrypt('Ubuntu')));
+    await tester.tap(find.checkButton(l10n.installationTypeEncrypt('Ubuntu')));
     await tester.pump();
 
     await tester.tapOk();
@@ -63,12 +63,15 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final result = showAdvancedFeaturesDialog(
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.radioButton<AdvancedFeature>(
-        tester.lang.installationTypeLVM('Ubuntu')));
+    await tester.tap(
+        find.radioButton<AdvancedFeature>(l10n.installationTypeLVM('Ubuntu')));
     await tester.pump();
 
     await tester.tapOk();
@@ -95,16 +98,18 @@ void main() {
       ),
     );
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final result = showAdvancedFeaturesDialog(
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.radioButton<AdvancedFeature>(
-        tester.lang.installationTypeLVM('Ubuntu')));
+    await tester.tap(
+        find.radioButton<AdvancedFeature>(l10n.installationTypeLVM('Ubuntu')));
     await tester.pump();
 
-    await tester
-        .tap(find.checkButton(tester.lang.installationTypeEncrypt('Ubuntu')));
+    await tester.tap(find.checkButton(l10n.installationTypeEncrypt('Ubuntu')));
     await tester.pump();
 
     await tester.tapOk();

--- a/packages/ubuntu_desktop_installer/test/storage/storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/storage_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_desktop_installer/l10n.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/storage_model.dart';
 import 'package:ubuntu_desktop_installer/pages/storage/storage_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
@@ -23,8 +24,11 @@ void main() {
     await tester
         .pumpWidget(tester.buildApp((_) => buildPage(buildStorageModel())));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeNoOSDetected),
+      find.text(l10n.installationTypeNoOSDetected),
       findsOneWidget,
     );
   });
@@ -35,8 +39,11 @@ void main() {
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeOSDetected('Ubuntu 18.04 LTS')),
+      find.text(l10n.installationTypeOSDetected('Ubuntu 18.04 LTS')),
       findsOneWidget,
     );
   });
@@ -48,8 +55,11 @@ void main() {
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeDualOSDetected(
+      find.text(l10n.installationTypeDualOSDetected(
           'Ubuntu 18.04 LTS', 'Ubuntu 20.04 LTS')),
       findsOneWidget,
     );
@@ -63,8 +73,11 @@ void main() {
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeMultiOSDetected),
+      find.text(l10n.installationTypeMultiOSDetected),
       findsOneWidget,
     );
   });
@@ -76,8 +89,11 @@ void main() {
     ]);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     expect(
-      find.text(tester.lang.installationTypeMultiOSDetected),
+      find.text(l10n.installationTypeMultiOSDetected),
       findsOneWidget,
     );
   });
@@ -97,8 +113,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final radio = find.radioButton<StorageType>(
-        tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 10'));
+        l10n.installationTypeAlongside('Ubuntu 22.10', 'Windows 10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.alongside).called(1);
@@ -120,8 +139,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final radio = find.radioButton<StorageType>(
-        tester.lang.installationTypeAlongside('Ubuntu 22.10', 'Windows 11'));
+        l10n.installationTypeAlongside('Ubuntu 22.10', 'Windows 11'));
     expect(radio, findsOneWidget);
 
     await tester.tap(radio);
@@ -143,8 +165,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.radioButton<StorageType>(tester.lang
-        .installationTypeAlongside('Ubuntu 22.10', 'Ubuntu 18.04 LTS'));
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio = find.radioButton<StorageType>(
+        l10n.installationTypeAlongside('Ubuntu 22.10', 'Ubuntu 18.04 LTS'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.alongside).called(1);
@@ -157,8 +182,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final radio = find.radioButton<StorageType>(
-        tester.lang.installationTypeAlongsideUnknown('Ubuntu 22.10'));
+        l10n.installationTypeAlongsideUnknown('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.alongside).called(1);
@@ -185,8 +213,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find.radioButton<StorageType>(tester.lang
-        .installationTypeAlongsideDual(
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio = find.radioButton<StorageType>(
+        l10n.installationTypeAlongsideDual(
             'Ubuntu 22.10', 'Windows 10', 'Ubuntu 20.04 LTS'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
@@ -214,8 +245,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final radio = find.radioButton<StorageType>(
-        tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10'));
+        l10n.installationTypeAlongsideMulti('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.alongside).called(1);
@@ -248,8 +282,11 @@ void main() {
     );
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
     final radio = find.radioButton<StorageType>(
-        tester.lang.installationTypeAlongsideMulti('Ubuntu 22.10'));
+        l10n.installationTypeAlongsideMulti('Ubuntu 22.10'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.alongside).called(1);
@@ -259,8 +296,11 @@ void main() {
     final model = buildStorageModel();
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio = find
-        .radioButton<StorageType>(tester.lang.installationTypeErase('Ubuntu'));
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio =
+        find.radioButton<StorageType>(l10n.installationTypeErase('Ubuntu'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.erase).called(1);
@@ -270,13 +310,15 @@ void main() {
     final model = buildStorageModel(type: StorageType.manual);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    final radio =
-        find.radioButton<StorageType>(tester.lang.installationTypeManual);
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio = find.radioButton<StorageType>(l10n.installationTypeManual);
     expect(radio, findsOneWidget);
     await tester.tap(radio);
     verify(model.type = StorageType.manual).called(1);
 
-    expect(find.button(tester.lang.installationTypeAdvancedLabel), isDisabled);
+    expect(find.button(l10n.installationTypeAdvancedLabel), isDisabled);
   });
 
   group('advanced features', () {
@@ -285,7 +327,10 @@ void main() {
       await tester.pumpWidget(
           ProviderScope(child: tester.buildApp((_) => buildPage(model))));
 
-      final button = find.button(tester.lang.installationTypeAdvancedLabel);
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = AppLocalizations.of(context);
+
+      final button = find.button(l10n.installationTypeAdvancedLabel);
       expect(button, findsOneWidget);
       await tester.tap(button);
       await tester.pumpAndSettle();
@@ -297,16 +342,20 @@ void main() {
       final model = buildStorageModel(advancedFeature: AdvancedFeature.none);
       await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-      expect(
-          find.text(tester.lang.installationTypeNoneSelected), findsOneWidget);
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = AppLocalizations.of(context);
+
+      expect(find.text(l10n.installationTypeNoneSelected), findsOneWidget);
     });
 
     testWidgets('lvm selected', (tester) async {
       final model = buildStorageModel(advancedFeature: AdvancedFeature.lvm);
       await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-      expect(
-          find.text(tester.lang.installationTypeLVMSelected), findsOneWidget);
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = AppLocalizations.of(context);
+
+      expect(find.text(l10n.installationTypeLVMSelected), findsOneWidget);
     });
 
     testWidgets('encrypted lvm selected', (tester) async {
@@ -314,7 +363,10 @@ void main() {
           advancedFeature: AdvancedFeature.lvm, encryption: true);
       await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-      expect(find.text(tester.lang.installationTypeLVMEncryptionSelected),
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = AppLocalizations.of(context);
+
+      expect(find.text(l10n.installationTypeLVMEncryptionSelected),
           findsOneWidget);
     });
   });
@@ -323,7 +375,7 @@ void main() {
     final model = buildStorageModel(hasStorage: false);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
 
     await tester.tapNext();
     verifyNever(model.save());

--- a/packages/ubuntu_desktop_installer/test/test_utils.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.dart
@@ -11,49 +11,7 @@ import 'package:yaru/yaru.dart';
 
 export 'test_utils.mocks.dart';
 
-/// An extension on [WidgetTester] for building test apps.
-///
-/// The additional [lang] property returns the [AppLocalizations] instance
-/// associated with the current [WizardPage], for easy access to the
-/// application's translated strings.
-///
-/// Use like so when writing tests:
-/// ```dart
-/// import 'widget_tester_extensions.dart';
-///
-/// void main() {
-///   Widget buildPage(WidgetTester tester) { [...] }
-///
-///   testWidgets('test description', (tester) async {
-///     await tester.pumpWidget(tester.buildApp((_) => buildPage(tester)));
-///
-///     expect(find.text(tester.lang.someTranslatableString), findsOneWidget);
-///   });
-/// }
-/// ```
-///
-/// If the tested widget is not in a [WizardPage], you can use the static
-/// [InstallerTester.context] property to specify the appropriate context to use.
-///
-/// For example:
-/// ```dart
-/// void main() {
-///   setUpAll(() => LangTester.context = MyWidget);
-/// }
-/// ```
 extension InstallerTester on WidgetTester {
-  static Type context = WizardPage;
-
-  AppLocalizations get lang {
-    final widget = element(find.byType(context).first);
-    return AppLocalizations.of(widget);
-  }
-
-  UbuntuLocalizations get ulang {
-    final widget = element(find.byType(context).first);
-    return UbuntuLocalizations.of(widget);
-  }
-
   Widget buildApp(WidgetBuilder builder) {
     view.devicePixelRatio = 1;
     view.physicalSize = const Size(960, 680);

--- a/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/welcome/welcome_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:ubuntu_desktop_installer/pages/welcome/welcome_model.dart';
 import 'package:ubuntu_desktop_installer/pages/welcome/welcome_page.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
@@ -39,7 +38,7 @@ void main() {
     final model = buildWelcomeModel(option: Option.none);
     await tester.pumpWidget(tester.buildApp((_) => buildWelcomePage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), isDisabled);
 
     await tester.tap(find.radio(Option.welcomeInstallOption));
     verify(model.selectOption(Option.welcomeInstallOption)).called(1);
@@ -52,14 +51,14 @@ void main() {
     final model = buildWelcomeModel(option: Option.welcomeInstallOption);
     await tester.pumpWidget(tester.buildApp((_) => buildWelcomePage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
   });
 
   testWidgets('try ubuntu', (tester) async {
     final model = buildWelcomeModel(option: Option.welcomeTryOption);
     await tester.pumpWidget(tester.buildApp((_) => buildWelcomePage(model)));
 
-    expect(find.button(tester.ulang.nextLabel), isEnabled);
+    expect(find.button(find.nextLabel), isEnabled);
 
     final windowClosed = YaruTestWindow.waitForClosed();
 


### PR DESCRIPTION
The approach doesn't work when there are multiple localizations (`ubuntu_desktop_installer`/`ubuntu_welcome` vs. `ubuntu_provision`) in the game. Get rid of the helper and use the usual `FooLocalizations.of()` instead. It's a bit verbose but easy to understand and straightforward to change from `AppLocalizations` to `AnyOtherLocalizations` while moving pages.