### PR TITLE
feat: track archive/main branch of ubuntu-desktop-provision

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ubuntu-desktop-provision"]
 	path = vendor/ubuntu-desktop-provision
 	url = https://github.com/canonical/ubuntu-desktop-provision.git
+	branch = archive/main


### PR DESCRIPTION
In case we need to land any additional changes in the current desktop installer, we should track the `archive/main` branch of ubuntu-desktop-provision here, as work on the new provisioning flow continues in the `main` branch there. We'll also build a new "ubuntu-desktop-provision" snap in a separate branch there, so that this repo won't be needed any longer.