### PR TITLE
fix(installer): respect subiquity's guided storage targets

### DIFF
--- a/packages/ubuntu_desktop_installer/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_desktop_installer/lib/pages/storage/storage_page.dart
@@ -81,42 +81,47 @@ class StoragePage extends ConsumerWidget {
                 onChanged: (v) => model.type = v!,
               ),
             ),
-          YaruRadioButton<StorageType>(
-            title: Text(lang.installationTypeErase(flavor.name)),
-            subtitle: Html(
-              data: lang.installationTypeEraseWarning(
-                  Theme.of(context).colorScheme.error.toHex()),
-              style: {'body': Style(margin: Margins.zero)},
-            ),
-            value: StorageType.erase,
-            groupValue: model.type,
-            onChanged: (value) => model.type = value!,
-          ),
-          const SizedBox(height: kWizardSpacing),
-          Padding(
-            padding: kWizardIndentation,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                OutlinedButton(
-                  onPressed: model.type == StorageType.erase
-                      ? () => showAdvancedFeaturesDialog(context, model)
-                      : null,
-                  child: Text(lang.installationTypeAdvancedLabel),
+          if (model.canEraseDisk) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: kWizardSpacing),
+              child: YaruRadioButton<StorageType>(
+                title: Text(lang.installationTypeErase(flavor.name)),
+                subtitle: Html(
+                  data: lang.installationTypeEraseWarning(
+                      Theme.of(context).colorScheme.error.toHex()),
+                  style: {'body': Style(margin: Margins.zero)},
                 ),
-                const SizedBox(width: kWizardSpacing),
-                Text(model.advancedFeature.localize(lang, model.encryption)),
-              ],
+                value: StorageType.erase,
+                groupValue: model.type,
+                onChanged: (value) => model.type = value!,
+              ),
             ),
-          ),
-          const SizedBox(height: kWizardSpacing),
-          YaruRadioButton<StorageType>(
-            title: Text(lang.installationTypeManual),
-            subtitle: Text(lang.installationTypeManualInfo(flavor.name)),
-            value: StorageType.manual,
-            groupValue: model.type,
-            onChanged: (v) => model.type = v!,
-          ),
+            Padding(
+              padding: kWizardIndentation,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  OutlinedButton(
+                    onPressed: model.type == StorageType.erase
+                        ? () => showAdvancedFeaturesDialog(context, model)
+                        : null,
+                    child: Text(lang.installationTypeAdvancedLabel),
+                  ),
+                  const SizedBox(width: kWizardSpacing),
+                  Text(model.advancedFeature.localize(lang, model.encryption)),
+                ],
+              ),
+            ),
+            const SizedBox(height: kWizardSpacing),
+          ],
+          if (model.canManualPartition)
+            YaruRadioButton<StorageType>(
+              title: Text(lang.installationTypeManual),
+              subtitle: Text(lang.installationTypeManualInfo(flavor.name)),
+              value: StorageType.manual,
+              groupValue: model.type,
+              onChanged: (v) => model.type = v!,
+            ),
         ],
       ),
       bottomBar: WizardBar(
@@ -124,7 +129,7 @@ class StoragePage extends ConsumerWidget {
         trailing: [
           WizardButton.next(
             context,
-            enabled: model.hasStorage,
+            enabled: model.type != null,
             arguments: model.type,
             onNext: model.save,
             // If the user returns back to select another installation type, the

--- a/packages/ubuntu_desktop_installer/test/storage/storage_dialogs_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/storage_dialogs_test.dart
@@ -53,7 +53,8 @@ void main() {
     when(model.advancedFeature).thenReturn(AdvancedFeature.lvm);
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
-    when(model.hasStorage).thenReturn(true);
+    when(model.canEraseDisk).thenReturn(true);
+    when(model.canManualPartition).thenReturn(true);
     when(model.hasBitLocker).thenReturn(false);
 
     await tester.pumpWidget(
@@ -88,7 +89,8 @@ void main() {
     when(model.advancedFeature).thenReturn(AdvancedFeature.lvm);
     when(model.encryption).thenReturn(false);
     when(model.canInstallAlongside).thenReturn(false);
-    when(model.hasStorage).thenReturn(true);
+    when(model.canEraseDisk).thenReturn(true);
+    when(model.canManualPartition).thenReturn(true);
     when(model.hasBitLocker).thenReturn(false);
 
     await tester.pumpWidget(

--- a/packages/ubuntu_desktop_installer/test/storage/storage_page_test.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/storage_page_test.dart
@@ -292,8 +292,8 @@ void main() {
     verify(model.type = StorageType.alongside).called(1);
   });
 
-  testWidgets('erase', (tester) async {
-    final model = buildStorageModel();
+  testWidgets('can erase disk', (tester) async {
+    final model = buildStorageModel(canEraseDisk: true);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     final context = tester.element(find.byType(StoragePage));
@@ -306,7 +306,19 @@ void main() {
     verify(model.type = StorageType.erase).called(1);
   });
 
-  testWidgets('manual', (tester) async {
+  testWidgets('cannot erase disk', (tester) async {
+    final model = buildStorageModel(canEraseDisk: false);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio =
+        find.radioButton<StorageType>(l10n.installationTypeErase('Ubuntu'));
+    expect(radio, findsNothing);
+  });
+
+  testWidgets('can manual partition', (tester) async {
     final model = buildStorageModel(type: StorageType.manual);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
@@ -319,6 +331,17 @@ void main() {
     verify(model.type = StorageType.manual).called(1);
 
     expect(find.button(l10n.installationTypeAdvancedLabel), isDisabled);
+  });
+
+  testWidgets('cannot manual partition', (tester) async {
+    final model = buildStorageModel(canManualPartition: false);
+    await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+    final context = tester.element(find.byType(StoragePage));
+    final l10n = AppLocalizations.of(context);
+
+    final radio = find.radioButton<StorageType>(l10n.installationTypeManual);
+    expect(radio, findsNothing);
   });
 
   group('advanced features', () {
@@ -371,8 +394,8 @@ void main() {
     });
   });
 
-  testWidgets('no storage', (tester) async {
-    final model = buildStorageModel(hasStorage: false);
+  testWidgets('no type', (tester) async {
+    final model = buildStorageModel(type: null);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     expect(find.button(find.nextLabel), isDisabled);
@@ -382,7 +405,7 @@ void main() {
   });
 
   testWidgets('continue', (tester) async {
-    final model = buildStorageModel(hasStorage: true);
+    final model = buildStorageModel(type: StorageType.manual);
     await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
 
     await tester.tapNext();

--- a/packages/ubuntu_desktop_installer/test/storage/test_storage.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/test_storage.dart
@@ -16,24 +16,26 @@ export 'test_storage.mocks.dart';
 
 @GenerateMocks([StorageModel])
 StorageModel buildStorageModel({
-  StorageType? type,
+  StorageType? type = StorageType.erase,
   AdvancedFeature? advancedFeature,
   bool? encryption,
   ProductInfo? productInfo,
   List<OsProber>? existingOS,
   bool? canInstallAlongside,
-  bool? hasStorage,
+  bool? canEraseDisk,
+  bool? canManualPartition,
   bool? hasBitLocker,
 }) {
   final model = MockStorageModel();
-  when(model.type).thenReturn(type ?? StorageType.erase);
+  when(model.type).thenReturn(type);
   when(model.advancedFeature)
       .thenReturn(advancedFeature ?? AdvancedFeature.none);
   when(model.encryption).thenReturn(encryption ?? false);
   when(model.productInfo).thenReturn(productInfo ?? ProductInfo(name: ''));
   when(model.existingOS).thenReturn(existingOS);
   when(model.canInstallAlongside).thenReturn(canInstallAlongside ?? false);
-  when(model.hasStorage).thenReturn(hasStorage ?? true);
+  when(model.canEraseDisk).thenReturn(canEraseDisk ?? true);
+  when(model.canManualPartition).thenReturn(canManualPartition ?? true);
   when(model.hasBitLocker).thenReturn(hasBitLocker ?? false);
   return model;
 }

--- a/packages/ubuntu_desktop_installer/test/storage/test_storage.mocks.dart
+++ b/packages/ubuntu_desktop_installer/test/storage/test_storage.mocks.dart
@@ -83,11 +83,6 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
         ),
       ) as _i2.ProductInfo);
   @override
-  bool get hasStorage => (super.noSuchMethod(
-        Invocation.getter(#hasStorage),
-        returnValue: false,
-      ) as bool);
-  @override
   bool get hasBitLocker => (super.noSuchMethod(
         Invocation.getter(#hasBitLocker),
         returnValue: false,
@@ -95,6 +90,16 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
   @override
   bool get canInstallAlongside => (super.noSuchMethod(
         Invocation.getter(#canInstallAlongside),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get canEraseDisk => (super.noSuchMethod(
+        Invocation.getter(#canEraseDisk),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get canManualPartition => (super.noSuchMethod(
+        Invocation.getter(#canManualPartition),
         returnValue: false,
       ) as bool);
   @override


### PR DESCRIPTION
Don't offer options that Subiquity doesn't allow. This doesn't fix the problem that we're currently not able to perform a guided reformat of a 25GiB disk (gnome-boxes default for 23.10) but at least such options are no longer offered that Subiquity explicitly says are not allowed.

Ref: #2252