### PR TITLE
fix(loading): auto-dispose the view model

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/loading/loading_model.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/loading/loading_model.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_desktop_installer/services.dart';
 
-final loadingModelProvider = Provider(
+final loadingModelProvider = Provider.autoDispose(
   (_) => LoadingModel(getService<InstallerService>()),
 );
 


### PR DESCRIPTION
The wizard never returns to the loading view so it's not useful to keep the view model alive.