### PR TITLE
feat(init): add helper for registering all init-phase services

### DIFF
--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -9,6 +9,7 @@ import 'services/xdg_locale_service.dart';
 import 'services/xdg_session_service.dart';
 import 'services/xdg_timezone_service.dart';
 
+export 'package:timezone_map/timezone_map.dart' show GeoService;
 export 'services/realmd_active_directory_service.dart';
 export 'services/xdg_identity_service.dart';
 export 'services/xdg_keyboard_service.dart';

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -1,0 +1,36 @@
+import 'package:timezone_map/timezone_map.dart';
+import 'package:ubuntu_provision/services.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import 'services/realmd_active_directory_service.dart';
+import 'services/xdg_identity_service.dart';
+import 'services/xdg_keyboard_service.dart';
+import 'services/xdg_locale_service.dart';
+import 'services/xdg_session_service.dart';
+import 'services/xdg_timezone_service.dart';
+
+export 'services/realmd_active_directory_service.dart';
+export 'services/xdg_identity_service.dart';
+export 'services/xdg_keyboard_service.dart';
+export 'services/xdg_locale_service.dart';
+export 'services/xdg_session_service.dart';
+export 'services/xdg_timezone_service.dart';
+
+Future<void> registerInitServices() {
+  tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
+  tryRegisterService<IdentityService>(XdgIdentityService.new);
+  tryRegisterService<KeyboardService>(XdgKeyboardService.new);
+  tryRegisterService<LocaleService>(XdgLocaleService.new);
+  tryRegisterService<NetworkService>(NetworkService.new);
+  tryRegisterService<SessionService>(XdgSessionService.new);
+  tryRegisterService<TimezoneService>(XdgTimezoneService.new);
+
+  var geo = tryGetService<GeoService>();
+  if (geo == null) {
+    final geodata = Geodata.asset();
+    final geoname = Geoname.ubuntu(geodata: geodata);
+    geo = GeoService(sources: [geodata, geoname]);
+    registerServiceInstance(geo);
+  }
+  return geo.init();
+}

--- a/packages/ubuntu_init/lib/ubuntu_init.dart
+++ b/packages/ubuntu_init/lib/ubuntu_init.dart
@@ -1,9 +1,4 @@
 library ubuntu_init;
 
+export 'src/init_services.dart';
 export 'src/init_wizard.dart';
-export 'src/services/realmd_active_directory_service.dart';
-export 'src/services/xdg_identity_service.dart';
-export 'src/services/xdg_keyboard_service.dart';
-export 'src/services/xdg_locale_service.dart';
-export 'src/services/xdg_session_service.dart';
-export 'src/services/xdg_timezone_service.dart';

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -17,9 +17,15 @@ dependencies:
   gsettings: ^0.2.7
   meta: ^1.7.0
   stdlibc: ^0.1.0
+  timezone_map:
+    git:
+      url: https://github.com/canonical/ubuntu-flutter-plugins.git
+      path: packages/timezone_map
+      ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
   ubuntu_localizations: ^0.3.3
   ubuntu_provision:
     path: ../ubuntu_provision
+  ubuntu_service: ^0.2.0
   ubuntu_session: ^0.0.4
   ubuntu_wizard:
     path: ../ubuntu_wizard

--- a/packages/ubuntu_init/test/init_services_test.dart
+++ b/packages/ubuntu_init/test/init_services_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';

--- a/packages/ubuntu_init/test/init_services_test.dart
+++ b/packages/ubuntu_init/test/init_services_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timezone_map/timezone_map.dart';
+import 'package:ubuntu_init/ubuntu_init.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('register init services', () async {
+    await registerInitServices();
+
+    expect(tryGetService<ActiveDirectoryService>(), isNotNull);
+    expect(tryGetService<GeoService>(), isNotNull);
+    expect(tryGetService<IdentityService>(), isNotNull);
+    expect(tryGetService<KeyboardService>(), isNotNull);
+    expect(tryGetService<LocaleService>(), isNotNull);
+    expect(tryGetService<NetworkService>(), isNotNull);
+    expect(tryGetService<SessionService>(), isNotNull);
+    expect(tryGetService<TimezoneService>(), isNotNull);
+  });
+}

--- a/packages/ubuntu_welcome/lib/main.dart
+++ b/packages/ubuntu_welcome/lib/main.dart
@@ -3,11 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_welcome/l10n.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
@@ -19,13 +17,6 @@ Future<void> main(List<String> args) async {
   })!;
   setupLogger(options);
 
-  tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
-  tryRegisterService<IdentityService>(XdgIdentityService.new);
-  tryRegisterService<KeyboardService>(XdgKeyboardService.new);
-  tryRegisterService<LocaleService>(XdgLocaleService.new);
-  tryRegisterService<NetworkService>(NetworkService.new);
-  tryRegisterService<TimezoneService>(XdgTimezoneService.new);
-
   final log = Logger();
 
   return runZonedGuarded(() async {
@@ -35,14 +26,7 @@ Future<void> main(List<String> args) async {
 
     await YaruWindowTitleBar.ensureInitialized();
 
-    var geo = tryGetService<GeoService>();
-    if (geo == null) {
-      final geodata = Geodata.asset();
-      final geoname = Geoname.ubuntu(geodata: geodata);
-      geo = GeoService(sources: [geodata, geoname]);
-      registerServiceInstance(geo);
-    }
-    await geo.init();
+    await registerInitServices();
 
     runApp(ProviderScope(
       child: Consumer(

--- a/packages/ubuntu_welcome/pubspec.yaml
+++ b/packages/ubuntu_welcome/pubspec.yaml
@@ -13,18 +13,12 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.3.6
   handy_window: ^0.3.0
-  timezone_map:
-    git:
-      url: https://github.com/canonical/ubuntu-flutter-plugins.git
-      path: packages/timezone_map
-      ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
   ubuntu_init:
     path: ../ubuntu_init
   ubuntu_localizations: ^0.3.3
   ubuntu_logger: ^0.0.3
   ubuntu_provision:
     path: ../ubuntu_provision
-  ubuntu_service: ^0.2.0
   ubuntu_utils:
     path: ../ubuntu_utils
   ubuntu_wizard:


### PR DESCRIPTION
Helps to move some boilerplate and dependencies from `ubuntu_welcome` to `ubuntu_init`.

Ref: #2194 