### PR TITLE
Add missing dep on python3-debian

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,6 +103,7 @@ parts:
       - python3-apport
       - python3-attr
       - python3-bson
+      - python3-debian
       - python3-jsonschema
       - python3-minimal
       - python3-oauthlib


### PR DESCRIPTION
This has been added to subiquity and must be reflected in the installer.
Related commit https://github.com/canonical/subiquity/commit/dd620b40b3495fa568b41035b99dae53d1ca74f5