### PR TITLE
refactor(installer): demote config to post-inst service

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/installer.dart
+++ b/packages/ubuntu_desktop_installer/lib/installer.dart
@@ -69,10 +69,10 @@ Future<void> runInstallerApp(
   // conditional registration if not already registered by flavors or tests
   tryRegisterService<ActiveDirectoryService>(
       () => SubiquityActiveDirectoryService(getService<SubiquityClient>()));
-  tryRegisterService(() => ConfigService('/tmp/$baseName.conf'));
+  tryRegisterService(() => PostInstallService('/tmp/$baseName.conf'));
   tryRegisterService<DesktopService>(() => GnomeService());
   tryRegisterService<IdentityService>(() => SubiquityIdentityService(
-      getService<SubiquityClient>(), getService<ConfigService>()));
+      getService<SubiquityClient>(), getService<PostInstallService>()));
   tryRegisterService<InstallerService>(() => InstallerService(
       getService<SubiquityClient>(),
       routes: options['routes']?.split(',') ?? routes));

--- a/packages/ubuntu_desktop_installer/lib/services.dart
+++ b/packages/ubuntu_desktop_installer/lib/services.dart
@@ -6,6 +6,7 @@ export 'services/installer_service.dart';
 export 'services/keyboard_service.dart';
 export 'services/locale_service.dart';
 export 'services/network_service.dart';
+export 'services/post_install_service.dart' hide log;
 export 'services/product_service.dart';
 export 'services/session_service.dart';
 export 'services/storage_service.dart' hide log;

--- a/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/identity_service.dart
@@ -3,13 +3,15 @@ import 'package:meta/meta.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_provision/services.dart';
 
+import 'post_install_service.dart';
+
 class SubiquityIdentityService implements IdentityService {
-  const SubiquityIdentityService(this._subiquity, this._config);
+  const SubiquityIdentityService(this._subiquity, this._postInstall);
 
   final SubiquityClient _subiquity;
-  final ConfigService _config;
+  final PostInstallService _postInstall;
 
-  /// The auto-login user config key for testing purposes.
+  /// The auto-login post-install config key for testing purposes.
   @visibleForTesting
   static const kAutoLoginUser = 'AutoLoginUser';
 
@@ -20,16 +22,16 @@ class SubiquityIdentityService implements IdentityService {
       realname: data.realname,
       username: data.username,
       hostname: data.hostname,
-      autoLogin: await _config.get(kAutoLoginUser) != null,
+      autoLogin: await _postInstall.get(kAutoLoginUser) != null,
     );
   }
 
   @override
   Future<void> setIdentity(Identity identity) async {
     if (identity.autoLogin) {
-      await _config.set(kAutoLoginUser, identity.username);
+      await _postInstall.set(kAutoLoginUser, identity.username);
     } else {
-      await _config.set(kAutoLoginUser, null);
+      await _postInstall.set(kAutoLoginUser, null);
     }
 
     return _subiquity.setIdentity(IdentityData(

--- a/packages/ubuntu_desktop_installer/lib/services/post_install_service.dart
+++ b/packages/ubuntu_desktop_installer/lib/services/post_install_service.dart
@@ -4,10 +4,10 @@ import 'package:meta/meta.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 
 /// @internal
-final log = Logger('config');
+final log = Logger('post-install');
 
-class ConfigService {
-  ConfigService(this._path, {@visibleForTesting FileSystem? fs})
+class PostInstallService {
+  PostInstallService(this._path, {@visibleForTesting FileSystem? fs})
       : _fs = fs ?? const LocalFileSystem();
 
   final String _path;

--- a/packages/ubuntu_desktop_installer/test/services/identity_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/identity_service_test.dart
@@ -17,10 +17,10 @@ void main() {
   test('get identity', () async {
     final client = MockSubiquityClient();
     when(client.getIdentity()).thenAnswer((_) async => testIdentity);
-    final config = MockConfigService();
-    when(config.get(SubiquityIdentityService.kAutoLoginUser))
+    final postInstall = MockPostInstallService();
+    when(postInstall.get(SubiquityIdentityService.kAutoLoginUser))
         .thenAnswer((_) async => testIdentity.username);
-    final service = SubiquityIdentityService(client, config);
+    final service = SubiquityIdentityService(client, postInstall);
     expect(
         await service.getIdentity(),
         equals(Identity(
@@ -31,13 +31,13 @@ void main() {
         )));
 
     verify(client.getIdentity()).called(1);
-    verify(config.get(SubiquityIdentityService.kAutoLoginUser)).called(1);
+    verify(postInstall.get(SubiquityIdentityService.kAutoLoginUser)).called(1);
   });
 
   test('set identity', () async {
     final client = MockSubiquityClient();
-    final config = MockConfigService();
-    final service = SubiquityIdentityService(client, config);
+    final postInstall = MockPostInstallService();
+    final service = SubiquityIdentityService(client, postInstall);
     await service.setIdentity(Identity(
       realname: testIdentity.realname,
       username: testIdentity.username,
@@ -53,7 +53,7 @@ void main() {
             .having((i) => i.cryptedPassword, 'cryptedPassword',
                 hasLength(greaterThan(8))))))
         .called(1);
-    verify(config.set(
+    verify(postInstall.set(
             SubiquityIdentityService.kAutoLoginUser, testIdentity.username))
         .called(1);
   });

--- a/packages/ubuntu_desktop_installer/test/services/post_install_service_test.dart
+++ b/packages/ubuntu_desktop_installer/test/services/post_install_service_test.dart
@@ -1,6 +1,6 @@
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ubuntu_provision/services.dart';
+import 'package:ubuntu_desktop_installer/services.dart';
 
 void main() {
   test('load existing config', () async {
@@ -15,31 +15,31 @@ Str="foo bar"
 Trim=  baz
 ''');
 
-    final config = ConfigService(file.path, fs: fs);
-    expect(await config.load(), {
+    final service = PostInstallService(file.path, fs: fs);
+    expect(await service.load(), {
       'Num': '1',
       'Empty': '',
       'Str': 'foo bar',
       'Trim': 'baz',
     });
 
-    expect(await config.get('Num'), equals('1'));
-    expect(await config.get('Empty'), isEmpty);
-    expect(await config.get('Str'), equals('foo bar'));
-    expect(await config.get('Trim'), equals('baz'));
-    expect(await config.get('None'), isNull);
+    expect(await service.get('Num'), equals('1'));
+    expect(await service.get('Empty'), isEmpty);
+    expect(await service.get('Str'), equals('foo bar'));
+    expect(await service.get('Trim'), equals('baz'));
+    expect(await service.get('None'), isNull);
   });
 
   test('initially missing config', () async {
     final fs = MemoryFileSystem.test();
     final file = fs.file('/foo/bar.conf');
 
-    final config = ConfigService(file.path, fs: fs);
-    expect(await config.load(), isEmpty);
-    expect(await config.get('Anything'), isNull);
+    final service = PostInstallService(file.path, fs: fs);
+    expect(await service.load(), isEmpty);
+    expect(await service.get('Anything'), isNull);
     expect(file.existsSync(), isFalse);
 
-    await config.set('Something', 'value');
+    await service.set('Something', 'value');
     expect(file.existsSync(), isTrue);
     expect(file.readAsStringSync(), '''
 Something=value
@@ -50,14 +50,14 @@ Something=value
     final fs = MemoryFileSystem.test();
     final file = fs.file('/foo/bar.conf');
 
-    final config = ConfigService(file.path, fs: fs);
-    await config.save({
+    final service = PostInstallService(file.path, fs: fs);
+    await service.save({
       'Num': '1',
       'Empty': '',
       'Str': 'foo bar',
       'Trim': '  baz  ',
     });
-    await config.set('Extra', 'value');
+    await service.set('Extra', 'value');
 
     expect(file.existsSync(), isTrue);
     expect(file.readAsStringSync(), '''

--- a/packages/ubuntu_desktop_installer/test/test_utils.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.dart
@@ -33,6 +33,7 @@ extension InstallerTester on WidgetTester {
 
 @GenerateMocks([
   InstallerService,
+  PostInstallService,
   ProductService,
   StorageService,
 ])

--- a/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/test_utils.mocks.dart
@@ -9,8 +9,10 @@ import 'package:mockito/mockito.dart' as _i1;
 import 'package:subiquity_client/subiquity_client.dart' as _i3;
 import 'package:ubuntu_desktop_installer/services/installer_service.dart'
     as _i4;
+import 'package:ubuntu_desktop_installer/services/post_install_service.dart'
+    as _i6;
 import 'package:ubuntu_desktop_installer/services/product_service.dart' as _i2;
-import 'package:ubuntu_desktop_installer/services/storage_service.dart' as _i6;
+import 'package:ubuntu_desktop_installer/services/storage_service.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -97,6 +99,59 @@ class MockInstallerService extends _i1.Mock implements _i4.InstallerService {
       ) as bool);
 }
 
+/// A class which mocks [PostInstallService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPostInstallService extends _i1.Mock
+    implements _i6.PostInstallService {
+  MockPostInstallService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Future<String?> get(String? key) => (super.noSuchMethod(
+        Invocation.method(
+          #get,
+          [key],
+        ),
+        returnValue: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
+  @override
+  _i5.Future<void> set(
+    String? key,
+    String? value,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #set,
+          [
+            key,
+            value,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  _i5.Future<Map<String, String?>> load() => (super.noSuchMethod(
+        Invocation.method(
+          #load,
+          [],
+        ),
+        returnValue:
+            _i5.Future<Map<String, String?>>.value(<String, String?>{}),
+      ) as _i5.Future<Map<String, String?>>);
+  @override
+  _i5.Future<void> save(Map<String, String?>? config) => (super.noSuchMethod(
+        Invocation.method(
+          #save,
+          [config],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
 /// A class which mocks [ProductService].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -124,7 +179,7 @@ class MockProductService extends _i1.Mock implements _i2.ProductService {
 /// A class which mocks [StorageService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStorageService extends _i1.Mock implements _i6.StorageService {
+class MockStorageService extends _i1.Mock implements _i7.StorageService {
   MockStorageService() {
     _i1.throwOnMissingStub(this);
   }

--- a/packages/ubuntu_provision/lib/services.dart
+++ b/packages/ubuntu_provision/lib/services.dart
@@ -1,5 +1,4 @@
 export 'src/services/active_directory_service.dart';
-export 'src/services/config_service.dart' hide log;
 export 'src/services/desktop_service.dart' hide log;
 export 'src/services/identity_service.dart';
 export 'src/services/journal_service.dart';

--- a/packages/ubuntu_provision/test/test_utils.dart
+++ b/packages/ubuntu_provision/test/test_utils.dart
@@ -50,7 +50,6 @@ extension UbuntuProvisionTester on WidgetTester {
 
 @GenerateMocks([
   ActiveDirectoryService,
-  ConfigService,
   DesktopService,
   GeoService,
   IdentityService,

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -4,32 +4,31 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i8;
-import 'dart:ui' as _i24;
+import 'dart:ui' as _i23;
 
-import 'package:dbus/dbus.dart' as _i18;
+import 'package:dbus/dbus.dart' as _i17;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:nm/nm.dart' as _i4;
 import 'package:subiquity_client/subiquity_client.dart' as _i2;
-import 'package:timezone_map/src/location.dart' as _i13;
-import 'package:timezone_map/src/service.dart' as _i11;
-import 'package:timezone_map/src/source.dart' as _i12;
+import 'package:timezone_map/src/location.dart' as _i12;
+import 'package:timezone_map/src/service.dart' as _i10;
+import 'package:timezone_map/src/source.dart' as _i11;
 import 'package:ubuntu_provision/src/services/active_directory_service.dart'
     as _i7;
-import 'package:ubuntu_provision/src/services/config_service.dart' as _i9;
-import 'package:ubuntu_provision/src/services/desktop_service.dart' as _i10;
+import 'package:ubuntu_provision/src/services/desktop_service.dart' as _i9;
 import 'package:ubuntu_provision/src/services/identity_service.dart' as _i3;
-import 'package:ubuntu_provision/src/services/journal_service.dart' as _i14;
-import 'package:ubuntu_provision/src/services/keyboard_service.dart' as _i15;
-import 'package:ubuntu_provision/src/services/locale_service.dart' as _i16;
-import 'package:ubuntu_provision/src/services/network_service.dart' as _i17;
-import 'package:ubuntu_provision/src/services/power_service.dart' as _i19;
-import 'package:ubuntu_provision/src/services/session_service.dart' as _i20;
-import 'package:ubuntu_provision/src/services/sound_service.dart' as _i21;
-import 'package:ubuntu_provision/src/services/telemetry_service.dart' as _i22;
-import 'package:ubuntu_provision/src/services/theme_service.dart' as _i23;
-import 'package:ubuntu_provision/src/services/timezone_service.dart' as _i25;
+import 'package:ubuntu_provision/src/services/journal_service.dart' as _i13;
+import 'package:ubuntu_provision/src/services/keyboard_service.dart' as _i14;
+import 'package:ubuntu_provision/src/services/locale_service.dart' as _i15;
+import 'package:ubuntu_provision/src/services/network_service.dart' as _i16;
+import 'package:ubuntu_provision/src/services/power_service.dart' as _i18;
+import 'package:ubuntu_provision/src/services/session_service.dart' as _i19;
+import 'package:ubuntu_provision/src/services/sound_service.dart' as _i20;
+import 'package:ubuntu_provision/src/services/telemetry_service.dart' as _i21;
+import 'package:ubuntu_provision/src/services/theme_service.dart' as _i22;
+import 'package:ubuntu_provision/src/services/timezone_service.dart' as _i24;
 import 'package:ubuntu_provision/src/services/udev_service.dart' as _i6;
-import 'package:ubuntu_utils/src/url_launcher.dart' as _i26;
+import 'package:ubuntu_utils/src/url_launcher.dart' as _i25;
 import 'package:upower/upower.dart' as _i5;
 
 // ignore_for_file: type=lint
@@ -261,62 +260,10 @@ class MockActiveDirectoryService extends _i1.Mock
       ) as _i8.Future<_i2.AdJoinResult>);
 }
 
-/// A class which mocks [ConfigService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockConfigService extends _i1.Mock implements _i9.ConfigService {
-  MockConfigService() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i8.Future<String?> get(String? key) => (super.noSuchMethod(
-        Invocation.method(
-          #get,
-          [key],
-        ),
-        returnValue: _i8.Future<String?>.value(),
-      ) as _i8.Future<String?>);
-  @override
-  _i8.Future<void> set(
-    String? key,
-    String? value,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #set,
-          [
-            key,
-            value,
-          ],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-  @override
-  _i8.Future<Map<String, String?>> load() => (super.noSuchMethod(
-        Invocation.method(
-          #load,
-          [],
-        ),
-        returnValue:
-            _i8.Future<Map<String, String?>>.value(<String, String?>{}),
-      ) as _i8.Future<Map<String, String?>>);
-  @override
-  _i8.Future<void> save(Map<String, String?>? config) => (super.noSuchMethod(
-        Invocation.method(
-          #save,
-          [config],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-}
-
 /// A class which mocks [DesktopService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDesktopService extends _i1.Mock implements _i10.DesktopService {
+class MockDesktopService extends _i1.Mock implements _i9.DesktopService {
   MockDesktopService() {
     _i1.throwOnMissingStub(this);
   }
@@ -344,13 +291,13 @@ class MockDesktopService extends _i1.Mock implements _i10.DesktopService {
 /// A class which mocks [GeoService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGeoService extends _i1.Mock implements _i11.GeoService {
+class MockGeoService extends _i1.Mock implements _i10.GeoService {
   MockGeoService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void addSource(_i12.GeoSource? source) => super.noSuchMethod(
+  void addSource(_i11.GeoSource? source) => super.noSuchMethod(
         Invocation.method(
           #addSource,
           [source],
@@ -358,7 +305,7 @@ class MockGeoService extends _i1.Mock implements _i11.GeoService {
         returnValueForMissingStub: null,
       );
   @override
-  void removeSource(_i12.GeoSource? source) => super.noSuchMethod(
+  void removeSource(_i11.GeoSource? source) => super.noSuchMethod(
         Invocation.method(
           #removeSource,
           [source],
@@ -375,44 +322,44 @@ class MockGeoService extends _i1.Mock implements _i11.GeoService {
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
   @override
-  _i8.Future<_i13.GeoLocation?> lookupLocation() => (super.noSuchMethod(
+  _i8.Future<_i12.GeoLocation?> lookupLocation() => (super.noSuchMethod(
         Invocation.method(
           #lookupLocation,
           [],
         ),
-        returnValue: _i8.Future<_i13.GeoLocation?>.value(),
-      ) as _i8.Future<_i13.GeoLocation?>);
+        returnValue: _i8.Future<_i12.GeoLocation?>.value(),
+      ) as _i8.Future<_i12.GeoLocation?>);
   @override
-  _i8.Future<Iterable<_i13.GeoLocation>> searchLocation(String? location) =>
+  _i8.Future<Iterable<_i12.GeoLocation>> searchLocation(String? location) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchLocation,
           [location],
         ),
         returnValue:
-            _i8.Future<Iterable<_i13.GeoLocation>>.value(<_i13.GeoLocation>[]),
-      ) as _i8.Future<Iterable<_i13.GeoLocation>>);
+            _i8.Future<Iterable<_i12.GeoLocation>>.value(<_i12.GeoLocation>[]),
+      ) as _i8.Future<Iterable<_i12.GeoLocation>>);
   @override
-  _i8.Future<Iterable<_i13.GeoLocation>> searchCoordinates(
-          _i13.LatLng? coordinates) =>
+  _i8.Future<Iterable<_i12.GeoLocation>> searchCoordinates(
+          _i12.LatLng? coordinates) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchCoordinates,
           [coordinates],
         ),
         returnValue:
-            _i8.Future<Iterable<_i13.GeoLocation>>.value(<_i13.GeoLocation>[]),
-      ) as _i8.Future<Iterable<_i13.GeoLocation>>);
+            _i8.Future<Iterable<_i12.GeoLocation>>.value(<_i12.GeoLocation>[]),
+      ) as _i8.Future<Iterable<_i12.GeoLocation>>);
   @override
-  _i8.Future<Iterable<_i13.GeoLocation>> searchTimezone(String? timezone) =>
+  _i8.Future<Iterable<_i12.GeoLocation>> searchTimezone(String? timezone) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchTimezone,
           [timezone],
         ),
         returnValue:
-            _i8.Future<Iterable<_i13.GeoLocation>>.value(<_i13.GeoLocation>[]),
-      ) as _i8.Future<Iterable<_i13.GeoLocation>>);
+            _i8.Future<Iterable<_i12.GeoLocation>>.value(<_i12.GeoLocation>[]),
+      ) as _i8.Future<Iterable<_i12.GeoLocation>>);
   @override
   _i8.Future<void> cancelSearch() => (super.noSuchMethod(
         Invocation.method(
@@ -470,7 +417,7 @@ class MockIdentityService extends _i1.Mock implements _i3.IdentityService {
 /// A class which mocks [JournalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i14.JournalService {
+class MockJournalService extends _i1.Mock implements _i13.JournalService {
   MockJournalService() {
     _i1.throwOnMissingStub(this);
   }
@@ -478,7 +425,7 @@ class MockJournalService extends _i1.Mock implements _i14.JournalService {
   @override
   _i8.Stream<String> start(
     List<String>? ids, {
-    _i14.JournalOutput? output = _i14.JournalOutput.short,
+    _i13.JournalOutput? output = _i13.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -493,7 +440,7 @@ class MockJournalService extends _i1.Mock implements _i14.JournalService {
 /// A class which mocks [KeyboardService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockKeyboardService extends _i1.Mock implements _i15.KeyboardService {
+class MockKeyboardService extends _i1.Mock implements _i14.KeyboardService {
   MockKeyboardService() {
     _i1.throwOnMissingStub(this);
   }
@@ -561,7 +508,7 @@ class MockKeyboardService extends _i1.Mock implements _i15.KeyboardService {
 /// A class which mocks [LocaleService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLocaleService extends _i1.Mock implements _i16.LocaleService {
+class MockLocaleService extends _i1.Mock implements _i15.LocaleService {
   MockLocaleService() {
     _i1.throwOnMissingStub(this);
   }
@@ -588,7 +535,7 @@ class MockLocaleService extends _i1.Mock implements _i16.LocaleService {
 /// A class which mocks [NetworkService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNetworkService extends _i1.Mock implements _i17.NetworkService {
+class MockNetworkService extends _i1.Mock implements _i16.NetworkService {
   MockNetworkService() {
     _i1.throwOnMissingStub(this);
   }
@@ -743,7 +690,7 @@ class MockNetworkService extends _i1.Mock implements _i17.NetworkService {
         ),
       ) as _i4.NetworkManagerDnsManager);
   @override
-  Map<String, Map<String, _i18.DBusValue>> getWifiSettings(
+  Map<String, Map<String, _i17.DBusValue>> getWifiSettings(
           {required String? ssid}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -751,8 +698,8 @@ class MockNetworkService extends _i1.Mock implements _i17.NetworkService {
           [],
           {#ssid: ssid},
         ),
-        returnValue: <String, Map<String, _i18.DBusValue>>{},
-      ) as Map<String, Map<String, _i18.DBusValue>>);
+        returnValue: <String, Map<String, _i17.DBusValue>>{},
+      ) as Map<String, Map<String, _i17.DBusValue>>);
   @override
   _i8.Future<void> markConfigured() => (super.noSuchMethod(
         Invocation.method(
@@ -801,7 +748,7 @@ class MockNetworkService extends _i1.Mock implements _i17.NetworkService {
       ) as _i8.Future<void>);
   @override
   _i8.Future<_i4.NetworkManagerActiveConnection> addAndActivateConnection({
-    Map<String, Map<String, _i18.DBusValue>>? connection = const {},
+    Map<String, Map<String, _i17.DBusValue>>? connection = const {},
     required _i4.NetworkManagerDevice? device,
     _i4.NetworkManagerAccessPoint? accessPoint,
   }) =>
@@ -884,7 +831,7 @@ class MockNetworkService extends _i1.Mock implements _i17.NetworkService {
 /// A class which mocks [PowerService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPowerService extends _i1.Mock implements _i19.PowerService {
+class MockPowerService extends _i1.Mock implements _i18.PowerService {
   MockPowerService() {
     _i1.throwOnMissingStub(this);
   }
@@ -984,7 +931,7 @@ class MockPowerService extends _i1.Mock implements _i19.PowerService {
 /// A class which mocks [SessionService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSessionService extends _i1.Mock implements _i20.SessionService {
+class MockSessionService extends _i1.Mock implements _i19.SessionService {
   MockSessionService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1014,7 +961,7 @@ class MockSessionService extends _i1.Mock implements _i20.SessionService {
 /// A class which mocks [SoundService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSoundService extends _i1.Mock implements _i21.SoundService {
+class MockSoundService extends _i1.Mock implements _i20.SoundService {
   MockSoundService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1033,7 +980,7 @@ class MockSoundService extends _i1.Mock implements _i21.SoundService {
 /// A class which mocks [TelemetryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTelemetryService extends _i1.Mock implements _i22.TelemetryService {
+class MockTelemetryService extends _i1.Mock implements _i21.TelemetryService {
   MockTelemetryService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1093,13 +1040,13 @@ class MockTelemetryService extends _i1.Mock implements _i22.TelemetryService {
 /// A class which mocks [ThemeService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockThemeService extends _i1.Mock implements _i23.ThemeService {
+class MockThemeService extends _i1.Mock implements _i22.ThemeService {
   MockThemeService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i8.Future<void> setBrightness(_i24.Brightness? brightness) =>
+  _i8.Future<void> setBrightness(_i23.Brightness? brightness) =>
       (super.noSuchMethod(
         Invocation.method(
           #setBrightness,
@@ -1131,7 +1078,7 @@ class MockThemeService extends _i1.Mock implements _i23.ThemeService {
 /// A class which mocks [TimezoneService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTimezoneService extends _i1.Mock implements _i25.TimezoneService {
+class MockTimezoneService extends _i1.Mock implements _i24.TimezoneService {
   MockTimezoneService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1211,7 +1158,7 @@ class MockUdevService extends _i1.Mock implements _i6.UdevService {
 /// A class which mocks [UrlLauncher].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUrlLauncher extends _i1.Mock implements _i26.UrlLauncher {
+class MockUrlLauncher extends _i1.Mock implements _i25.UrlLauncher {
   MockUrlLauncher() {
     _i1.throwOnMissingStub(this);
   }


### PR DESCRIPTION
While the current "config" service does indeed write a config file, it's a very minimal Bash-compatible config file specifically for passing values to the post-inst scripts. Rename it to "post-install" service instead to make room for a more generic TOML/YAML config service that will be used for configuring pages for any provisioning phase.

Ref: #2194