### PR TITLE
ci: clean up

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,0 @@
-ci:
-- all: ['.github/**']
-
-l10n:
-- all: ['**/l10n/**']
-
-test:
-- all: ['**/test/**']

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,31 +11,3 @@ jobs:
         uses: canonical/has-signed-canonical-cla@v1
         with:
           exempted-bots: dependabot,github-actions,renovate
-
-  labeler:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/labeler@v4
-
-  title:
-    permissions:
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        id: semantic-pr
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - uses: marocchino/sticky-pull-request-comment@v2
-        if: always() && steps.semantic-pr.outputs.error_message != null
-        with:
-          header: semantic-pr-error
-          message: ${{steps.semantic-pr.outputs.error_message}}
-      - if: steps.semantic-pr.outputs.error_message == null
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: semantic-pr-error
-          delete: true


### PR DESCRIPTION
- Drop the labeler because there's not much to label here anymore because the development has moved to ubuntu-desktop-provision.
- Throw away the broken semantic PR title check